### PR TITLE
map function was not working correctly...

### DIFF
--- a/lib/CXGN/List.pm
+++ b/lib/CXGN/List.pm
@@ -524,7 +524,7 @@ sub add_bulk {
 	my %elements_in_list;
 	my @elements_added;
 	my @duplicates;
-
+	s/^\s+|\s+$//g for @$elements;
 	#print STDERR Dumper $elements;
 
 	my $q = "SELECT content FROM sgn_people.list join sgn_people.list_item using(list_id) where list.list_id =?";
@@ -547,7 +547,7 @@ sub add_bulk {
 
 		my @values;
 		foreach (@$elements) {
-			if (!exists $elements_in_list{$_}){
+			if ($_ && !exists $elements_in_list{$_}){
 				push @values, [$list_item_id, $list_id, $_];
 				$elements_in_list{$_} = 1;
 				push @elements_added, $_;

--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -83,7 +83,7 @@ sub do_fuzzy_search {
 	return;
     }
     #remove all trailing and ending spaces from accessions 
-    @accession_list = map { $_ =~ s/^\s+|\s+$//g }  @accession_list; 
+    s/^\s+|\s+$//g for @accession_list;
    
     $fuzzy_search_result = $fuzzy_accession_search->get_matches(\@accession_list, $max_distance);
     #print STDERR "\n\nResult:\n".Data::Dumper::Dumper($fuzzy_search_result)."\n\n";


### PR DESCRIPTION
would return an array of only empty strings..

using:
s/^\s+|\s+$//g for @accession_list;

instead of:
@accession_list = map { $_ =~ s/^\s+|\s+$//g }  @accession_list; 