### PR TITLE
Topic/postcomposed cass

### DIFF
--- a/bin/load_phenotypes_fieldbook.pl
+++ b/bin/load_phenotypes_fieldbook.pl
@@ -177,9 +177,9 @@ if ($verified_warning && !$opt_o) {
 
 print STDERR "Done validating. Now storing\n";
 
-my $stored_phenotype_error = $store_phenotypes->store();
+my ($stored_phenotype_error, $stored_Phenotype_success) = $store_phenotypes->store();
 if ($stored_phenotype_error) {
     die $stored_phenotype_error."\n";
 }
-
+print STDERR $stored_Phenotype_success."\n";
 print STDERR "Script Complete.\n";

--- a/bin/load_phenotypes_spreadsheet_csv.pl
+++ b/bin/load_phenotypes_spreadsheet_csv.pl
@@ -188,9 +188,9 @@ if ($verified_warning && !$opt_o) {
 
 print STDERR "Done validating. Now storing\n";
 
-my $stored_phenotype_error = $store_phenotypes->store();
+my ($stored_phenotype_error, $stored_Phenotype_success) = $store_phenotypes->store();
 if ($stored_phenotype_error) {
     die $stored_phenotype_error."\n";
 }
-
+print STDERR $stored_Phenotype_success."\n";
 print STDERR "Script Complete.\n";

--- a/js/CXGN/ComposeTrait.js
+++ b/js/CXGN/ComposeTrait.js
@@ -1,38 +1,4 @@
 
-function create_multi_selects(cv_names) {
-    jQuery('#compose_trait').prop('disabled', true);
-    var names = cv_names.split(',');
-
-    for(i = 0; i < names.length; i++){
-        var cv_name = names[i];
-        var name = cv_name.trim();
-
-        switch (name) {
-            case "time":
-                jQuery("#tod_div,#toy_div,#gen_div").show();
-                get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': 'cass time of day|CASSTIME:0000001', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
-                get_select_box('ontology_children', 'toy_select_div', { 'selectbox_id' : 'toy_select', 'selectbox_name': 'toy_select', 'multiple': 'true', 'parent_node_cvterm': 'cass number of weeks|CASSTIME:0000005', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
-                get_select_box('ontology_children', 'gen_select_div', { 'selectbox_id' : 'gen_select', 'selectbox_name': 'gen_select', 'multiple': 'true', 'parent_node_cvterm': 'generation|TIME:0000072', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
-                break;
-            case "tod":
-                jQuery("#tod_div").show();
-                console.log('Here');
-                get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': 'cass time of day|CASSTIME:0000001', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
-                break;
-            case "toy":
-                jQuery("#toy_div").show();
-                get_select_box('ontology_children', 'toy_select_div', { 'selectbox_id' : 'toy_select', 'selectbox_name': 'toy_select', 'multiple': 'true', 'parent_node_cvterm': 'time of year|TIME:0000005', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
-                break;
-            case "gen":
-                jQuery("#gen_div").show();
-                get_select_box('ontology_children', 'gen_select_div', { 'selectbox_id' : 'gen_select', 'selectbox_name': 'gen_select', 'multiple': 'true', 'parent_node_cvterm': 'generation|TIME:0000072', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
-                break;
-            default:
-                if (window.console) console.log("Did not recognize "+name+" category");
-        }
-    }
-}
-
 function display_matching_traits () {
 
 var component_ids = get_component_ids();

--- a/js/CXGN/ComposeTrait.js
+++ b/js/CXGN/ComposeTrait.js
@@ -10,13 +10,14 @@ function create_multi_selects(cv_names) {
         switch (name) {
             case "time":
                 jQuery("#tod_div,#toy_div,#gen_div").show();
-                get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': 'time of day|TIME:0000001', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
-                get_select_box('ontology_children', 'toy_select_div', { 'selectbox_id' : 'toy_select', 'selectbox_name': 'toy_select', 'multiple': 'true', 'parent_node_cvterm': 'time of year|TIME:0000005', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': 'cass time of day|CASSTIME:0000001', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                get_select_box('ontology_children', 'toy_select_div', { 'selectbox_id' : 'toy_select', 'selectbox_name': 'toy_select', 'multiple': 'true', 'parent_node_cvterm': 'cass number of weeks|CASSTIME:0000005', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
                 get_select_box('ontology_children', 'gen_select_div', { 'selectbox_id' : 'gen_select', 'selectbox_name': 'gen_select', 'multiple': 'true', 'parent_node_cvterm': 'generation|TIME:0000072', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
                 break;
             case "tod":
                 jQuery("#tod_div").show();
-                get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': 'time of day|TIME:0000001', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                console.log('Here');
+                get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': 'cass time of day|CASSTIME:0000001', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
                 break;
             case "toy":
                 jQuery("#toy_div").show();

--- a/lib/CXGN/List/Validate/Plugin/Traits.pm
+++ b/lib/CXGN/List/Validate/Plugin/Traits.pm
@@ -25,8 +25,8 @@ sub validate {
         my $full_accession = substr $term, rindex( $term, $delim ) + length($delim);
         my $full_accession_length = length($full_accession) + length($delim);
         $term = substr($term, 0, -$full_accession_length);
-        print STDERR $full_accession."\n";
-        print STDERR $term."\n";
+        #print STDERR $full_accession."\n";
+        #print STDERR $term."\n";
         my ($db_name, $accession) = split ":", $full_accession;
 
         if ($accession) {
@@ -52,10 +52,10 @@ sub validate {
             if ($rs->count == 0) {
                 push @missing, $term;
             } else {
-#                my $rs_var = $rs->search_related('cvterm_relationship_subjects', {'type.name' => 'VARIABLE_OF'}, { 'join' => 'type'});
-#                if ($rs_var->count == 0) {
-#                    push @missing, $term;
-#                }
+                my $rs_var = $rs->search_related('cvterm_relationship_subjects', {'type.name' => 'VARIABLE_OF'}, { 'join' => 'type'});
+                if ($rs_var->count == 0) {
+                    push @missing, $term;
+                }
             }
 
             if ($db->name eq 'COMP'){
@@ -81,10 +81,10 @@ sub validate {
                 my $component_rs = $cvterm_rs->first->search_related('cvterm_relationship_objects', {'me.type_id' => $contains_cvterm_id});
                 while(my $r = $component_rs->next){
                     my $component_cvterm = $r->subject();
-                    print STDERR $component_cvterm->name."\n";
+                    #print STDERR $component_cvterm->name."\n";
                     my $component_cvprops_rs = $schema->resultset('Cv::Cvprop')->search({cv_id=>$component_cvterm->cv_id});
                     while(my $cvprop = $component_cvprops_rs->next){
-                        print STDERR $cvprop->type_id."\n";
+                        #print STDERR $cvprop->type_id."\n";
                         if (!exists($cvtypes{$cvprop->type_id})){
                             print STDERR "Component not part of allowed cv ontologies\n";
                             push @missing, $term;
@@ -96,7 +96,7 @@ sub validate {
         }
 
     }
-    print STDERR Dumper \@missing;
+    #print STDERR Dumper \@missing;
     return { missing => \@missing };
 }
 

--- a/lib/CXGN/List/Validate/Plugin/Traits.pm
+++ b/lib/CXGN/List/Validate/Plugin/Traits.pm
@@ -50,12 +50,12 @@ sub validate {
             );
 
             if ($rs->count == 0) {
-                push @missing, $_;
+                push @missing, $term;
             } else {
-            #        my $rs_var = $rs->search_related('cvterm_relationship_subjects', {'type.name' => 'VARIABLE_OF'}, { 'join' => 'type'});
-            #        if ($rs_var->count == 0) {
-            #            push @missing, $_;
-            #        }
+#                my $rs_var = $rs->search_related('cvterm_relationship_subjects', {'type.name' => 'VARIABLE_OF'}, { 'join' => 'type'});
+#                if ($rs_var->count == 0) {
+#                    push @missing, $term;
+#                }
             }
 
             if ($db->name eq 'COMP'){
@@ -96,6 +96,7 @@ sub validate {
         }
 
     }
+    print STDERR Dumper \@missing;
     return { missing => \@missing };
 }
 

--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -90,6 +90,12 @@ sub store_composed_term {
             die "Should not save postcomposed term with less than 2 components\n";
         }
 
+        my $cvterm_name_check = $schema->resultset('Cv::Cvterm')->find({ name=>$name });
+        if ($cvterm_name_check){
+            print STDERR "Cvterm with name $name already exists... skipping new addition\n";
+            next;
+        }
+
         my $existing_trait_id = SGN::Model::Cvterm->get_trait_from_exact_components($schema, \@component_ids);
         if ($existing_trait_id) {
             die "This trait already exists.\n";

--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -174,12 +174,14 @@ sub compose_trait {
 
     #print STDERR "Contains relationship cvterm_id = " . $contains_relationship->cvterm_id();
 
+    my $variable_relationship = $schema->resultset("Cv::Cvterm")->find({ name => 'VARIABLE_OF' });
+
     my @component_ids = split ',', $ids;
 
     my $isa_rel = $schema->resultset('Cv::CvtermRelationship')->create(
       { subject_id => $new_term->cvterm_id(),
         object_id  => $parent_term->cvterm_id(),
-        type_id    => $isa_relationship->cvterm_id()
+        type_id    => $variable_relationship->cvterm_id()
     });
 
     foreach my $component_id (@component_ids) {

--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -74,71 +74,34 @@ sub get_root_nodes {
 }
 
 
-sub compose_trait {
-      my $self = shift;
-      my $ids = shift;
+sub store_composed_term {
+    my $self = shift;
+    my $new_trait_names = shift;
 
-      my @ids = split(',', $ids);
-      print STDERR "Ids for composing in CXGN:Onto = $ids\n";
-      if (scalar @ids < 2) {
-        die "Can't create a new trait from fewer than 2 components.\n";
-      }
+    my $schema = $self->schema();
+    my $dbh = $schema->storage->dbh;
 
-      my $schema = $self->schema();
-      my $dbh = $schema->storage->dbh;
+    my @new_terms;
+    foreach my $name (keys %$new_trait_names){
+        my $ids = $new_trait_names->{$name};
+        my @component_ids = split ',', $ids;
 
-      my $existing_trait_id = SGN::Model::Cvterm->get_trait_from_exact_components($schema, \@ids);
-      if ($existing_trait_id) {
-        die "This trait already exists.\n";
-      }
+        if (scalar(@component_ids)<2){
+            die "Should not save postcomposed term with less than 2 components\n";
+        }
 
-      my $db = $schema->resultset("General::Db")->find_or_create(
-          { name => 'COMP' });
+        my $existing_trait_id = SGN::Model::Cvterm->get_trait_from_exact_components($schema, \@component_ids);
+        if ($existing_trait_id) {
+            die "This trait already exists.\n";
+        }
 
-      my $cv= $schema->resultset('Cv::Cv')->find_or_create( { name => 'composed_trait' });
+        my $db = $schema->resultset("General::Db")->find_or_create({ name => 'COMP' });
+        my $cv= $schema->resultset('Cv::Cv')->find_or_create( { name => 'composed_trait' });
 
-      my $accession_query = "SELECT nextval('composed_trait_ids')";
-      my $h = $dbh->prepare($accession_query);
-      $h->execute();
-      my $accession = $h->fetchrow_array();
-
-      # check for minimum of OBJ, ATTR, METH, UNIT OR TRAIT + TIME
-
-      #print STDERR "New trait accession = $accession and name = $name\n";
-
-      my $compose_query = " SELECT string_agg(ordered_components.name::text, '|'),
-                                  string_agg(ordered_components.synonym::text, '_')
-                                  FROM (
-                                    SELECT cvterm.name,
-                                    CASE WHEN synonym IS NULL THEN cvterm.name
-                                      WHEN substring(synonym from '\"(.+)\"') IS NULL THEN synonym
-                                      ELSE substring(synonym from '\"(.+)\"')
-                                    END AS synonym,
-                                          cv.cv_id
-                                    FROM cvterm
-                                    LEFT JOIN cvtermsynonym syn ON (cvterm.cvterm_id = syn.cvterm_id AND syn.type_id = (SELECT cvterm_id from cvterm where name = 'EXACT'))
-                                    JOIN cv USING(cv_id)
-                                    JOIN cvprop ON(cv.cv_id = cvprop.cv_id)
-                                    JOIN cvterm type ON(cvprop.type_id = type.cvterm_id)
-                                    WHERE cvterm.cvterm_id IN (@{[join',', ('?') x @ids]})
-                                    ORDER BY (
-                                      case when type.name = 'object_ontology' then 1
-                                          when type.name = 'attribute_ontology' then 2
-                                          when type.name = 'method_ontology' then 3
-                                          when type.name = 'unit_ontology' then 4
-                                          when type.name = 'trait_ontology' then 5
-                                          when type.name = 'time_ontology' then 6
-                                      end
-                                    )
-                                  ) ordered_components";
-
-      print STDERR "Compose query = $compose_query\n";
-
-      $h = $dbh->prepare($compose_query);
-      $h->execute(@ids);
-      my ($name, $synonym) = $h->fetchrow_array();
-
-      print STDERR "New trait name = $name and synonym = $synonym\n";
+        my $accession_query = "SELECT nextval('composed_trait_ids')";
+        my $h = $dbh->prepare($accession_query);
+        $h->execute();
+        my $accession = $h->fetchrow_array();
 
       my $new_term_dbxref =  $schema->resultset("General::Dbxref")->create(
       {   db_id     => $db->get_column('db_id'),
@@ -158,51 +121,37 @@ sub compose_trait {
         dbxref_id  => $new_term_dbxref-> dbxref_id()
       });
 
-      $new_term->add_synonym($synonym, { synonym_type => 'EXACT' , autocreate => 1});  #adds synonym with type
-
     #print STDERR "New term cvterm_id = " . $new_term->cvterm_id();
 
-    my $isa_relationship = $schema->resultset("Cv::Cvterm")->find(
-    	  { name => 'is_a',
-      });
+        my $contains_relationship = $schema->resultset("Cv::Cvterm")->find({ name => 'contains' });
+        my $variable_relationship = $schema->resultset("Cv::Cvterm")->find({ name => 'VARIABLE_OF' });
 
-    #print STDERR "Is a relationship cvterm_id = " . $isa_relationship->cvterm_id();
+        my $variable_rel = $schema->resultset('Cv::CvtermRelationship')->create({
+            subject_id => $new_term->cvterm_id(),
+            object_id  => $parent_term->cvterm_id(),
+            type_id    => $variable_relationship->cvterm_id()
+        });
 
-    my $contains_relationship = $schema->resultset("Cv::Cvterm")->find(
-        { name => 'contains',
-      });
+        foreach my $component_id (@component_ids) {
+            my $contains_rel = $schema->resultset('Cv::CvtermRelationship')->create({
+                subject_id => $component_id,
+                object_id  => $new_term->cvterm_id(),
+                type_id    => $contains_relationship->cvterm_id()
+            });
+        }
 
-    #print STDERR "Contains relationship cvterm_id = " . $contains_relationship->cvterm_id();
-
-    my $variable_relationship = $schema->resultset("Cv::Cvterm")->find({ name => 'VARIABLE_OF' });
-
-    my @component_ids = split ',', $ids;
-
-    my $isa_rel = $schema->resultset('Cv::CvtermRelationship')->create(
-      { subject_id => $new_term->cvterm_id(),
-        object_id  => $parent_term->cvterm_id(),
-        type_id    => $variable_relationship->cvterm_id()
-    });
-
-    foreach my $component_id (@component_ids) {
-      my $contains_rel = $schema->resultset('Cv::CvtermRelationship')->create(
-        { subject_id => $component_id,
-          object_id  => $new_term->cvterm_id(),
-          type_id    => $contains_relationship->cvterm_id()
-      });
+        push @new_terms, [$new_term->cvterm_id, $new_term->name().'|COMP:'.sprintf("%07d",$accession)];
     }
 
     my $refresh1 = "REFRESH MATERIALIZED VIEW traits";
-    $h = $dbh->prepare($refresh1);
+    my $h = $dbh->prepare($refresh1);
     $h->execute();
 
     my $refresh2 = "REFRESH MATERIALIZED VIEW trait_componentsXtraits";
     $h = $dbh->prepare($refresh2);
     $h->execute();
 
-    return { cvterm_id => $new_term->cvterm_id(),
-            name => $new_term->name().'|COMP:'.sprintf("%07d",$accession)
-        };
+    return \@new_terms;
 }
 
 

--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -82,7 +82,7 @@ sub store_composed_term {
     my $dbh = $schema->storage->dbh;
 
     my @new_terms;
-    foreach my $name (keys %$new_trait_names){
+    foreach my $name (sort keys %$new_trait_names){
         my $ids = $new_trait_names->{$name};
         my @component_ids = split ',', $ids;
 
@@ -98,7 +98,8 @@ sub store_composed_term {
 
         my $existing_trait_id = SGN::Model::Cvterm->get_trait_from_exact_components($schema, \@component_ids);
         if ($existing_trait_id) {
-            die "This trait already exists.\n";
+            print STDERR "This trait already exists $name with the following component_ids".Dumper(\@component_ids)."\n";
+            next;
         }
 
         my $db = $schema->resultset("General::Db")->find_or_create({ name => 'COMP' });

--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheet.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheet.pm
@@ -143,6 +143,7 @@ sub parse {
     my $timestamp_included = shift;
     my $data_level = shift;
     my $schema = shift;
+    my $composable_cvterm_format = shift // 'extended';
     my %parse_result;
     my @file_lines;
     my $delimiter = ',';
@@ -216,7 +217,10 @@ sub parse {
                             push @component_cvterm_ids, $component_cvterm_id;
                         }
                     }
-                    $trait_name = SGN::Model::Cvterm->get_trait_from_exact_components($schema, \@component_cvterm_ids)->name();
+                    my $trait_cvterm_id = SGN::Model::Cvterm->get_cvterm_row_from_trait_name($schema, $trait_name)->cvterm_id();
+                    push @component_cvterm_ids, $trait_cvterm_id;
+                    my $trait_name_cvterm_id = SGN::Model::Cvterm->get_trait_from_exact_components($schema, \@component_cvterm_ids);
+                    $trait_name = SGN::Model::Cvterm::get_trait_from_cvterm_id($schema, $trait_name_cvterm_id, $composable_cvterm_format);
                 }
 
                 $traits_seen{$trait_name} = 1;

--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -163,7 +163,7 @@ sub verify {
     my $trait_validator = CXGN::List::Validate->new();
     my @plots_missing = @{$plot_validator->validate($schema,'plots_or_plants',\@plot_list)->{'missing'}};
     my @traits_missing = @{$trait_validator->validate($schema,'traits',\@trait_list)->{'missing'}};
-    my @trait_list = @{$self->trait_list};
+    @trait_list = @{$self->trait_list};
     my $error_message;
     my $warning_message;
 

--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -20,7 +20,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     image_zipfile_path=>$image_zip
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
-my $stored_phenotype_error = $store_phenotypes->store();
+my ($stored_phenotype_error, $stored_Phenotype_success) = $store_phenotypes->store();
 
 =head1 DESCRIPTION
 

--- a/lib/CXGN/Trial.pm
+++ b/lib/CXGN/Trial.pm
@@ -1305,6 +1305,7 @@ sub get_traits_assayed {
 sub get_trait_components_assayed {
     my $self = shift;
     my $stock_type = shift;
+    my $composable_cvterm_format = shift;
     my $dbh = $self->bcs_schema->storage()->dbh();
     my $traits_assayed = $self->get_traits_assayed($stock_type);
 
@@ -1314,8 +1315,8 @@ sub get_trait_components_assayed {
         my $trait_components = SGN::Model::Cvterm->get_components_from_trait($self->bcs_schema, $_->[0]);
         foreach (@$trait_components){
             if (!exists($unique_components{$_})){
-                my $component_cvterm = $self->bcs_schema->resultset("Cv::Cvterm")->find({cvterm_id=>$_});
-                push @trait_components_assayed, [$component_cvterm->cvterm_id(), $component_cvterm->name()];
+                my $component_cvterm = SGN::Model::Cvterm::get_trait_from_cvterm_id($self->bcs_schema, $_, $composable_cvterm_format);
+                push @trait_components_assayed, [$_, $component_cvterm];
                 $unique_components{$_}++;
             }
         }

--- a/lib/SGN/Controller/AJAX/DeriveTrait.pm
+++ b/lib/SGN/Controller/AJAX/DeriveTrait.pm
@@ -284,7 +284,7 @@ project.project_id=? ) );");
         metadata_hash=>\%phenotype_metadata,
     );
 
-    my $store_error = $store_phenotypes->store();
+    my ($store_error, $store_success) = $store_phenotypes->store();
     if ($store_error) {
         $c->stash->{rest} = {error => $store_error};
     }
@@ -400,7 +400,7 @@ sub store_generated_plot_phenotypes : Path('/ajax/breeders/trial/store_generated
             overwrite_values=>$overwrite,
             metadata_hash=>\%phenotype_metadata,
         );
-        my $store_error = $store_phenotypes->store();
+        my ($store_error, $store_success) = $store_phenotypes->store();
         if ($store_error) {
             $c->stash->{rest} = {error => $store_error};
         }

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -340,6 +340,7 @@ sub get_phenotyped_trait_components_select : Path('/ajax/html/select/phenotyped_
     #my $stock_type = $c->req->param('stock_type') . 's' || 'none';
     my $data_level = $c->req->param('data_level') || 'all';
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
+    my $composable_cvterm_format = $c->config->{composable_cvterm_format};
 
     if ($data_level eq 'all') {
         $data_level = '';
@@ -350,10 +351,15 @@ sub get_phenotyped_trait_components_select : Path('/ajax/html/select/phenotyped_
     my @trait_components;
     foreach (@trial_ids){
         my $trial = CXGN::Trial->new({bcs_schema=>$schema, trial_id=>$_});
-        push @trait_components, @{$trial->get_trait_components_assayed($data_level)};
+        push @trait_components, @{$trial->get_trait_components_assayed($data_level, $composable_cvterm_format)};
     }
-    my %unique_trait_components = map {$_=>1} @trait_components;
-    my @unique_components = keys %unique_trait_components;
+    #print STDERR Dumper \@trait_components;
+    my %unique_trait_components = map {$_->[0] => $_->[1]} @trait_components;
+    my @unique_components;
+    foreach my $id (keys %unique_trait_components){
+        push @unique_components, [$id, $unique_trait_components{$id}];
+    }
+    #print STDERR Dumper \@unique_components;
 
     my $id = $c->req->param("id") || "html_trait_component_select";
     my $name = $c->req->param("name") || "html_trait_component_select";

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -472,6 +472,7 @@ sub ontology_children_select : Path('/ajax/html/select/ontology_children') Args(
     my $rel_cvterm = $c->request->param("rel_cvterm");
     my $rel_cv = $c->request->param("rel_cv");
     my $size = $c->req->param('size') || '5';
+    my $value_format = $c->req->param('value_format') || 'ids';
     print STDERR "Parent Node $parent_node_cvterm\n";
 
     my $select_name = $c->request->param("selectbox_name");
@@ -496,14 +497,19 @@ sub ontology_children_select : Path('/ajax/html/select/ontology_children') Args(
         my $accession = $dbxref_info->first()->accession();
         my $db_info = $dbxref_info->search_related('db');
         my $db_name = $db_info->first()->name();
-        push @ontology_children, [$cvterm_id, $child->name."|".$db_name.":".$accession];
+        if ($value_format eq 'ids'){
+            push @ontology_children, [$cvterm_id, $child->name."|".$db_name.":".$accession];
+        }
+        if ($value_format eq 'names'){
+            push @ontology_children, [$child->name."|".$db_name.":".$accession, $child->name."|".$db_name.":".$accession];
+        }
     }
 
     @ontology_children = sort { $a->[1] cmp $b->[1] } @ontology_children;
     if ($empty) {
         unshift @ontology_children, [ 0, "None" ];
     }
-    print STDERR Dumper \@ontology_children;
+    #print STDERR Dumper \@ontology_children;
     my $html = simple_selectbox_html(
         name => $select_name,
         id => $select_id,

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -373,7 +373,7 @@ sub get_phenotyped_trait_components_select : Path('/ajax/html/select/phenotyped_
     $c->stash->{rest} = { select => $html };
 }
 
-sub get_phenotyped_trait_components_select : Path('/ajax/html/select/composable_cvs_allowed_combinations') Args(0) {
+sub get_composable_cvs_allowed_combinations_select : Path('/ajax/html/select/composable_cvs_allowed_combinations') Args(0) {
     my $self = shift;
     my $c = shift;
     my $id = $c->req->param("id") || "html_composable_cvs_combinations_select";

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -373,6 +373,26 @@ sub get_phenotyped_trait_components_select : Path('/ajax/html/select/phenotyped_
     $c->stash->{rest} = { select => $html };
 }
 
+sub get_phenotyped_trait_components_select : Path('/ajax/html/select/composable_cvs_allowed_combinations') Args(0) {
+    my $self = shift;
+    my $c = shift;
+    my $id = $c->req->param("id") || "html_composable_cvs_combinations_select";
+    my $name = $c->req->param("name") || "html_composable_cvs_combinations_select";
+    my $composable_cvs_allowed_combinations = $c->config->{composable_cvs_allowed_combinations};
+    my @combinations = split ',', $composable_cvs_allowed_combinations;
+    my @select;
+    foreach (@combinations){
+        my @parts = split /\|/, $_; #/#
+        push @select, [$parts[1], $parts[0]];
+    }
+    my $html = simple_selectbox_html(
+      name => $name,
+      id => $id,
+      choices => \@select,
+    );
+    $c->stash->{rest} = { select => $html };
+}
+
 sub get_crosses_select : Path('/ajax/html/select/crosses') Args(0) {
     my $self = shift;
     my $c = shift;

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -472,6 +472,7 @@ sub ontology_children_select : Path('/ajax/html/select/ontology_children') Args(
     my $rel_cvterm = $c->request->param("rel_cvterm");
     my $rel_cv = $c->request->param("rel_cv");
     my $size = $c->req->param('size') || '5';
+    print STDERR "Parent Node $parent_node_cvterm\n";
 
     my $select_name = $c->request->param("selectbox_name");
     my $select_id = $c->request->param("selectbox_id");
@@ -502,7 +503,7 @@ sub ontology_children_select : Path('/ajax/html/select/ontology_children') Args(
     if ($empty) {
         unshift @ontology_children, [ 0, "None" ];
     }
-    #print STDERR Dumper \@ontology_children;
+    print STDERR Dumper \@ontology_children;
     my $html = simple_selectbox_html(
         name => $select_name,
         id => $select_id,

--- a/lib/SGN/Controller/AJAX/Onto.pm
+++ b/lib/SGN/Controller/AJAX/Onto.pm
@@ -31,6 +31,7 @@ use SGN::Model::Cvterm;
 use CXGN::Chado::Cvterm;
 use CXGN::Onto;
 use Data::Dumper;
+use JSON;
 
 use namespace::autoclean;
 
@@ -48,7 +49,7 @@ Creates a new term in the designated composed trait cv and links it to component
 
 =cut
 
-sub compose_trait: Path('/ajax/onto/compose') Args(0) {
+sub compose_trait: Path('/ajax/onto/store_composed_term') Args(0) {
 
   my $self = shift;
   my $c = shift;
@@ -56,19 +57,25 @@ sub compose_trait: Path('/ajax/onto/compose') Args(0) {
   #my @ids = $c->req->param("ids[]");
   #print STDERR "Ids array for composing in AJAX Onto = @ids\n";
 
-  my $ids = $c->req->param("ids");
-  print STDERR "Ids string for composing in AJAX Onto = $ids\n";
-  my $composed_trait;
+  my $new_trait_names = decode_json $c->req->param("new_trait_names");
+  #print STDERR Dumper $new_trait_names;
+  my $new_terms;
   eval {
       my $onto = CXGN::Onto->new( { schema => $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado') } );
-      $composed_trait = $onto->compose_trait($ids);
+      $new_terms = $onto->store_composed_term($new_trait_names);
   };
   if ($@) {
       $c->stash->{rest} = { error => "An error occurred saving the new trait details: $@" };
   }
   else {
-      $c->stash->{rest} = { success => 'Saved new trait <a href="/cvterm/'.$composed_trait->{cvterm_id}.'/view">'.$composed_trait->{name}.'</a>.',
-                            name => $composed_trait->{name} };
+      my $message = '';
+      my @names;
+      foreach (@$new_terms){
+          $message .= 'Saved new trait <a href="/cvterm/'.$_->[0].'/view">'.$_->[1].'</a><br>';
+          push @names, $_->[1];
+      }
+      $c->stash->{rest} = { success => $message,
+                            names => \@names };
   }
 
 }

--- a/lib/SGN/Controller/AJAX/Onto.pm
+++ b/lib/SGN/Controller/AJAX/Onto.pm
@@ -30,6 +30,7 @@ use Moose;
 use SGN::Model::Cvterm;
 use CXGN::Chado::Cvterm;
 use CXGN::Onto;
+use Data::Dumper;
 
 use namespace::autoclean;
 
@@ -105,6 +106,8 @@ sub get_traits_from_component_categories: Path('/ajax/onto/get_traits_from_compo
   my $self = shift;
   my $c = shift;
   my @allowed_composed_cvs = split ',', $c->config->{composable_cvs};
+  my $composable_cvterm_delimiter = $c->config->{composable_cvterm_delimiter};
+  my $composable_cvterm_format = $c->config->{composable_cvterm_format};
   my @object_ids = $c->req->param("object_ids[]");
   my @attribute_ids = $c->req->param("attribute_ids[]");
   my @method_ids = $c->req->param("method_ids[]");
@@ -115,18 +118,17 @@ sub get_traits_from_component_categories: Path('/ajax/onto/get_traits_from_compo
   my @gen_ids = $c->req->param("gen_ids[]");
 
   print STDERR "Obj ids are @object_ids\n Attr ids are @attribute_ids\n Method ids are @method_ids\n unit ids are @unit_ids\n trait ids are @trait_ids\n tod ids are @tod_ids\n toy ids are @toy_ids\n gen ids are @gen_ids\n";
-
   my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
 
-  my $traits = SGN::Model::Cvterm->get_traits_from_component_categories($schema, \@allowed_composed_cvs, {
-      object_ids => \@object_ids,
-      attribute_ids => \@attribute_ids,
-      method_ids => \@method_ids,
-      unit_ids => \@unit_ids,
-      trait_ids => \@trait_ids,
-      tod_ids => \@tod_ids,
-      toy_ids => \@toy_ids,
-      gen_ids => \@gen_ids,
+  my $traits = SGN::Model::Cvterm->get_traits_from_component_categories($schema, \@allowed_composed_cvs, $composable_cvterm_delimiter, $composable_cvterm_format, {
+      object => \@object_ids,
+      attribute => \@attribute_ids,
+      method => \@method_ids,
+      unit => \@unit_ids,
+      trait => \@trait_ids,
+      tod => \@tod_ids,
+      toy => \@toy_ids,
+      gen => \@gen_ids,
   });
 
   if (!$traits) {

--- a/lib/SGN/Controller/AJAX/Onto.pm
+++ b/lib/SGN/Controller/AJAX/Onto.pm
@@ -104,7 +104,7 @@ sub get_traits_from_component_categories: Path('/ajax/onto/get_traits_from_compo
 
   my $self = shift;
   my $c = shift;
-
+  my @allowed_composed_cvs = split ',', $c->config->{composable_cvs};
   my @object_ids = $c->req->param("object_ids[]");
   my @attribute_ids = $c->req->param("attribute_ids[]");
   my @method_ids = $c->req->param("method_ids[]");
@@ -118,7 +118,7 @@ sub get_traits_from_component_categories: Path('/ajax/onto/get_traits_from_compo
 
   my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
 
-  my $traits = SGN::Model::Cvterm->get_traits_from_component_categories($schema, {
+  my $traits = SGN::Model::Cvterm->get_traits_from_component_categories($schema, \@allowed_composed_cvs, {
       object_ids => \@object_ids,
       attribute_ids => \@attribute_ids,
       method_ids => \@method_ids,

--- a/lib/SGN/Controller/AJAX/PhenotypesDownload.pm
+++ b/lib/SGN/Controller/AJAX/PhenotypesDownload.pm
@@ -97,6 +97,41 @@ sub create_phenotype_spreadsheet_POST : Args(0) {
     print STDERR "DOWNLOAD FILENAME = ".$create_spreadsheet->filename()."\n";
     print STDERR "RELATIVE  = $rel_file\n";
 
+    #Add postcomposed terms from selected predefined_columns
+    my @allowed_composed_cvs = split ',', $c->config->{composable_cvs};
+    my $composable_cvterm_delimiter = $c->config->{composable_cvterm_delimiter};
+    my $composable_cvterm_format = $c->config->{composable_cvterm_format};
+    my @allowed_composed_cvs_minus_trait = grep { $_ ne 'trait' } @allowed_composed_cvs;
+    my %id_hash;
+    for my $i (0 .. scalar @$predefined_columns){
+        my $cv_type = $allowed_composed_cvs_minus_trait[$i];
+        foreach my $selected_term (values %{$predefined_columns->[$i]}){
+            my $cvterm_id = SGN::Model::Cvterm->get_cvterm_row_from_trait_name($schema, $selected_term)->cvterm_id();
+            push @{$id_hash{$cv_type}}, $cvterm_id;
+        }
+    }
+    my @trait_cvterm_ids;
+    foreach (@trait_list){
+        push @trait_cvterm_ids, SGN::Model::Cvterm->get_cvterm_row_from_trait_name($schema, $_)->cvterm_id();
+    }
+    $id_hash{'trait'} = \@trait_cvterm_ids;
+    #print STDERR Dumper \%id_hash;
+    my $traits = SGN::Model::Cvterm->get_traits_from_component_categories($schema, \@allowed_composed_cvs, $composable_cvterm_delimiter, $composable_cvterm_format, \%id_hash);
+    my %new_traits;
+    foreach (@{$traits->{new_traits}}){
+        $new_traits{$_->[1]} = join ',', @{$_->[0]};
+    }
+    #print STDERR Dumper \%new_traits;
+    my $new_terms;
+    eval {
+        my $onto = CXGN::Onto->new({ schema => $schema });
+        $new_terms = $onto->store_composed_term(\%new_traits);
+    };
+    if ($@) {
+        die "An error occurred saving the new trait details: $@";
+    }
+    #print STDERR Dumper $new_terms;
+
 #if ($error) {
 #$c->stash->{rest} = { error => $error };
 #return;

--- a/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
+++ b/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
@@ -55,7 +55,6 @@ sub upload_phenotype_verify_POST : Args(1) {
     if ($timestamp_included) {
         $timestamp = 1;
     }
-
     my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
         bcs_schema=>$schema,
         metadata_schema=>$metadata_schema,
@@ -128,11 +127,14 @@ sub upload_phenotype_store_POST : Args(1) {
     #}
     #push @$success_status, "File data verified. Plot names and trait names are valid.";
 
-    my $stored_phenotype_error = $store_phenotypes->store();
+    my ($stored_phenotype_error, $stored_phenotype_success) = $store_phenotypes->store();
     if ($stored_phenotype_error) {
         push @$error_status, $stored_phenotype_error;
         $c->stash->{rest} = {success => $success_status, error => $error_status};
         return;
+    }
+    if ($stored_phenotype_success) {
+        push @$success_status, $stored_phenotype_success;
     }
 
     if ($image_zip) {
@@ -144,7 +146,6 @@ sub upload_phenotype_store_POST : Args(1) {
     }
 
     push @$success_status, "Metadata saved for archived file.";
-    push @$success_status, "File data successfully stored.";
 
     $c->stash->{rest} = {success => $success_status, error => $error_status};
 }

--- a/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
+++ b/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
@@ -368,7 +368,7 @@ sub update_plot_phenotype_POST : Args(0) {
     $c->detach;
   }
 
-  my $store_error = $store_phenotypes->store();
+  my ($store_error, $store_success) = $store_phenotypes->store();
   if ($store_error) {
       $c->stash->{rest} = {error => $store_error};
       $c->detach;

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -432,7 +432,7 @@ sub download_action : Path('/breeders/download_action') Args(0) {
     my $datalevel         = $c->req->param("phenotype_datalevel");
     my $timestamp_included = $c->req->param("timestamp") || 0;
     my $cookie_value      = $c->req->param("download_token_value");
-    my $search_type        = $c->req->param("search_type") || 'fast';
+    my $search_type        = $c->req->param("search_type") || 'complete';
 
     my $accession_data;
     if ($accession_list_id) {
@@ -498,10 +498,10 @@ sub download_action : Path('/breeders/download_action') Args(0) {
 
     if ($format eq "html") { #dump html in browser
         $output = "";
-        my @header = split /\t/, $data[0];
+        my @header = @{$data[0]};
         my $num_col = scalar(@header);
         for (my $line =0; $line< @data; $line++) {
-            my @columns = split /\t/, $data[$line];
+            my @columns = @{$data[$line]};
             my $step = 1;
             for(my $i=0; $i<$num_col; $i++) {
                 if ($columns[$i]) {
@@ -532,10 +532,10 @@ sub download_action : Path('/breeders/download_action') Args(0) {
 
             #build csv with column names
             open(CSV, ">", $tempfile) || die "Can't open file $tempfile\n";
-                my @header = split /\t/, $data[0];
+                my @header = @{$data[0]};
                 my $num_col = scalar(@header);
                 for (my $line =0; $line< @data; $line++) {
-                    my @columns = split /\t/, $data[$line];
+                    my @columns = @{$data[$line]};
                     my $step = 1;
                     for(my $i=0; $i<$num_col; $i++) {
                         if ($columns[$i]) {
@@ -557,7 +557,7 @@ sub download_action : Path('/breeders/download_action') Args(0) {
             my $ws = $ss->add_worksheet();
 
             for (my $line =0; $line< @data; $line++) {
-                my @columns = split /\t/, $data[$line];
+                my @columns = @{$data[$line]};
                 for(my $col = 0; $col<@columns; $col++) {
                     $ws->write($line, $col, $columns[$col]);
                 }

--- a/lib/SGN/Controller/Ontology.pm
+++ b/lib/SGN/Controller/Ontology.pm
@@ -101,7 +101,10 @@ sub compose_trait : Path('/tools/compose') :Args(0) {
     $c->stash->{trait_select} = $html_hash{'trait_ontology'};
 
     $c->stash->{composable_cvs} = $c->config->{composable_cvs};
-    $c->stash->{allowed_combinations} = $c->config->{allowed_combinations};
+    $c->stash->{composable_cvs_allowed_combinations} = $c->config->{composable_cvs_allowed_combinations};
+    $c->stash->{composable_tod_root_cvterm} = $c->config->{composable_tod_root_cvterm};
+    $c->stash->{composable_toy_root_cvterm} = $c->config->{composable_toy_root_cvterm};
+    $c->stash->{composable_gen_root_cvterm} = $c->config->{composable_gen_root_cvterm};
 
     $c->stash->{user} = $c->user();
     $c->stash->{template} = '/ontology/compose_trait.mas';

--- a/lib/SGN/Controller/Phenotypes.pm
+++ b/lib/SGN/Controller/Phenotypes.pm
@@ -70,7 +70,7 @@ sub delete_uploaded_phenotype_files : Path('/breeders/phenotyping/delete/') Args
      my $h = $dbh->prepare("
         DROP TABLE IF EXISTS temp;
         CREATE TEMP TABLE temp AS
-        SELECT nd_experiment_id, nd_experiment_md_files_id, phenotype_id FROM metadata.md_files LEFT JOIN phenome.nd_experiment_md_files USING(file_id) JOIN nd_experiment_phenotype USING (nd_experiment_id) WHERE file_id=?;
+        SELECT nd_experiment_id, nd_experiment_md_files_id, phenotype_id FROM metadata.md_files JOIN phenome.nd_experiment_md_files USING(file_id) JOIN nd_experiment_phenotype USING (nd_experiment_id) WHERE file_id=?;
         DELETE FROM phenome.nd_experiment_md_files WHERE nd_experiment_md_files_id IN (SELECT nd_experiment_md_files_id FROM temp);
         DELETE FROM nd_experiment where nd_experiment_id IN (SELECT nd_experiment_id FROM temp);
         DELETE FROM phenotype where phenotype_id IN (SELECT phenotype_id FROM temp);

--- a/lib/SGN/Controller/Phenotypes.pm
+++ b/lib/SGN/Controller/Phenotypes.pm
@@ -67,9 +67,16 @@ sub delete_uploaded_phenotype_files : Path('/breeders/phenotyping/delete/') Args
 	print "File ID: $file_id\n"; 
      my $dbh = $c->dbc->dbh();
      #my $h = $dbh->prepare("delete from metadata.md_files where file_id=?;");
-     my $h = $dbh->prepare("UPDATE metadata.md_metadata SET obsolete = 1 where metadata_id IN (SELECT metadata_id from metadata.md_files where file_id=?);");
-
+     my $h = $dbh->prepare("
+        CREATE TEMP TABLE temp AS
+        SELECT nd_experiment_id, nd_experiment_md_files_id, phenotype_id FROM metadata.md_files LEFT JOIN phenome.nd_experiment_md_files USING(file_id) JOIN nd_experiment_phenotype USING (nd_experiment_id) WHERE file_id=?;
+        DELETE FROM phenome.nd_experiment_md_files WHERE nd_experiment_md_files_id IN (SELECT nd_experiment_md_files_id FROM temp);
+        DELETE FROM nd_experiment where nd_experiment_id IN (SELECT nd_experiment_id FROM temp);
+        DELETE FROM phenotype where phenotype_id IN (SELECT phenotype_id FROM temp);
+        ");
+     my $h2 = $dbh->prepare("UPDATE metadata.md_metadata SET obsolete = 1 where metadata_id IN (SELECT metadata_id from metadata.md_files where file_id=?);");
      $h->execute($decoded);
+     $h2->execute($decoded);
      print STDERR "Phenotype file successfully made obsolete (AKA deleted).\n";
 	$c->response->redirect('/breeders/phenotyping');	
 }

--- a/lib/SGN/Controller/Phenotypes.pm
+++ b/lib/SGN/Controller/Phenotypes.pm
@@ -68,6 +68,7 @@ sub delete_uploaded_phenotype_files : Path('/breeders/phenotyping/delete/') Args
      my $dbh = $c->dbc->dbh();
      #my $h = $dbh->prepare("delete from metadata.md_files where file_id=?;");
      my $h = $dbh->prepare("
+        DROP TABLE IF EXISTS temp;
         CREATE TEMP TABLE temp AS
         SELECT nd_experiment_id, nd_experiment_md_files_id, phenotype_id FROM metadata.md_files LEFT JOIN phenome.nd_experiment_md_files USING(file_id) JOIN nd_experiment_phenotype USING (nd_experiment_id) WHERE file_id=?;
         DELETE FROM phenome.nd_experiment_md_files WHERE nd_experiment_md_files_id IN (SELECT nd_experiment_md_files_id FROM temp);

--- a/lib/SGN/Model/Cvterm.pm
+++ b/lib/SGN/Model/Cvterm.pm
@@ -125,25 +125,46 @@ sub get_trait_from_exact_components {
 sub get_traits_from_component_categories {
     my $self= shift;
     my $schema = shift;
+    my $allowed_composed_cvs = shift;
     my $cvterm_id_hash = shift;
     my %id_hash = %$cvterm_id_hash;
     my @id_strings;
+
+    my $object_order = List::MoreUtils::first_index {$_ eq 'object'} @$allowed_composed_cvs;
+    my $attribute_order = List::MoreUtils::first_index {$_ eq 'attribute'} @$allowed_composed_cvs;
+    my $method_order = List::MoreUtils::first_index {$_ eq 'method'} @$allowed_composed_cvs;
+    my $unit_order = List::MoreUtils::first_index {$_ eq 'unit'} @$allowed_composed_cvs;
+    my $trait_order = List::MoreUtils::first_index {$_ eq 'trait'} @$allowed_composed_cvs;
+    my $time_order = List::MoreUtils::first_index {$_ eq 'time'} @$allowed_composed_cvs;
+    my $tod_order = List::MoreUtils::first_index {$_ eq 'tod'} @$allowed_composed_cvs;
+    my $toy_order = List::MoreUtils::first_index {$_ eq 'toy'} @$allowed_composed_cvs;
+    my $gen_order = List::MoreUtils::first_index {$_ eq 'gen'} @$allowed_composed_cvs;
+    $object_order++;
+    $attribute_order++;
+    $method_order++;
+    $unit_order++;
+    $trait_order++;
+    $time_order++;
+    $tod_order++;
+    $toy_order++;
+    $gen_order++;
+    print STDERR "ALLOWED CV ORDER: object $object_order attribute $attribute_order method $method_order unit $unit_order trait $trait_order time $time_order\n";
 
     delete @id_hash{ grep { scalar @{$id_hash{$_}} < 1 } keys %id_hash }; #remove cvtypes with no ids
     my @keys = sort keys %id_hash;
 
     product { push @id_strings, join(',', map { "'$_[$_]'" } 0 .. $#keys); } @id_hash{@keys};
-    #print STDERR "id strings are: ".Dumper(@id_strings)."\n";
+    print STDERR "id strings are: ".Dumper(@id_strings)."\n";
 
     my $select = "SELECT string_agg(ordered_components.name::text, '|'), array_agg(ordered_components.cvterm_id)";
     my $from = " FROM (SELECT cvterm.name, cvterm.cvterm_id, cv.cv_id FROM cvterm JOIN cv USING(cv_id) JOIN cvprop ON(cv.cv_id = cvprop.cv_id) JOIN cvterm type ON(cvprop.type_id = type.cvterm_id)";
     my $where = " WHERE cvterm.cvterm_id IN (";
-    my $order = ") ORDER BY ( case when type.name = 'object_ontology' then 1
-                                    when type.name = 'attribute_ontology' then 2
-                                    when type.name = 'method_ontology' then 3
-                                    when type.name = 'unit_ontology' then 4
-                                    when type.name = 'trait_ontology' then 5
-                                    when type.name = 'time_ontology' then 6
+    my $order = ") ORDER BY ( case when type.name = 'object_ontology' then $object_order
+                                    when type.name = 'attribute_ontology' then $attribute_order
+                                    when type.name = 'method_ontology' then $method_order
+                                    when type.name = 'unit_ontology' then $unit_order
+                                    when type.name = 'trait_ontology' then $trait_order
+                                    when type.name = 'time_ontology' then $time_order
                                   end
                                 )
                               ) ordered_components";

--- a/lib/SGN/Model/Cvterm.pm
+++ b/lib/SGN/Model/Cvterm.pm
@@ -121,7 +121,7 @@ sub get_trait_from_exact_components {
     return $trait_cvterm_ids[0];
 }
 
-sub get_cvterm_from_cvterm_id {
+sub get_trait_from_cvterm_id {
     my $schema = shift;
     my $cvterm_id = shift;
     my $format = shift;
@@ -147,7 +147,7 @@ sub _concatenate_cvterm_array {
     foreach my $f (keys %first_hash){
         my $ids = $first_hash{$f};
         foreach my $s (@$second){
-            my $name = get_cvterm_from_cvterm_id($schema, $s, $format);
+            my $name = get_trait_from_cvterm_id($schema, $s, $format);
             my $concatenated_cvterm = $f.$delimiter.$name;
             push @$ids, $s;
             delete $first_hash{$f};
@@ -175,7 +175,7 @@ sub get_traits_from_component_categories {
     my $id_array_count = scalar(@ordered_id_groups);
     my $concatenated_cvterms;
     foreach (@{$ordered_id_groups[0]}){
-        my $name = get_cvterm_from_cvterm_id($schema, $_, $composable_cvterm_format);
+        my $name = get_trait_from_cvterm_id($schema, $_, $composable_cvterm_format);
         $concatenated_cvterms->{$name} = [$_];
     }
     for my $n (0 .. $id_array_count-2){

--- a/mason/breeders_toolbox/breeder_search_download.mas
+++ b/mason/breeders_toolbox/breeder_search_download.mas
@@ -19,20 +19,11 @@
                 <label class="col-sm-3 control-label">Format: </label>
                 <div class="col-sm-9" >
                     <select class="form-control" id="download_wizard_phenotypes_format">
-                        <option value="xls">Excel (xls)</option>
                         <option value="csv">CSV</option>
+                        <option value="xls">Excel (xls)</option>
                     </select>
                 </div>
 	        </div>
-            <div class="form-group">
-                <label class="col-sm-3 control-label">Include Timestamps: </label>
-                <div class="col-sm-9" >
-                    <select class="form-control" id="download_wizard_phenotypes_timestamp_option">
-                        <option value="0">No</option>
-                        <option value="1">Yes</option>
-                    </select>
-                </div>
-            </div>
             <div class="form-group">
                 <label class="col-sm-3 control-label">Data Level: </label>
                 <div class="col-sm-9" >
@@ -43,6 +34,19 @@
                     </select>
                 </div>
             </div>
+
+<&| /page/info_section.mas, title=>"Additional Search Options",  collapsible => 1, collapsed=>1 &>
+
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Include Timestamps: </label>
+                <div class="col-sm-9" >
+                    <select class="form-control" id="download_wizard_phenotypes_timestamp_option">
+                        <option value="0">No</option>
+                        <option value="1">Yes</option>
+                    </select>
+                </div>
+            </div>
+
             <div class="form-group">
                 <label class="col-sm-3 control-label">Trait Name Contains: </label>
                 <div class="col-sm-9" >
@@ -68,13 +72,16 @@
                     </div>
                 </div>
             </div>
+</&>
+<&| /page/info_section.mas, title=>"Too Slow?",  collapsible => 1, collapsed=>1 &>
             <div class="form-group">
-                <label class="col-sm-3 control-label">Download Type: </label>
+                <label class="col-sm-3 control-label">Search Type Option: </label>
                 <div class="col-sm-9" >
-                    <label class="radio-inline" title="Optimizes speed using the database cache. May exclude most recently uploaded data."><input type="radio" name="search_type" id="search_type" value="fast" checked>Fast (plots only)</label>
-                    <label class="radio-inline" title="Optimizes completeness using an exhaustive search. May result in longer download times."><input type="radio" name="search_type" id="search_type" value="complete">Complete</label>
+                    <label class="radio-inline" title="Optimizes completeness using an exhaustive search. May result in longer download times."><input type="radio" name="search_type" id="search_type" value="complete" checked>Complete</label>
+                    <label class="radio-inline" title="Optimizes speed using the database cache. May exclude most recently uploaded data."><input type="radio" name="search_type" id="search_type" value="fast" >Fast (plots only)</label>
                 </div>
             </div>
+</&>
 
         </form><br/>
 

--- a/mason/breeders_toolbox/breeder_search_download.mas
+++ b/mason/breeders_toolbox/breeder_search_download.mas
@@ -75,7 +75,7 @@
 </&>
 <&| /page/info_section.mas, title=>"Too Slow?",  collapsible => 1, collapsed=>1 &>
             <div class="form-group">
-                <label class="col-sm-3 control-label">Search Type Option: </label>
+                <label class="col-sm-3 control-label">Download Type: </label>
                 <div class="col-sm-9" >
                     <label class="radio-inline" title="Optimizes completeness using an exhaustive search. May result in longer download times."><input type="radio" name="search_type" id="search_type" value="complete" checked>Complete</label>
                     <label class="radio-inline" title="Optimizes speed using the database cache. May exclude most recently uploaded data."><input type="radio" name="search_type" id="search_type" value="fast" >Fast (plots only)</label>

--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -54,11 +54,11 @@ Choose a list for each parameter and click "Download".
       </div>
    </td>
    <td>
- <div class="checkbox">
-  <label><input type="checkbox" id="format" name="format" value=".xls">.xls (default)</label>
+<div class="checkbox">
+ <label><input type="checkbox" id="format" name="format" value=".csv" checked>.csv</label>
 </div>
 <div class="checkbox">
-  <label><input type="checkbox" id="format" name="format" value=".csv">.csv</label>
+  <label><input type="checkbox" id="format" name="format" value=".xls">.xls</label>
 </div>
 <div class="checkbox">
   <label><input type="checkbox" id="format" name="format" value="html">html</label>

--- a/mason/breeders_toolbox/trial/download_phenotypes_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_phenotypes_dialog.mas
@@ -27,15 +27,6 @@ $dialog_name => undef
                 </div>
 	        </div>
             <div class="form-group">
-                <label class="col-sm-3 control-label">Include Timestamps: </label>
-                <div class="col-sm-9" >
-                    <select class="form-control" id="download_trial_phenotypes_timestamp_option">
-                        <option value="0">No</option>
-                        <option value="1">Yes</option>
-                    </select>
-                </div>
-            </div>
-            <div class="form-group">
                 <label class="col-sm-3 control-label">Data Level: </label>
                 <div class="col-sm-9" >
                     <select class="form-control" id="download_trial_phenotypes_level_option">
@@ -59,6 +50,19 @@ $dialog_name => undef
                     </div>
                 </div>
             </div>
+
+<&| /page/info_section.mas, title=>"Additional Search Options",  collapsible => 1, collapsed=>1 &>
+
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Include Timestamps: </label>
+                <div class="col-sm-9" >
+                    <select class="form-control" id="download_trial_phenotypes_timestamp_option">
+                        <option value="0">No</option>
+                        <option value="1">Yes</option>
+                    </select>
+                </div>
+            </div>
+
             <div class="form-group">
                 <label class="col-sm-3 control-label">Trait Name Contains: </label>
                 <div class="col-sm-9" >
@@ -84,13 +88,16 @@ $dialog_name => undef
                     </div>
                 </div>
             </div>
+</&>
+<&| /page/info_section.mas, title=>"Too Slow?",  collapsible => 1, collapsed=>1 &>
             <div class="form-group">
                 <label class="col-sm-3 control-label">Download Type: </label>
                 <div class="col-sm-9" >
-                    <label class="radio-inline" title="Optimizes speed using the database cache. May exclude most recently uploaded data."><input type="radio" name="trial_search_type" id="trial_search_type" value="fast" checked>Fast (plots only)</label>
-                    <label class="radio-inline" title="Optimizes completeness using an exhaustive search. May result in longer download times."><input type="radio" name="trial_search_type" id="trial_search_type" value="complete">Complete</label>
+                    <label class="radio-inline" title="Optimizes completeness using an exhaustive search. May result in longer download times."><input type="radio" name="trial_search_type" id="trial_search_type" value="complete" checked>Complete</label>
+                    <label class="radio-inline" title="Optimizes speed using the database cache. May exclude most recently uploaded data."><input type="radio" name="trial_search_type" id="trial_search_type" value="fast">Fast (plots only)</label>
                 </div>
             </div>
+</&>
 
         </form><br/>
 

--- a/mason/breeders_toolbox/trial/download_trials_phenotypes_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_trials_phenotypes_dialog.mas
@@ -16,20 +16,11 @@
                 <label class="col-sm-3 control-label">Format: </label>
                 <div class="col-sm-9" >
                     <select class="form-control" id="download_trials_phenotypes_format">
-                        <option value="xls">Excel (xls)</option>
                         <option value="csv">CSV</option>
+                        <option value="xls">Excel (xls)</option>
                     </select>
                 </div>
 	        </div>
-            <div class="form-group">
-                <label class="col-sm-3 control-label">Include Timestamps: </label>
-                <div class="col-sm-9" >
-                    <select class="form-control" id="download_trials_phenotypes_timestamp_option">
-                        <option value="0">No</option>
-                        <option value="1">Yes</option>
-                    </select>
-                </div>
-            </div>
             <div class="form-group">
                 <label class="col-sm-3 control-label">Data Level: </label>
                 <div class="col-sm-9" >
@@ -37,6 +28,18 @@
                         <option value="plot">Plots</option>
                         <option value="plant">Plants</option>
                         <option value="all">All</option>
+                    </select>
+                </div>
+            </div>
+
+<&| /page/info_section.mas, title=>"Additional Search Options",  collapsible => 1, collapsed=>1 &>
+
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Include Timestamps: </label>
+                <div class="col-sm-9" >
+                    <select class="form-control" id="download_trials_phenotypes_timestamp_option">
+                        <option value="0">No</option>
+                        <option value="1">Yes</option>
                     </select>
                 </div>
             </div>
@@ -93,13 +96,16 @@
                     </div>
                 </div>
             </div>
+</&>
+<&| /page/info_section.mas, title=>"Too Slow?",  collapsible => 1, collapsed=>1 &>
             <div class="form-group">
                 <label class="col-sm-3 control-label">Download Type: </label>
                 <div class="col-sm-9" >
-                    <label class="radio-inline" title="Optimizes speed using the database cache. May exclude most recently uploaded data."><input type="radio" name="trials_search_type" id="trials_search_type" value="fast" checked>Fast (plots only)</label>
-                    <label class="radio-inline" title="Optimizes completeness using an exhaustive search. May result in longer download times."><input type="radio" name="trials_search_type" id="trials_search_type" value="complete">Complete</label>
+                    <label class="radio-inline" title="Optimizes speed using the database cache. May exclude most recently uploaded data."><input type="radio" name="trials_search_type" id="trials_search_type" value="fast" >Fast (plots only)</label>
+                    <label class="radio-inline" title="Optimizes completeness using an exhaustive search. May result in longer download times."><input type="radio" name="trials_search_type" id="trials_search_type" value="complete" checked>Complete</label>
                 </div>
             </div>
+</&>
 
             </form><br/>
 

--- a/mason/ontology/compose_trait.mas
+++ b/mason/ontology/compose_trait.mas
@@ -263,7 +263,7 @@ var new_traits = jQuery("#new_traits").val();
 var new_trait_names = {};
 jQuery("#new_traits option:selected").each(function () {
    if (jQuery(this).length) {
-    new_trait_names[jQuery(this).text()] = jQuery(this).val();
+        new_trait_names[jQuery.trim(jQuery(this).text())] = jQuery(this).val();
    }
 });
 //console.log(new_trait_names);
@@ -278,6 +278,7 @@ var names = [];
       data: {'new_trait_names': JSON.stringify(new_trait_names)},
       success: function(response) {
       if (response.success) {
+        //console.log(response);
         successes.push("<li class='list-group-item list-group-item-success'>"+response.success+"</li>");
         //console.log("Names are "+response.names);
         for(var i=0; i<response.names.length; i++){

--- a/mason/ontology/compose_trait.mas
+++ b/mason/ontology/compose_trait.mas
@@ -6,7 +6,10 @@ $method_select => undef
 $unit_select => undef
 $trait_select => undef
 $composable_cvs => undef
-$allowed_combinations => undef
+$composable_cvs_allowed_combinations => undef
+$composable_tod_root_cvterm => undef
+$composable_toy_root_cvterm => undef
+$composable_gen_root_cvterm => undef
 </%args>
 
 <& /util/import_javascript.mas, classes => ['CXGN.BreederSearch', 'CXGN.ComposeTrait'] &>
@@ -302,5 +305,38 @@ addToListMenu('results_to_list_menu', 'new_trait_names', {
 enable_ui();
 jQuery('#traits_saved_dialog').modal("show");
 });
+
+function create_multi_selects(cv_names) {
+    jQuery('#compose_trait').prop('disabled', true);
+    var names = cv_names.split(',');
+
+    for(i = 0; i < names.length; i++){
+        var cv_name = names[i];
+        var name = cv_name.trim();
+
+        switch (name) {
+            case "time":
+                jQuery("#tod_div,#toy_div,#gen_div").show();
+                get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_tod_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                get_select_box('ontology_children', 'toy_select_div', { 'selectbox_id' : 'toy_select', 'selectbox_name': 'toy_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_toy_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                get_select_box('ontology_children', 'gen_select_div', { 'selectbox_id' : 'gen_select', 'selectbox_name': 'gen_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_gen_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                break;
+            case "tod":
+                jQuery("#tod_div").show();
+                get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_tod_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                break;
+            case "toy":
+                jQuery("#toy_div").show();
+                get_select_box('ontology_children', 'toy_select_div', { 'selectbox_id' : 'toy_select', 'selectbox_name': 'toy_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_toy_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                break;
+            case "gen":
+                jQuery("#gen_div").show();
+                get_select_box('ontology_children', 'gen_select_div', { 'selectbox_id' : 'gen_select', 'selectbox_name': 'gen_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_gen_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                break;
+            default:
+                if (window.console) console.log("Did not recognize "+name+" category");
+        }
+    }
+}
 
 </script>

--- a/mason/ontology/compose_trait.mas
+++ b/mason/ontology/compose_trait.mas
@@ -249,29 +249,29 @@ jQuery('#compose_trait').on('click', function () {
     disable_ui();
     //console.log("just disabled ui");
 var new_traits = jQuery("#new_traits").val();
-var new_trait_names = [];
+var new_trait_names = {};
 jQuery("#new_traits option:selected").each(function () {
    if (jQuery(this).length) {
-    new_trait_names.push(jQuery(this).text());
+    new_trait_names[jQuery(this).text()] = jQuery(this).val();
    }
 });
-//console.log("new trait names = "+new_trait_names);
+//console.log(new_trait_names);
 var successes = [];
 var errors = [];
 var names = [];
-for (var i = 0; i < new_traits.length; i++) {
-  var component_ids = new_traits[i];
     jQuery.ajax( {
-      url: '/ajax/onto/compose',
+      url: '/ajax/onto/store_composed_term',
       timeout: 60000,
       async: false,
       method: 'POST',
-      data: {'ids': component_ids},
+      data: {'new_trait_names': JSON.stringify(new_trait_names)},
       success: function(response) {
       if (response.success) {
         successes.push("<li class='list-group-item list-group-item-success'>"+response.success+"</li>");
-        //console.log("Name is "+response.name);
-        names.push(response.name+"\n");
+        //console.log("Names are "+response.names);
+        for(var i=0; i<response.names.length; i++){
+            names.push(response.names[i]+"\n");
+        }
         return;
       }
       else {
@@ -284,7 +284,6 @@ for (var i = 0; i < new_traits.length; i++) {
         return;
       }
     });
-}
 // display results
 var results_html = '';
 if (successes.length > 0) {

--- a/mason/ontology/compose_trait.mas
+++ b/mason/ontology/compose_trait.mas
@@ -18,6 +18,20 @@ $composable_gen_root_cvterm => undef
 </br>
 
 <div class="panel panel-default">
+    <div class="panel-heading" data-toggle="collapse" data-parent="#accordion" data-target="#collapse0">
+        <div class="panel-title"><a href="#form" class="accordion-toggle">Trait Combinations</a><span class="pull-right clickable" onmouseover="" style="cursor: pointer;"><i class="glyphicon glyphicon-chevron-up"></i></span></div>
+    </div>
+    <div id="collapse0" class="panel-collapse collapse in">
+        <div class="panel-body form-horizontal container-fluid" style="overflow:hidden">
+            <div class="col-sm-12 col-md-12 col-lg-12">
+                <div id="cv_combination_allowed_select_div">
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-default">
   <div class="panel-heading" data-toggle="collapse" data-parent="#accordion" data-target="#collapse1">
     <div class="panel-title"><a href="#form" class="accordion-toggle">Base Trait</a><span class="pull-right clickable" onmouseover="" style="cursor: pointer;"><i class="glyphicon glyphicon-chevron-up"></i></span></div>
   </div>
@@ -185,9 +199,6 @@ if (trait_html) {
     jQuery("#trait_div").show();
 }
 
-console.log("composable cvs are "+'<% $composable_cvs %>');
-create_multi_selects('<% $composable_cvs %>');
-
 addToListMenu('existing_traits_to_list', 'existing_traits', {
   selectText: true,
   listType: 'traits'
@@ -305,15 +316,45 @@ enable_ui();
 jQuery('#traits_saved_dialog').modal("show");
 });
 
-function create_multi_selects(cv_names) {
+function create_multi_selects(allowed_names) {
     jQuery('#compose_trait').prop('disabled', true);
-    var names = cv_names.split(',');
-
-    for(i = 0; i < names.length; i++){
-        var cv_name = names[i];
+    jQuery('#tod_div').hide();
+    jQuery('#toy_div').hide();
+    jQuery('#gen_div').hide();
+    jQuery('#object_div').hide();
+    jQuery('#trait_div').hide();
+    jQuery('#attribute_div').hide();
+    jQuery('#unit_div').hide();
+    jQuery('#method_div').hide();
+    jQuery('#tod_select').val([]);
+    jQuery('#toy_select').val([]);
+    jQuery('#gen_select').val([]);
+    jQuery('#object_select').val([]);
+    jQuery('#trait_select').val([]);
+    jQuery('#attribute_select').val([]);
+    jQuery('#unit_select').val([]);
+    jQuery('#method_select').val([]);
+    console.log(allowed_names);
+    for(i = 0; i < allowed_names.length; i++){
+        var cv_name = allowed_names[i];
         var name = cv_name.trim();
 
         switch (name) {
+            case "object":
+                jQuery('#object_div').show();
+                break;
+            case "trait":
+                jQuery('#trait_div').show();
+                break;
+            case "attribute":
+                jQuery('#attribute_div').show();
+                break;
+            case "unit":
+                jQuery('#unit_div').show();
+                break;
+            case "method":
+                jQuery('#method_div').show();
+                break;
             case "time":
                 jQuery("#tod_div,#toy_div,#gen_div").show();
                 get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_tod_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
@@ -337,5 +378,18 @@ function create_multi_selects(cv_names) {
         }
     }
 }
+
+jQuery(document).ready(function() {
+    get_select_box('composable_cvs_allowed_combinations', 'cv_combination_allowed_select_div', { 'id' : 'cv_combination_allowed_select', 'name' : 'cv_combination_allowed_select' });
+    jQuery(document).on('change', '#cv_combination_allowed_select', function(){
+        var names = jQuery('#cv_combination_allowed_select').val();
+        var allowed_names = names.split('+');
+        create_multi_selects(allowed_names);
+    });
+    var allowed_combinations = '<% $composable_cvs_allowed_combinations %>';
+    var allowed_combo = allowed_combinations.split(',');
+    var allowed_combo_first = allowed_combo[0].split('|');
+    create_multi_selects(allowed_combo_first[1].split('+'));
+});
 
 </script>

--- a/sgn.conf
+++ b/sgn.conf
@@ -11,7 +11,12 @@ dbuser   web_usr
 #dbpass   set_this_here
 
 composable_cvs trait, toy
-allowed_combinations "trait+toy"
+composable_cvs_allowed_combinations Agronomic|trait+toy
+composable_cvterm_delimiter |
+composable_cvterm_format concise
+composable_tod_root_cvterm "time of day|TIME:0000001"
+composable_toy_root_cvterm "time of year|TIME:0000005"
+composable_gen_root_cvterm "generation|TIME:0000072"
 
 project_name SGN
 

--- a/sgn.conf
+++ b/sgn.conf
@@ -11,7 +11,7 @@ dbuser   web_usr
 #dbpass   set_this_here
 
 composable_cvs trait, toy
-composable_cvs_allowed_combinations Agronomic|trait+toy
+composable_cvs_allowed_combinations Agronomic|trait+toy,Metabolic|trait+object+tod+toy+unit+method
 composable_cvterm_delimiter |
 composable_cvterm_format concise
 composable_tod_root_cvterm "time of day|TIME:0000001"

--- a/system_cvterms.txt
+++ b/system_cvterms.txt
@@ -178,4 +178,11 @@ protocol_property	published date	From BrAPI	03/27/2017	nm529	00076
 protocol_property	protocol type	From BrAPI	03/27/2017	nm529	00076	
 protocol_property	protocol unit	From BrAPI	03/27/2017	nm529	00076	
 protocol_property	protocol comment	From BrAPI	03/27/2017	nm529	00076	
+composable_cvs	trait_ontology		05/01/2017		00073	
+composable_cvs	composed_trait_ontology		05/01/2017		00073	
+composable_cvs	object_ontology		05/01/2017		00073	
+composable_cvs	attribute_ontology		05/01/2017		00073	
+composable_cvs	method_ontology		05/01/2017		00073	
+composable_cvs	unit_ontology		05/01/2017		00073	
+composable_cvs	time_ontology		05/01/2017		00073	
 project_design? 						suggested to move the trial design names from projectprop.value to projectprop.type_id

--- a/t/unit_fixture/CXGN/Onto.t
+++ b/t/unit_fixture/CXGN/Onto.t
@@ -7,6 +7,7 @@ use Test::More;
 use Data::Dumper;
 use SGN::Test::Fixture;
 use CXGN::Onto;
+use SGN::Model::Cvterm;
 
 my $t = SGN::Test::Fixture->new();
 my $onto = CXGN::Onto->new( { schema => $t->bcs_schema() });
@@ -37,13 +38,370 @@ my @cass_tissues = ["[77181,'cass fibrous root|CASSTISS:0000011']",
 is_deeply(@results, @cass_tissues, 'onto get terms test');
 =cut
 
-my $ids = "77172,77285,77412,77470";
-@results = $onto->compose_trait($ids);
-print STDERR Dumper "test 3 results ".@results;
+my @allowed_composed_cvs = ('trait','toy');
+my $composable_cvterm_delimiter = '|';
+my $composable_cvterm_format = 'concise';
+my $traits1 = SGN::Model::Cvterm->get_traits_from_component_categories($t->bcs_schema(), \@allowed_composed_cvs, $composable_cvterm_delimiter, $composable_cvterm_format, {
+    object => [],
+    attribute => [],
+    method => [],
+    unit => [],
+    trait => [70775,76555],
+    tod => [],
+    toy => [77526,77499],
+    gen => [],
+});
+#print STDERR Dumper $traits1;
+is_deeply($traits1, {
+          'existing_traits' => [],
+          'new_traits' => [
+                            [
+                              [
+                                70775,
+                                77526
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3|month 1'
+                            ],
+                            [
+                              [
+                                70775,
+                                77499
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3|month 10'
+                            ],
+                            [
+                              [
+                                76555,
+                                77526
+                              ],
+                              'ease of harvest assessment 1-3|month 1'
+                            ],
+                            [
+                              [
+                                76555,
+                                77499
+                              ],
+                              'ease of harvest assessment 1-3|month 10'
+                            ]
+                          ]
+        }, 'check composed trait creation 1');
 
-is_deeply(@results, {
-               'cvterm_id' => 77560,
-               'name' => 'cass upper stem|zinc atom|ug/g|week 54|COMP:0000014'
-             }, 'onto compose trait test');
+@allowed_composed_cvs = ('trait','toy','tod','object');
+$composable_cvterm_delimiter = '||';
+$composable_cvterm_format = 'concise';
+my $traits2 = SGN::Model::Cvterm->get_traits_from_component_categories($t->bcs_schema(), \@allowed_composed_cvs, $composable_cvterm_delimiter, $composable_cvterm_format, {
+  object => [77176, 77180],
+  attribute => [],
+  method => [],
+  unit => [],
+  trait => [70775,76555],
+  tod => [77536],
+  toy => [77526,77499],
+  gen => [],
+});
+#print STDERR Dumper $traits2;
+is_deeply($traits2, {
+          'existing_traits' => [],
+          'new_traits' => [
+                            [
+                              [
+                                70775,
+                                77499,
+                                77536,
+                                77176
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3||month 10||end of day||cass lower leaf'
+                            ],
+                            [
+                              [
+                                70775,
+                                77499,
+                                77536,
+                                77180
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3||month 10||end of day||cass sink leaf'
+                            ],
+                            [
+                              [
+                                70775,
+                                77526,
+                                77536,
+                                77176
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3||month 1||end of day||cass lower leaf'
+                            ],
+                            [
+                              [
+                                70775,
+                                77526,
+                                77536,
+                                77180
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3||month 1||end of day||cass sink leaf'
+                            ],
+                            [
+                              [
+                                76555,
+                                77499,
+                                77536,
+                                77176
+                              ],
+                              'ease of harvest assessment 1-3||month 10||end of day||cass lower leaf'
+                            ],
+                            [
+                              [
+                                76555,
+                                77499,
+                                77536,
+                                77180
+                              ],
+                              'ease of harvest assessment 1-3||month 10||end of day||cass sink leaf'
+                            ],
+                            [
+                              [
+                                76555,
+                                77526,
+                                77536,
+                                77176
+                              ],
+                              'ease of harvest assessment 1-3||month 1||end of day||cass lower leaf'
+                            ],
+                            [
+                              [
+                                76555,
+                                77526,
+                                77536,
+                                77180
+                              ],
+                              'ease of harvest assessment 1-3||month 1||end of day||cass sink leaf'
+                            ]
+                          ]
+        }, 'check composed trait creation 2');
+
+@allowed_composed_cvs = ('trait','toy','tod','object');
+$composable_cvterm_delimiter = '||';
+$composable_cvterm_format = 'extended';
+my $traits3 = SGN::Model::Cvterm->get_traits_from_component_categories($t->bcs_schema(), \@allowed_composed_cvs, $composable_cvterm_delimiter, $composable_cvterm_format, {
+  object => [77171, 77174],
+  attribute => [],
+  method => [],
+  unit => [],
+  trait => [70775,76555],
+  tod => [77536],
+  toy => [77526,77499],
+  gen => [],
+});
+#print STDERR Dumper $traits3;
+is_deeply($traits3, {
+          'existing_traits' => [],
+          'new_traits' => [
+                            [
+                              [
+                                70775,
+                                77499,
+                                77536,
+                                77171
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010'
+                            ],
+                            [
+                              [
+                                70775,
+                                77499,
+                                77536,
+                                77174
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009'
+                            ],
+                            [
+                              [
+                                70775,
+                                77526,
+                                77536,
+                                77171
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010'
+                            ],
+                            [
+                              [
+                                70775,
+                                77526,
+                                77536,
+                                77174
+                              ],
+                              'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009'
+                            ],
+                            [
+                              [
+                                76555,
+                                77499,
+                                77536,
+                                77171
+                              ],
+                              'ease of harvest assessment 1-3|CO:0000225||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010'
+                            ],
+                            [
+                              [
+                                76555,
+                                77499,
+                                77536,
+                                77174
+                              ],
+                              'ease of harvest assessment 1-3|CO:0000225||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009'
+                            ],
+                            [
+                              [
+                                76555,
+                                77526,
+                                77536,
+                                77171
+                              ],
+                              'ease of harvest assessment 1-3|CO:0000225||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010'
+                            ],
+                            [
+                              [
+                                76555,
+                                77526,
+                                77536,
+                                77174
+                              ],
+                              'ease of harvest assessment 1-3|CO:0000225||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009'
+                            ]
+                          ]
+        }, 'check composed trait creation 3');
+
+my $new_traits2 = $traits2->{new_traits};
+my %new_composed_terms2;
+foreach (@$new_traits2){
+  $new_composed_terms2{$_->[1]} = join ',', @{$_->[0]};
+}
+my $results2 = $onto->store_composed_term(\%new_composed_terms2);
+#print STDERR Dumper $results2;
+is_deeply($results2, [
+          [
+            77560,
+            'anthocyanin pigmentation visual rating 0-3||month 10||end of day||cass lower leaf|COMP:0000014'
+          ],
+          [
+            77561,
+            'anthocyanin pigmentation visual rating 0-3||month 10||end of day||cass sink leaf|COMP:0000015'
+          ],
+          [
+            77562,
+            'anthocyanin pigmentation visual rating 0-3||month 1||end of day||cass lower leaf|COMP:0000016'
+          ],
+          [
+            77563,
+            'anthocyanin pigmentation visual rating 0-3||month 1||end of day||cass sink leaf|COMP:0000017'
+          ],
+          [
+            77564,
+            'ease of harvest assessment 1-3||month 10||end of day||cass lower leaf|COMP:0000018'
+          ],
+          [
+            77565,
+            'ease of harvest assessment 1-3||month 10||end of day||cass sink leaf|COMP:0000019'
+          ],
+          [
+            77566,
+            'ease of harvest assessment 1-3||month 1||end of day||cass lower leaf|COMP:0000020'
+          ],
+          [
+            77567,
+            'ease of harvest assessment 1-3||month 1||end of day||cass sink leaf|COMP:0000021'
+          ]
+        ], 'check store composed terms 2');
+
+my $new_traits3 = $traits3->{new_traits};
+my %new_composed_terms3;
+foreach (@$new_traits3){
+    $new_composed_terms3{$_->[1]} = join ',', @{$_->[0]};
+}
+my $results3 = $onto->store_composed_term(\%new_composed_terms3);
+#print STDERR Dumper $results3;
+is_deeply($results3, [
+          [
+            77568,
+            'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010|COMP:0000022'
+          ],
+          [
+            77569,
+            'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009|COMP:0000023'
+          ],
+          [
+            77570,
+            'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010|COMP:0000024'
+          ],
+          [
+            77571,
+            'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009|COMP:0000025'
+          ],
+          [
+            77572,
+            'ease of harvest assessment 1-3|CO:0000225||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010|COMP:0000026'
+          ],
+          [
+            77573,
+            'ease of harvest assessment 1-3|CO:0000225||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009|COMP:0000027'
+          ],
+          [
+            77574,
+            'ease of harvest assessment 1-3|CO:0000225||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010|COMP:0000028'
+          ],
+          [
+            77575,
+            'ease of harvest assessment 1-3|CO:0000225||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009|COMP:0000029'
+          ]
+        ], 'test save composed terms 3');
+
+my $traits3_duplicate = SGN::Model::Cvterm->get_traits_from_component_categories($t->bcs_schema(), \@allowed_composed_cvs, $composable_cvterm_delimiter, $composable_cvterm_format, {
+  object => [77171, 77174],
+  attribute => [],
+  method => [],
+  unit => [],
+  trait => [70775,76555],
+  tod => [77536],
+  toy => [77526,77499],
+  gen => [],
+});
+#print STDERR Dumper $traits3_duplicate;
+is_deeply($traits3_duplicate, {
+          'new_traits' => [],
+          'existing_traits' => [
+                                 [
+                                   77568,
+                                   'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010'
+                                 ],
+                                 [
+                                   77569,
+                                   'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009'
+                                 ],
+                                 [
+                                   77570,
+                                   'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010'
+                                 ],
+                                 [
+                                   77571,
+                                   'anthocyanin pigmentation visual rating 0-3|CO:0000103||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009'
+                                 ],
+                                 [
+                                   77572,
+                                   'ease of harvest assessment 1-3|CO:0000225||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010'
+                                 ],
+                                 [
+                                   77573,
+                                   'ease of harvest assessment 1-3|CO:0000225||month 10|TIME:0000069||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009'
+                                 ],
+                                 [
+                                   77574,
+                                   'ease of harvest assessment 1-3|CO:0000225||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem bark|CASSTISS:0000010'
+                                 ],
+                                 [
+                                   77575,
+                                   'ease of harvest assessment 1-3|CO:0000225||month 1|TIME:0000060||end of day|TIME:0000003||cass lower stem whole|CASSTISS:0000009'
+                                 ]
+                               ]
+        }, 'check that duplicate traits are separated from new_traits');
+
 
 done_testing();

--- a/t/unit_fixture/CXGN/Trial/DeriveTrait.t
+++ b/t/unit_fixture/CXGN/Trial/DeriveTrait.t
@@ -141,7 +141,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     metadata_hash=>\%phenotype_metadata
 );
 
-my $stored_phenotype_error_msg = $store_phenotypes->store();
+my ($stored_phenotype_error_msg, $stored_phenotype_success) = $store_phenotypes->store();
 ok(!$stored_phenotype_error_msg, "check that store pheno spreadsheet works");
 
 my $tn = CXGN::Trial->new( { bcs_schema => $fix->bcs_schema(),
@@ -193,7 +193,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     metadata_hash=>\%phenotype_metadata
 );
 
-my $store_error = $store_phenotypes->store();
+my ($store_error, $store_success) = $store_phenotypes->store();
 ok(!$store_error, "check that store pheno spreadsheet works");
 
 my $trait_id = SGN::Model::Cvterm->get_cvterm_row_from_trait_name($fix->bcs_schema, 'dry matter content|CO:0000092')->cvterm_id();

--- a/t/unit_fixture/CXGN/Uploading/Phenotype.t
+++ b/t/unit_fixture/CXGN/Uploading/Phenotype.t
@@ -420,7 +420,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 ok(!$verified_error);
-my $stored_phenotype_error_msg = $store_phenotypes->store();
+my ($stored_phenotype_error_msg, $store_success) = $store_phenotypes->store();
 ok(!$stored_phenotype_error_msg, "check that store pheno spreadsheet works");
 
 my $tn = CXGN::Trial->new( { bcs_schema => $f->bcs_schema(),
@@ -548,7 +548,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 #print STDERR Dumper $verified_error;
 ok(!$verified_error);
-$stored_phenotype_error_msg = $store_phenotypes->store();
+my ($stored_phenotype_error_msg, $store_success) = $store_phenotypes->store();
 ok(!$stored_phenotype_error_msg, "check that store pheno spreadsheet works");
 
 my $traits_assayed  = $tn->get_traits_assayed();
@@ -875,7 +875,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
 my $validate_phenotype_error_msg = $store_phenotypes->verify();
 #print STDERR Dumper $validate_phenotype_error_msg;
 
-$stored_phenotype_error_msg = $store_phenotypes->store();
+my ($stored_phenotype_error_msg, $store_success) = $store_phenotypes->store();
 ok(!$stored_phenotype_error_msg, "check that store fieldbook works");
 my $image = SGN::Image->new( $f->dbh, undef, $f );
 my $image_error = $image->upload_fieldbook_zipfile('t/data/fieldbook/photos.zip', $user_id);
@@ -1309,7 +1309,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 #print STDERR Dumper $verified_error;
 ok(!$verified_error);
-$stored_phenotype_error_msg = $store_phenotypes->store();
+my ($stored_phenotype_error_msg, $store_success) = $store_phenotypes->store();
 ok(!$stored_phenotype_error_msg, "check that store fieldbook works");
 
 $tn = CXGN::Trial->new( { bcs_schema => $f->bcs_schema(),
@@ -1980,7 +1980,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 ok(!$verified_error);
-$stored_phenotype_error_msg = $store_phenotypes->store();
+my ($stored_phenotype_error_msg, $store_success) = $store_phenotypes->store();
 ok(!$stored_phenotype_error_msg, "check that store large pheno spreadsheet works");
 
 $tn = CXGN::Trial->new( { bcs_schema => $f->bcs_schema(),
@@ -2545,7 +2545,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 ok(!$verified_error);
-$stored_phenotype_error_msg = $store_phenotypes->store();
+my ($stored_phenotype_error_msg, $store_success) = $store_phenotypes->store();
 ok(!$stored_phenotype_error_msg, "check that store large pheno spreadsheet works");
 
 $tn = CXGN::Trial->new( { bcs_schema => $f->bcs_schema(),
@@ -2893,7 +2893,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 ok(!$verified_error);
-$stored_phenotype_error_msg = $store_phenotypes->store();
+my ($stored_phenotype_error_msg, $store_success) = $store_phenotypes->store();
 ok(!$stored_phenotype_error_msg, "check that store fieldbook plants works");
 
 $tn = CXGN::Trial->new( { bcs_schema => $f->bcs_schema(),


### PR DESCRIPTION
added conf variables for customizing order, format, and combinations of postcomposed cvterms.
spreadsheet creation using the cass interface also creates postcomposed cvterms for selected components.
trait validation.
phenotype upload of cass phenotype spreadsheet works.
phenotype upload now obsoletes old files if the uploaded file overwrites all store measurements in db.
simplified postcomposing code: terms are named from selected component terms using SGN::Model::Cvterm->get_traits_from_component_categories, and then these names are saved using CXGN::Onto->store_composed_terms.
added unit tests for postcomposed term creation and saving
