### PR TITLE
allow longer output in stock search results table

### DIFF
--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -285,6 +285,7 @@ jQuery(document).ready(function () {
      'ordering'  : false,
      'processing': true,
      'serverSide': true,
+     'lengthMenu': [10,20,50,100,1000],
      'ajax': { 'url':  '/ajax/search/stocks',
                'data': function(d) {
                   d.any_name  = jQuery('#any_name').val();


### PR DESCRIPTION
Allows up to 1,000 stock search results to be copied to a list. Closes #1081