### PR TITLE
Topic/accesions to seedlot tool

### DIFF
--- a/js/CXGN/List.js
+++ b/js/CXGN/List.js
@@ -753,10 +753,10 @@ CXGN.List.prototype = {
         }
     },
 		seedlotSearch: function(list_id){
+			var self = this;
 			jQuery('#working_modal').modal('show');
 			var data = this.getListData(list_id);
 			var accessions = data.elements.map(function(d){return d[1];})
-			console.log(accessions);
 			if (window.available_seedlots){
 				window.available_seedlots.build_table(accessions);
 			} else {
@@ -765,11 +765,31 @@ CXGN.List.prototype = {
 			jQuery('#working_modal').modal('hide');
 			jQuery('#availible_seedlots_modal').modal('show');
 			jQuery("#new-list-from-seedlots").submit(function(){
+				jQuery('#working_modal').modal('show');
 				try {
-					console.log(window.available_seedlots.get_selected());
-				} catch (e) {
-					setTimeout(function(){throw e;},0);
-				} finally {
+					var form = jQuery(this).serializeArray().reduce(function(map,obj){
+						map[obj.name] = obj.value;
+						return map;
+					}, {});
+					console.log(form);
+					var list = new CXGN.List();
+					var names = window.available_seedlots.get_selected().map(function(d){
+						return d.name;
+					});
+					var newListID = list.newList(form["name"]);
+					if (!newListID) throw "List creation failed.";
+					list.setListType(newListID,"seedlots");
+					var count = list.addBulk(newListID, names);
+					if (!count) throw "Added nothing to list or addition failed.";
+					jQuery('#working_modal').modal('hide');
+					alert("List \""+form["name"]+"\" created with "+count+" entries.");
+					self.renderLists('list_dialog');
+				}
+				catch(err) {
+					setTimeout(function(){throw err;});
+				}
+				finally {
+					jQuery('#working_modal').modal('hide');
 					return false;
 				}
 			});

--- a/mason/site/list.mas
+++ b/mason/site/list.mas
@@ -156,6 +156,7 @@
                 <button class="btn btn-primary" type="submit">Save</button>
               </form>
               <form class="form-inline" style="float:right">
+                <a href="/breeders/seedlots/" class="btn btn-primary">Manage Seedlots</a>
                 <button id="close_availible_seedlots_modal" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
               </form>
             </div>

--- a/mason/tools/available_seedlots.mas
+++ b/mason/tools/available_seedlots.mas
@@ -18,7 +18,7 @@
 </form>
 <script type="text/javascript">
   (function(global){
-    var mainDivSelector = "#available-seedlots";
+    var mainFormSelector = "#available-seedlots";
     var d3 = global.d3v4;
     var ex = {};
     ex.build_table = function(accession_names){
@@ -41,17 +41,7 @@
       });
     };
     ex.get_selected = function(){
-      var main = d3.select(mainDivSelector);
-      var body = main.select("tbody");
-      var rows = body.selectAll("tr");
-      var selected = [];
-      rows.select("select").each(function(d){
-        var val = this.options[this.selectedIndex].value;
-        if(val!="NO-AVAIL"){
-          selected.push(val);
-        }
-      });
-      return selected;
+      return jQuery(mainFormSelector).serializeArray();
     };
     var empty_placeholder = new Object();
     function _build_table(accession_list,seedlot_obj,synonyms){
@@ -76,7 +66,7 @@
       var row_data = accession_list.map(function(acc){
         return {'name':acc,'seedlots':synonymized[acc]?synonymized[acc]:[]};
       });
-      var table = d3.select(mainDivSelector).select("table");
+      var table = d3.select(mainFormSelector).select("table");
       var groups = table.selectAll("tbody").data(row_data,function(d){return d.name;});
       groups.exit().remove();
       var newGroups = groups.enter().append("tbody");
@@ -85,9 +75,7 @@
         .style("text-align","center")
         .style("vertical-align","middle");
       var allGroups = newGroups.merge(groups);
-      allGroups.style("background",function(d,i){
-        return i%2 ? "#eee" : "#fff";
-      })
+      allGroups.style("border-top","2px solid #999")
       allGroups.select(".as-acc-name")
         .attr("rowspan",function(d){return Math.max(1,d.seedlots.length);})
         .text(function(d){return d.name;});
@@ -103,8 +91,7 @@
             return ['<input disabled type="checkbox">'," ","No Availible Seedlots"," "," "," "]
           }
           var cells = [];
-          console.log(d);
-          cells.push('<input value="'+d.seedlot[0]+'" type="checkbox">');
+          cells.push('<input value="'+d.seedlot[0]+'" name="'+d.seedlot[0]+'" type="checkbox">');
           cells.push(d.program);
           cells.push('<a href="/breeders/seedlot/'+d.seedlot[1]+'">'+d.seedlot[0]+'</a>');
           cells.push('<a href="/stock/'+d.contents[1]+'/view">'+d.contents[0]+'</a>');


### PR DESCRIPTION
![2017-09-13 12_13_32](https://user-images.githubusercontent.com/5115845/30388214-05ab0e42-987d-11e7-92e1-263d8ffda8f8.gif)

This branch consists of two main additions:

### The Available Seedlots List Tool
This is the tool shown in the gif above. It allows one to see all seedlots related to a list of accessions and select which of those seedlots one would like to add to a new seedlot list. It implements this functionality using `mason/tools/available_seedlots.mas`.

### The Available Seedlots Mason File  
(`mason/tools/available_seedlots.mas`)  
This mason file, when included, adds a form element `#available-seedlots`. It also adds an object to the global JS namespace (`window.available_seedlots`). Passing a list of accession names (unique or synonyms) to `window.available_seedlots.build_table(names)` will populate the table inside the form with check boxes like seen in the video above. Calling the function `window.available_seedlots.get_selected()` will return a jQuery serialized form object for all the ticked boxes. The form table can be redrawn simply with another call to `window.available_seedlots.build_table(names)`.