### PR TITLE
Fixed long-url error issue with the availible_seedlots table for long lists

### DIFF
--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -320,12 +320,12 @@ sub add_accession_list_POST : Args(0) {
     return;
 }
 sub possible_seedlots : Path('/ajax/accessions/possible_seedlots') : ActionClass('REST') { }
-sub possible_seedlots_GET : Args(0) {
+sub possible_seedlots_POST : Args(0) {
   my ($self, $c) = @_;
   my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
   
-  my $names = $c->req->params()->{'name'};
-  
+  my $names = $c->req->body_data->{'names'};
+    
   my $stock_lookup = CXGN::Stock::StockLookup->new(schema => $schema);
   my $accession_manager = CXGN::BreedersToolbox::Accessions->new(schema=>$schema);
   

--- a/mason/tools/available_seedlots.mas
+++ b/mason/tools/available_seedlots.mas
@@ -22,11 +22,12 @@
     var d3 = global.d3v4;
     var ex = {};
     ex.build_table = function(accession_names){
-      var callURL = '/ajax/accessions/possible_seedlots';
-      callURL+= "?name="+accession_names.join("&name=");
       jQuery('#working_modal').modal('show');
       jQuery.ajax({
-        url: callURL,
+        type: 'POST',
+        url: '/ajax/accessions/possible_seedlots',
+        data: {'names': accession_names},
+        dataType: "json",
         success: function(response) {
           _build_table(accession_names,response.seedlots,response.synonyms);
           jQuery('#working_modal').modal('hide');


### PR DESCRIPTION
Switched the availible_seedlots AJAX method from GET to POST and move the list of names from the URL to the POST body.