### PR TITLE
timestamps on stock_relationship and project_relationship

### DIFF
--- a/db/00086/AddTimestampToNdTables.pm
+++ b/db/00086/AddTimestampToNdTables.pm
@@ -111,6 +111,26 @@ EOSQL
         print STDOUT "nd_protocol already had create_date\n";
     };
 
+    try {
+        $self->dbh->do(<<EOSQL);
+ALTER TABLE stock_relationship ADD COLUMN create_date TIMESTAMP;
+ALTER TABLE stock_relationship ALTER COLUMN create_date SET DEFAULT now();
+EOSQL
+    }
+    catch {
+        print STDOUT "stock_relationship already had create_date\n";
+    };
+
+    try {
+        $self->dbh->do(<<EOSQL);
+ALTER TABLE project_relationship ADD COLUMN create_date TIMESTAMP;
+ALTER TABLE project_relationship ALTER COLUMN create_date SET DEFAULT now();
+EOSQL
+    }
+    catch {
+        print STDOUT "project_relationship already had create_date\n";
+    };
+
 print "You're done!\n";
 }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Added timestamp column called 'create_date' to nd_experiment, project, stock, phenotype, genotype, nd_protocol, stock_relationship, and project_relationship tables.
This patch will need to be run on all dbs.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [x] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
