### PR TITLE
fix bug in trial creation allowing user to de-select seedlot list

### DIFF
--- a/js/CXGN/BreedersToolbox/AddTrial.js
+++ b/js/CXGN/BreedersToolbox/AddTrial.js
@@ -97,13 +97,19 @@ jQuery(document).ready(function ($) {
     });
 
     $(document).on('focusout', '#select_seedlot_list_list_select', function() {
-        if ($('#select_seedlot_list_list_select').val()) {
+        if ($('#select_seedlot_list_list_select').val() != '') {
             seedlot_list_id = $('#select_seedlot_list_list_select').val();
             seedlot_list = JSON.stringify(list.getList(seedlot_list_id));
             if(stock_list && seedlot_list){
                 verify_seedlot_list(stock_list, seedlot_list);
             } else {
                 alert('Please make sure to select an accession list above!');
+            }
+        } else {
+            seedlot_list = undefined;
+            seedlot_list_verified = 1;
+            if (stock_list){
+                verify_stock_list(stock_list);
             }
         }
     });
@@ -881,7 +887,7 @@ jQuery(document).ready(function ($) {
 
 	//add lists to the list select and list of checks select dropdowns.
     document.getElementById("select_list").innerHTML = list.listSelect("select_list", [ 'accessions' ], '', 'refresh');
-    document.getElementById("select_seedlot_list").innerHTML = list.listSelect("select_seedlot_list", [ 'seedlots' ], '', 'refresh');
+    document.getElementById("select_seedlot_list").innerHTML = list.listSelect("select_seedlot_list", [ 'seedlots' ], 'none', 'refresh');
     document.getElementById("list_of_checks_section").innerHTML = list.listSelect("list_of_checks_section", [ 'accessions' ], '', 'refresh');
 
     //add lists to the list select and list of checks select dropdowns for CRBD.


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
During trial creation it was not possible to de-select the seedlot list once it was selected.
Now there is an option to choose 'none' and it will fix validation accordingly.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
