### PR TITLE
Fixed homepage PR preview to remove PR template

### DIFF
--- a/mason/homepage/github_pullrequests.mas
+++ b/mason/homepage/github_pullrequests.mas
@@ -17,6 +17,9 @@ $phenotype_files => undef
 
 <script>
 jQuery(document).ready(function() {
+    
+    var pr_body_begin = "Description <!-- Describe your changes in detail. -->\r\n-----------------------------------------------------";
+    var pr_body_end = "Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->";
 
     jQuery.ajax( {
       'url': 'https://api.github.com/repos/solgenomics/sgn/pulls?state=closed&sort=updated&direction=desc&per_page=5',
@@ -25,7 +28,10 @@ jQuery(document).ready(function() {
         //console.log(response);
         var html = '<table class="table table-bordered table-hover" id="homepage_github_pullrequests" alt=""><thead><tr><th>Title</th><th>Description</th><th>Date</th></tr></thead><tbody>';
         for (var i=0; i<response.length; i++){
-            html = html + '<tr><td><a href="'+response[i].html_url+'" >'+response[i].title+'</a></td><td>'+response[i].body+'</td><td>'+response[i].merged_at+'</td></tr>';
+            pr_body = response[i].body;
+            trim1 = pr_body.split(pr_body_end)[0];
+            body = trim1.split(pr_body_begin).slice(-1)[0];
+            html = html + '<tr><td><a href="'+response[i].html_url+'" >'+response[i].title+'</a></td><td>'+body+'</td><td>'+response[i].merged_at+'</td></tr>';
         }
         html = html + '</tbody></table>';
         jQuery('#homepage_github_pullrequests_div').html(html);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes PR template showing on the homepage by splitting the response.body string on section headers.

<!-- If there are relevant issues, link them here: -->

closes #1354 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
