### PR TITLE
Replace direct references to CassavaBase in the documentation

### DIFF
--- a/docs/01_basic_website_usage.md
+++ b/docs/01_basic_website_usage.md
@@ -15,7 +15,7 @@ layout: doc_page
 
 Before creating an account, please verify first that you don’t already have an account. You can use “Search” menu to check if you already registered as a user.
 
-In the "Search" menu, selecting the "People" tab and search your name. If nothing is found, proceed with the instructions below. Otherwise, clicking the “Login” button. If you have forgotten your password, you can retrieve it [*here*](http://www.cassavabase.org/solpeople/send-password.pl).
+In the "Search" menu, selecting the "People" tab and search your name. If nothing is found, proceed with the instructions below. Otherwise, clicking the “Login” button. If you have forgotten your password, you can retrieve it by clicking the "Forgot your password?" link on the login page.
 
 ### Creating a user account
 
@@ -34,7 +34,7 @@ After you submit the information, an email will be sent to the provided email ad
 
 To login, clicking the "Login" link in the toolbar on any page and enter your username and password.
 
-If you have forgotten your password, you can retrieve it [*here*](http://www.cassavabase.org/solpeople/send-password.pl).
+If you have forgotten your password, you can retrieve it by clicking the "Forgot your password?" link on the login page.
 
 <img src='{{"assets/images/image166.png" | relative_url }}' alt="login.png" width="624" height="133" />
 
@@ -60,16 +60,16 @@ Accounts with “user” status are able to:
 -   Post comments on pages
 -   Post to the forum
 
-To upgrade your account status to "submitter,” contact Cassavabase using the "contact" link provided at the footer of each page. Submitter accounts can add data, such as new plots, accessions, phenotype data and images. Click here to [*Contact Cassavabase*](http://www.cassavabase.org/contact/form).
+To upgrade your account status to "submitter,” contact the database curators using the "contact" link provided at the footer of each page. Submitter accounts can add data, such as new plots, accessions, phenotype data and images.
 
-### Submitting Feedback on the Cassavabase Website and Wiki
+### Submitting Feedback on an SGN Database
 
 We appreciate your feedback! Feel free to submit any questions or suggestions by using the "Feedback" link provided at the footer of each page.
 
 1.3. Menu Layout
 ----------------
 
-The Cassavabase website has a toolbar on the top of each page with a number of menus for convenient access of major functions. The menus, as pictured below, are “search,” “manage,” “analyze,” and “maps.” The toolbar also provides a quick search, a “log in” button, and a “new user” button.
+SGN Database websites have a toolbar on the top of each page with a number of menus for convenient access of major functions. The menus, as pictured below, are “search,” “manage,” “analyze,” and “maps.” The toolbar also provides a quick search, a “log in” button, and a “new user” button.
 
 <img src='{{"assets/images/image270.png" | relative_url }}' width="624" height="33" />
 
@@ -86,7 +86,7 @@ In the Search menu, the options are:
 | Trials                | Search trials by name, description, breeding program, year, location, and trial type.                                                  |
 | Markers               | Search different markers                                                                                                               |
 | Images                | Search images contained in the SGN database                                                                                            |
-| People                | Search Cassavabase users                                                                                                               |
+| People                | Search database users                                                                                                               |
 
 #### Manage
 
@@ -110,44 +110,21 @@ In the Manage menu, the options are:
 **Clicking on the "Analyze" link will give a full menu of all analysis functions**  
 In the Analyze menu, the options are:
 
-| Tab                     | Description                                                            |
-|-------------------------|------------------------------------------------------------------------|
-| **Breeder Tools**       |                                                                        |
-| Breeder Home            | Access breeding functionalities. Lists important and helpful links.    |
-| Barcode Tools           | Manage, create, and download barcodes. Also access barcode tools.      |
-| Genomic Selection       | Can search for traits, start building a GS model, and predict values based on genotypes |
-| **Sequence Analysis**   |                                                                        |
-| BLAST                   | Sequence homology search for the cassava genome                        |
-| **Other**               |                                                                        |
-| Ontology Browser        | Browse all recorded ontologies                                         |
-
-
-#### Maps
-
-| Tab                                    | Description                                                     |
-|----------------------------------------|-----------------------------------------------------------------|
-| Cassava 2011, 2013 and 2014 GBS Maps   | Map of cassava genomes, has markers listed per chromosome       |
-| **Genome**                             |                                                                 |
-| *Cassava Genome Browser at JGI*        | Comprehensive genome browser provided by Joint Genome Browser   |
-
-#### About
-
-| Tab   | Description   |
-|-----------------------|-----------------------------------------------------------------|
-| About NextGen Cassava | Access home page of NextGen Cassava Project                     |
-| Contact               | CassavaBase contact form                                        |
-| Cite CassavaBase      | cite CassavaBase in your publications                           |
-| Manual                | CassavaBase manual                                              |
-| Wiki                  | Access to NextGen Cassava wiki                                  |
-| FAQ                   | Cassavabase users frequently asked questions and useful answers |
-| Forum                 | CassavaBase forum                                               |
-| Twitter               | Sol Genomics twitter page                                       |
-| Facebook              | Sol Genomics facebook page                                      |
+| Tab                   | Description                                                                             |
+| --------------------- | --------------------------------------------------------------------------------------- |
+| **Breeder Tools**     |                                                                                         |
+| Breeder Home          | Access breeding functionalities. Lists important and helpful links.                     |
+| Barcode Tools         | Manage, create, and download barcodes. Also access barcode tools.                       |
+| Genomic Selection     | Can search for traits, start building a GS model, and predict values based on genotypes |
+| **Sequence Analysis** |                                                                                         |
+| BLAST                 | Sequence homology search                                                                |
+| **Other**             |                                                                                         |
+| Ontology Browser      | Browse all recorded ontologies                                                          |
 
 1.4. Working with Lists {#working-with-lists}
 -----------------------
 
-Lists are collections of identifiers that are stored in the database. Lists can be composed of accessions, plots, traits, locations, and trials. Lists are attached to the individual user's account, and can only be created and seen by the user while logged in. CassavaBase makes heavy use of lists in a number of tools on the website. For example, trials are created using lists of accessions.
+Lists are collections of identifiers that are stored in the database. Lists can be composed of accessions, plots, traits, locations, and trials. Lists are attached to the individual user's account, and can only be created and seen by the user while logged in. SGN databases make heavy use of lists in a number of tools on the website. For example, trials are created using lists of accessions.
 
 ### Generating lists
 

--- a/docs/02_searching_the_database.md
+++ b/docs/02_searching_the_database.md
@@ -103,11 +103,11 @@ You can also use “Search Accessions and Plots” page to add new stocks by cli
 
 ![]({{"assets/images/image86.png" | relative_url }})
 
-Clicking on the “Submit New Stock” link will redirect you to the “Create a New Stock” form. To submit new stock, you must login and have an account that has submitter privilege. To change your account status from “user” to “submitter”, you must contact CassavaBase. To learn how to change your account status, click here.
+Clicking on the “Submit New Stock” link will redirect you to the “Create a New Stock” form. To submit new stock, you must login and have an account that has submitter privilege. To change your account status from “user” to “submitter”, you must contact the database curators. To learn how to change your account status, click here.
 
 ![]({{"assets/images/image284.png" | relative_url }})
 
-The organism field is an autocomplete field for the organism. Start typing, and the matching organisms in the database will be shown in the drop-down list. For cassava, select Manihot esculenta. The stock name should be a standard name given to the stock at a national facility. The unique name is usually the same as the stock name. After completing the form, click on “Store” button to finish the process.
+The organism field is an autocomplete field for the organism. Start typing, and the matching organisms in the database will be shown in the drop-down list. (_i.e._ For cassava, select Manihot esculenta.) The stock name should be a standard name given to the stock at a national facility. The unique name is usually the same as the stock name. After completing the form, click on “Store” button to finish the process.
 
 ### Other information
 

--- a/docs/03_managing_breeding_data/03_06.md
+++ b/docs/03_managing_breeding_data/03_06.md
@@ -10,7 +10,7 @@ layout: doc_page
 
 ![]({{"assets/images/image21.png" | relative_url }})
 
-CassavaBase supports the Android Field Book App for collecting phenotypic data in the field with tablet computers. The app is available here:
+SGN databases support the Android Field Book App for collecting phenotypic data in the field with tablet computers. The app is available here:
 
 [*http://www.wheatgenetics.org/bioinformatics/22-android-field-book*](http://www.wheatgenetics.org/bioinformatics/22-android-field-book)
 
@@ -18,7 +18,7 @@ CassavaBase supports the Android Field Book App for collecting phenotypic data i
 
 -   Field Book App requires two files for collecting data: Field layout file and trait file.
 
--   CassavaBase can generate the field layout file and trait file, which can be downloaded onto your computer, then transferred to an Android tablet device.
+-   SGN databases can generate the field layout file and trait file, which can be downloaded onto your computer, then transferred to an Android tablet device.
 
 A typical workflow
 ------------------
@@ -27,7 +27,7 @@ A typical workflow
 
 2. Creating a [*trait file*](#creating-trait-files) from the list of traits
 
-3. Downloading the field layout file and trait file from CassavaBase to your computer
+3. Downloading the field layout file and trait file from the database to your computer
 
 4. Downloading the field layout file and trait file to the tablet (where the Field Book App is installed)
 
@@ -35,7 +35,7 @@ A typical workflow
 
 6. Exporting phenotypes from Field Book App to your computer
 
-7. [*Uploading the exported phenotype file*](#uploading-pheno-files) from your computer to CassavaBase
+7. [*Uploading the exported phenotype file*](#uploading-pheno-files) from your computer to the database
 
 3.6.1 Creating Field Layout Files for the Field Book App {#creating-layout-files}
 --------------------------------------------------------
@@ -131,7 +131,7 @@ After downloading the trait file to your computer, the file can be transferred t
 
 ### Files on your computer
 
-After downloading, Field Layout files and Trait files can be found in the “Downloads” folder of your computer. Field Layout files on your computer will have a prefix “fieldbook\_layout\_” added to the beginning of the file name. For example: **"2014-01-28\_19:14:34\_Trial Demo\_location 6767.xls"** on the Cassavabase website will be saved as **"field\_book\_layout\_2014-01-28\_19:14:34\_Trial Demo\_location 6767.xls"** on your computer.
+After downloading, Field Layout files and Trait files can be found in the “Downloads” folder of your computer. Field Layout files on your computer will have a prefix “fieldbook\_layout\_” added to the beginning of the file name. For example: **"2014-01-28\_19:14:34\_Trial Demo\_location 6767.xls"** on the the database website will be saved as **"field\_book\_layout\_2014-01-28\_19:14:34\_Trial Demo\_location 6767.xls"** on your computer.
 
 ![]({{"assets/images/image142.png" | relative_url }})
 
@@ -184,7 +184,7 @@ To set up the Field Book App:
 <img src='{{"assets/images/image12.png" | relative_url }}' alt="Import Field Layout File .png" width="237" />  
 Clicking on the "Fields" tab will open a new dialogue that will let you select the file that you want to import.  
 <img src='{{"assets/images/image115.png" | relative_url }}' alt="Choose Field File.png" width="238" />  
-Choosing a Field File will generate a new dialogue that will ask you to choose between an Excel or CSV format. Since the data from CassavaBase is in Excel format, choose the Excel option.  
+Choosing a Field File will generate a new dialogue that will ask you to choose between an Excel or CSV format. Since the data from the database is in Excel format, choose the Excel option.  
 <img src='{{"assets/images/image258.png" | relative_url }}' alt="Fields Excel.png" width="241" />  
 After submitting the file format, a final dialogue box will appear. Please provide information about the file that you want to import. To finalize the process, clicking “OK” button.  
 <img src='{{"assets/images/image342.png" | relative_url }}' alt="Field Import Info.png" width="244" />
@@ -208,7 +208,7 @@ To export files containing data from the Field Book App to your tablet, clicking
 
 <img src='{{"assets/images/image303.png" | relative_url }}' alt="Export Data.png" width="239" />
 
-Clicking on the "Export" link will open a new dialogue window. To ensure that data are exported in a correct format for CassavaBase, checking the "Database Format" box, then clicking on “OK” button.
+Clicking on the "Export" link will open a new dialogue window. To ensure that data are exported in a correct format for the database, checking the "Database Format" box, then clicking on “OK” button.
 
 <img src='{{"assets/images/image157.png" | relative_url }}' alt="Export Data Database Format.png" width="245" />
 
@@ -219,10 +219,10 @@ The exported file can then be found in the “field\_export” sub-folder within
 ![]({{"assets/images/image158.png" | relative_url }})
 
 
-3.6.6 Uploading Phenotype Files to CassavaBase {#uploading-pheno-files}
+3.6.6 Uploading Phenotype Files to an SGN database {#uploading-pheno-files}
 ----------------------------------------------
 
-To upload phenotype files to CassavaBase, clicking on “Field Book App” in the “Manage” menu.
+To upload phenotype files to the database, clicking on “Field Book App” in the “Manage” menu.
 
 ![]({{"assets/images/image302.png" | relative_url }})
 
@@ -230,7 +230,7 @@ On the “Field Book Tools” page, clicking on “Upload” link in the “Uplo
 
 ![]({{"assets/images/image165.png" | relative_url }})
 
-Clicking on the "Upload" link will open a new dialogue asking you to choose a file that you want to upload to the CassavaBase Website. To make sure that the file has a correct format for uploading, clicking on “Verify” button. After the file format was verified, clicking on the “Store” button.
+Clicking on the "Upload" link will open a new dialogue asking you to choose a file that you want to upload to the database Website. To make sure that the file has a correct format for uploading, clicking on “Verify” button. After the file format was verified, clicking on the “Store” button.
 
 ![]({{"assets/images/image131.png" | relative_url }})
 

--- a/docs/03_managing_breeding_data/03_08.md
+++ b/docs/03_managing_breeding_data/03_08.md
@@ -3,7 +3,7 @@ title: "3.8 Managing Barcodes"
 layout: doc_page
 ---
 
-CassavaBase provides tools for generating barcodes for stock identification. To access “Barcode Tools” page, clicking on “Barcodes” in the “Manage” menu.
+SGN databases provide tools for generating barcodes for stock identification. To access “Barcode Tools” page, clicking on “Barcodes” in the “Manage” menu.
 
 ![]({{"assets/images/image82.png" | relative_url }})
 
@@ -21,7 +21,7 @@ In the “Generate Barcode” section, specify the name of the barcode, size of 
 
 ![]({{"assets/images/image245.png" | relative_url }})
 
-CassavaBase will generate a barcode for your stock. The barcode can be printed for your stock identification. It also appears on its corresponding stock page.
+The database will generate a barcode for your stock. The barcode can be printed for your stock identification. It also appears on its corresponding stock page.
 
 ![]({{"assets/images/image264.png" | relative_url }})
 

--- a/docs/04_data_analysis_tools.md
+++ b/docs/04_data_analysis_tools.md
@@ -8,14 +8,14 @@ layout: doc_page
 {:toc}
 <!-- TOC-END -->
 
-CassavaBase provides several tools for phenotype data analysis, marker-assisted selection, sequence and expression analyses, as well as ontology browser. These tools can be found in the “Analyze” menu.
+SGN databases provides several tools for phenotype data analysis, marker-assisted selection, sequence and expression analyses, as well as ontology browser. These tools can be found in the “Analyze” menu.
 
 ![]({{"assets/images/image114.png" | relative_url }})
 
 4.1 Selection Index
 -------------------
 
-To determine rankings of accessions based on more than one desirable trait, CassavaBase provides “Selection Index” tool that allows you to specify a weighting on each trait. To access the tool, clicking on “Selection Index” in the “Analyze” menu.
+To determine rankings of accessions based on more than one desirable trait, SGN databases provide a “Selection Index” tool that allows you to specify a weighting on each trait. To access the tool, clicking on “Selection Index” in the “Analyze” menu.
 
 ![]({{"assets/images/image251.png" | relative_url }})
 
@@ -56,7 +56,7 @@ Selection Index tool also allows you to save top ranked accessions directly to �
 
 The prediction of breeding values for a trait is a one step or two steps process, depending on what stage in your breeding cycle you are. The first step is to build a prediction model for a trait using a training population of clones with phenotype and genotype data. If you have yet to select parents for crossing for your first cycle of selection you can use the breeding values of the training population. If you are at later stages of your selection program, you need to do the second step which is applying the prediction model on your selection population. All clones in your training and selection populations must exist in the database.
 
-To use the genomic selection tool, on [*cassavabase.org,*](http://cassavabase.org/) from the 'analyze' pull-down menu, select 'Genomic Selection'.
+To use the genomic selection tool, on [*cassavabase.org*](http://cassavabase.org/), select 'Genomic Selection' from the 'analyze' pull-down menu.
 
 ![]({{"assets/images/image247.png" | relative_url }})
 
@@ -151,7 +151,7 @@ You can apply the models to simultaneously predict GEBVs for respective traits i
 
 To compare clones based on their performance on multiple traits, you can calculate selection indices using the form below. Choose from the pulldown menu the population with predicted GEBVs for the traits and assign relative weights for each trait. The relative weight of each trait must be between 0 - 1. 0 being of least weight and importance, not wanting to consider that particular trait in selecting a genotype and 1 being a trait that you give highest importance.
 
-In this example we will be using the "Cassava Ibadan 2002/03" population and assigning values to each of the traits. Remember that there is a list of acronyms and trait names at the bottom of the page for reference. After entering whatever values you would like for each trait click on the "Calculate" button to generate results. This will create a list of the top 10 genotypes that most closely match the criteria that you entered. The list will be displayed right below the "Cassava selection index" tab. This information can also be downloaded onto your computer by clicking on the "Download selection indices" link underneath the listed genotypes and selection indices.
+In this example we will be using the "Cassava Ibadan 2002/03" population and assigning values to each of the traits. Remember that there is a list of acronyms and trait names at the bottom of the page for reference. After entering whatever values you would like for each trait click on the "Calculate" button to generate results. This will create a list of the top 10 genotypes that most closely match the criteria that you entered. The list will be displayed right below the "selection index" tab. This information can also be downloaded onto your computer by clicking on the "Download selection indices" link underneath the listed genotypes and selection indices.
 
 <img src='{{"assets/images/image81.png" | relative_url }}' width="463" />
 
@@ -186,7 +186,7 @@ If you are interested in browsing genotype information for a single accession, f
 
 Near the bottom of the detail page is a collapsible section called “Accession Jbrowse”.<img src='{{"assets/images/image20.png" | relative_url }}' width="465" />
 
-This section will contain a link to the accession jbrowse page if the necessary genotype data is available. Clicking the link should take you to a page that looks like this, a which point you can browsre the genotype data in the form of a vcf track aligned to the latest build of the cassava genome.
+This section will contain a link to the accession jbrowse page if the necessary genotype data is available. Clicking the link should take you to a page that looks like this, a which point you can browsre the genotype data in the form of a vcf track aligned to the latest build of the genome.
 
 ![]({{"assets/images/image318.png" | relative_url }})
 
@@ -198,7 +198,7 @@ Halfway down the page is a collapsible section called “Trial Jbrowse”. This 
 
 <img src='{{"assets/images/image268.png" | relative_url }}' width="435" />
 
-Clicking the link should take you to a page that looks like this, a which point you can browse the genotype data in the form of vcf tracks aligned to the latest build of the cassava genome.![]({{"assets/images/image327.png" | relative_url }})
+Clicking the link should take you to a page that looks like this, a which point you can browse the genotype data in the form of vcf tracks aligned to the latest build of the genome.![]({{"assets/images/image327.png" | relative_url }})
 
 4.4 Principal Component Analysis
 --------------------------------


### PR DESCRIPTION
Replaces direct references to CassavaBase with "SGN databases" or "the database". Some cassavabase-specific (but also rather intuitive) documentation was also removed. It would be helpful for someone to look over the diff just to make sure I didn't remove anything important (or accidentally mangle a sentence that I didn't notice.)


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

<!-- If there are relevant issues, link them here: -->
#1336

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [x] Documentation only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
