### PR TITLE
fixes seedlot editing issue

### DIFF
--- a/lib/CXGN/Stock/Seedlot.pm
+++ b/lib/CXGN/Stock/Seedlot.pm
@@ -669,8 +669,16 @@ sub store {
 
         } else { #Updating seedlot
             if($self->accession_stock_ids){
+                my $input_accession_ids = $self->accession_stock_ids;
                 my $transactions = $self->transactions();
-                if (scalar(@$transactions)>1){
+                my %stored_accessions = map {$_->[0] => 1} @{$self->accessions};
+                my $accessions_have_changed;
+                foreach (@$input_accession_ids){
+                    if (!exists($stored_accessions{$_})){
+                        $accessions_have_changed = 1;
+                    }
+                }
+                if ($accessions_have_changed && scalar(@$transactions)>1){
                     $error = "This seedlot ".$self->uniquename." has been used in transactions, so the accessions cannot be changed now!";
                 } else {
                     $error = $self->_update_accession_stock_ids();


### PR DESCRIPTION
You can edit seedlot info at any point; however, you cannot edit the seedlot contents (accession) once the seedlot has been used in transactions.

closes #1438 

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
