### PR TITLE
Filter pedigree relationship edges such that the unknown terminal node must be an accession

### DIFF
--- a/lib/SGN/Controller/AJAX/Pedigrees.pm
+++ b/lib/SGN/Controller/AJAX/Pedigrees.pm
@@ -9,6 +9,7 @@ use Bio::GeneticRelationships::Individual;
 use Bio::GeneticRelationships::Pedigree;
 use CXGN::Pedigree::AddPedigrees;
 use CXGN::List::Validate;
+use SGN::Model::Cvterm;
 use JSON;
 
 BEGIN { extends 'Catalyst::Controller::REST'; }
@@ -280,7 +281,7 @@ sub get_full_pedigree_GET {
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
     my $mother_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "female_parent"})->cvterm_id();
     my $father_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "male_parent"})->cvterm_id();
-    my $accession_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "accession"})->cvterm_id();
+    my $accession_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
     my @queue = ($stock_id);
     my $nodes = [];
     while (@queue){
@@ -321,7 +322,7 @@ sub get_relationships_POST {
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
     my $mother_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "female_parent"})->cvterm_id();
     my $father_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "male_parent"})->cvterm_id();
-    my $accession_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "accession"})->cvterm_id();
+    my $accession_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
     my $nodes = [];
     while (@{$stock_ids}){
         push @{$nodes}, _get_relationships($schema, $mother_cvterm, $father_cvterm, $accession_cvterm, (shift @{$stock_ids}));

--- a/lib/SGN/Controller/AJAX/Pedigrees.pm
+++ b/lib/SGN/Controller/AJAX/Pedigrees.pm
@@ -280,11 +280,12 @@ sub get_full_pedigree_GET {
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
     my $mother_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "female_parent"})->cvterm_id();
     my $father_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "male_parent"})->cvterm_id();
+    my $accession_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "accession"})->cvterm_id();
     my @queue = ($stock_id);
     my $nodes = [];
     while (@queue){
         my $node = pop @queue;
-        my $relationships = _get_relationships($schema, $mother_cvterm, $father_cvterm, $node);
+        my $relationships = _get_relationships($schema, $mother_cvterm, $father_cvterm, $accession_cvterm, $node);
         if ($relationships->{parents}->{mother}){
             push @queue, $relationships->{parents}->{mother};
         }
@@ -320,9 +321,10 @@ sub get_relationships_POST {
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
     my $mother_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "female_parent"})->cvterm_id();
     my $father_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "male_parent"})->cvterm_id();
+    my $accession_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "accession"})->cvterm_id();
     my $nodes = [];
     while (@{$stock_ids}){
-        push @{$nodes}, _get_relationships($schema, $mother_cvterm, $father_cvterm, (shift @{$stock_ids}));
+        push @{$nodes}, _get_relationships($schema, $mother_cvterm, $father_cvterm, $accession_cvterm, (shift @{$stock_ids}));
     }
     $c->stash->{rest} = $nodes;
 }
@@ -331,10 +333,11 @@ sub _get_relationships {
     my $schema = shift;
     my $mother_cvterm = shift;
     my $father_cvterm = shift;
+    my $accession_cvterm = shift;
     my $stock_id = shift;
     my $name = $schema->resultset("Stock::Stock")->find({stock_id=>$stock_id})->uniquename();
-    my $parents = _get_pedigree_parents($schema, $mother_cvterm, $father_cvterm, $stock_id);
-    my $children = _get_pedigree_children($schema, $mother_cvterm, $father_cvterm, $stock_id);
+    my $parents = _get_pedigree_parents($schema, $mother_cvterm, $father_cvterm, $accession_cvterm, $stock_id);
+    my $children = _get_pedigree_children($schema, $mother_cvterm, $father_cvterm, $accession_cvterm, $stock_id);
     return {
         id => $stock_id,
         name=>$name,
@@ -347,17 +350,20 @@ sub _get_pedigree_parents {
     my $schema = shift;
     my $mother_cvterm = shift;
     my $father_cvterm = shift;
+    my $accession_cvterm = shift;
     my $stock_id = shift;
     my $edges = $schema->resultset("Stock::StockRelationship")->search([
         { 
-            object_id => $stock_id,
-            type_id => $father_cvterm
+            'me.object_id' => $stock_id,
+            'me.type_id' => $father_cvterm,
+            'subject.type_id'=> $accession_cvterm
         },
         { 
-            object_id => $stock_id,
-            type_id => $mother_cvterm
+            'me.object_id' => $stock_id,
+            'me.type_id' => $mother_cvterm,
+            'subject.type_id'=> $accession_cvterm
         }
-    ]);
+    ],{join => 'subject'});
     my $parents = {};
     while (my $edge = $edges->next) {
         if ($edge->type_id==$mother_cvterm){
@@ -373,17 +379,20 @@ sub _get_pedigree_children {
     my $schema = shift;
     my $mother_cvterm = shift;
     my $father_cvterm = shift;
+    my $accession_cvterm = shift;
     my $stock_id = shift;
     my $edges = $schema->resultset("Stock::StockRelationship")->search([
         { 
-            subject_id => $stock_id,
-            type_id => $father_cvterm
+            'me.subject_id' => $stock_id,
+            'me.type_id' => $father_cvterm,
+            'object.type_id'=> $accession_cvterm
         },
         { 
-            subject_id => $stock_id,
-            type_id => $mother_cvterm
+            'me.subject_id' => $stock_id,
+            'me.type_id' => $mother_cvterm,
+            'object.type_id'=> $accession_cvterm
         }
-    ]);
+    ],{join => 'object'});
     my $children = {};
     $children->{mother_of}=[];
     $children->{father_of}=[];

--- a/lib/SGN/Controller/AJAX/Pedigrees.pm
+++ b/lib/SGN/Controller/AJAX/Pedigrees.pm
@@ -279,8 +279,8 @@ sub get_full_pedigree_GET {
     my $c = shift;
     my $stock_id = $c->req->param('stock_id');
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
-    my $mother_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "female_parent"})->cvterm_id();
-    my $father_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "male_parent"})->cvterm_id();
+    my $mother_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'female_parent', 'stock_relationship')->cvterm_id();
+    my $father_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'male_parent', 'stock_relationship')->cvterm_id();
     my $accession_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
     my @queue = ($stock_id);
     my $nodes = [];
@@ -320,8 +320,8 @@ sub get_relationships_POST {
     my $s_ids = $c->req->body_params->{stock_id};
     push @{$stock_ids}, (ref $s_ids eq 'ARRAY' ? @$s_ids : $s_ids);
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
-    my $mother_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "female_parent"})->cvterm_id();
-    my $father_cvterm = $schema->resultset("Cv::Cvterm")->find({name  => "male_parent"})->cvterm_id();
+    my $mother_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'female_parent', 'stock_relationship')->cvterm_id();
+    my $father_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'male_parent', 'stock_relationship')->cvterm_id();
     my $accession_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
     my $nodes = [];
     while (@{$stock_ids}){

--- a/mason/pedigree/stock_pedigree.mas
+++ b/mason/pedigree/stock_pedigree.mas
@@ -461,10 +461,23 @@ $stock_id
           .attr("rx",10)
           .attr("ry",10)
           .attr("x",-100);
-        nodeNodes.append("a").attr("target","_blank")
+        nodeNodes.filter(function(d){
+            return d.id!=STOCK_ID;
+          })
+          .append("a").attr("target","_blank")
           .attr("href",function(d){
             if(d.id==STOCK_ID) return null;
             return "/stock/"+d.value.id+"/view";
+          })
+          .append('text').classed('node-name-text',true)
+          .attr('y',15)
+          .attr('text-anchor',"middle")
+          .html(function(d){
+            return d.value.name;
+          })
+          .attr('fill',"black");
+        nodeNodes.filter(function(d){
+            return d.id==STOCK_ID;
           })
           .append('text').classed('node-name-text',true)
           .attr('y',15)


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes issue where crosses and populations would appear in the pedigree tree.

<!-- If there are relevant issues, link them here: -->
closes #1062 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
