### PR TITLE
Fixes BrAPI Progeny call null values bug

### DIFF
--- a/lib/CXGN/BrAPI/v1/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v1/Germplasm.pm
@@ -267,7 +267,11 @@ sub germplasm_progeny {
         }
     }
 	my $total_count = scalar @{$result->{data}};
-	my $result->{data} = [@{$result->{data}}[$page_size*$page .. $page_size*($page+1)-1]];
+	my $last_item = $page_size*($page+1)-1;
+	if($last_item > $total_count-1){
+	    $last_item = $total_count-1
+	}
+	my $result->{data} = [@{$result->{data}}[$page_size*$page .. $last_item]];
 	my @data_files;
 	my $pagination = CXGN::BrAPI::Pagination->pagination_response($total_count,$page_size,$page);
 	return CXGN::BrAPI::JSONResponse->return_success($result, $pagination, \@data_files, $status, 'Germplasm progeny result constructed');

--- a/lib/CXGN/BrAPI/v1/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v1/Germplasm.pm
@@ -248,30 +248,30 @@ sub germplasm_progeny {
 		    'object.type_id'=> $accession_cvterm
 		}
 	],{join => 'object'});
-    my $result = {
-		defaultDisplayName=>$stock->uniquename,
-		germplasmDbId=>$stock_id,
-		data=>[]
-	};
+    my $full_data = [];
     while (my $edge = $edges->next) {
         if ($edge->type_id==$mother_cvterm){
-            push @{$result->{data}}, {
+            push @{$full_data}, {
 				progenyGermplasmDbId => $edge->object_id,
 				parentType => "FEMALE"
 			};
         } else {
-            push @{$result->{data}}, {
+            push @{$full_data}, {
 				progenyGermplasmDbId => $edge->object_id,
 				parentType => "MALE"
 			};
         }
     }
-	my $total_count = scalar @{$result->{data}};
+	my $total_count = scalar @{$full_data};
 	my $last_item = $page_size*($page+1)-1;
 	if($last_item > $total_count-1){
-	    $last_item = $total_count-1
+	    $last_item = $total_count-1;
 	}
-	my $result->{data} = [@{$result->{data}}[$page_size*$page .. $last_item]];
+	my $result = { 
+		defaultDisplayName=>$stock->uniquename,
+		germplasmDbId=>$stock_id,
+		data=>[@{$full_data}[$page_size*$page .. $last_item]]
+	};
 	my @data_files;
 	my $pagination = CXGN::BrAPI::Pagination->pagination_response($total_count,$page_size,$page);
 	return CXGN::BrAPI::JSONResponse->return_success($result, $pagination, \@data_files, $status, 'Germplasm progeny result constructed');


### PR DESCRIPTION
Array was slicing past end causing null values to be returned when the number of fetched items was less than the page size.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
