### PR TITLE
fix upload of seedlot with missing accessions

### DIFF
--- a/lib/CXGN/Stock/Search.pm
+++ b/lib/CXGN/Stock/Search.pm
@@ -498,8 +498,9 @@ sub search {
             };
         }
     }
+    #print STDERR Dumper \%result_hash;
 
-    if ($self->stockprop_columns_view && scalar(keys %{$self->stockprop_columns_view})>0){
+    if ($self->stockprop_columns_view && scalar(keys %{$self->stockprop_columns_view})>0 && scalar(@result_stock_ids)>0){
         my @stockprop_view = keys %{$self->stockprop_columns_view};
         my $result_stock_ids_sql = join ",", @result_stock_ids;
         my $stockprop_where = "WHERE stock_id IN ($result_stock_ids_sql)";

--- a/mason/breeders_toolbox/upload_seedlots_dialogs.mas
+++ b/mason/breeders_toolbox/upload_seedlots_dialogs.mas
@@ -195,11 +195,15 @@ jQuery(document).ready(function(){
             console.log(response);
             jQuery('#working_modal').modal("hide");
 
+            if (response.error){
+                alert(response.error);
+            }
+
             if (response.error_string) {
                 jQuery("#upload_trial_error_display tbody").html('');
 
                 if (response.missing_accessions) {
-                    var missing_accessions_html = "<div class='well well-sm'><h3>Add the missing accessions to a list</h3><div id='upload_seedlot_missing_accessions' style='display:none'></div><div id='upload_seedlot_add_missing_accessions'></div><hr><h4>Go to <a href='/breeders/accessions'>Manage Accessions</a> to add these new accessions. Please create a list of the missing accessions before clicking the link.</h4></div><br/>";
+                    var missing_accessions_html = "<div class='well well-sm'><h3>Add the missing accessions to a list</h3><div id='upload_seedlot_add_missing_accessions_div_html'></div><div id='upload_seedlot_missing_accessions' style='display:none'></div><div id='upload_seedlot_add_missing_accessions'></div><hr><h4>Go to <a href='/breeders/accessions'>Manage Accessions</a> to add these new accessions. Please create a list of the missing accessions before clicking the link.</h4></div><br/>";
                     jQuery("#upload_seedlot_add_missing_accessions_html").html(missing_accessions_html);
 
                     var missing_accessions_vals = '';
@@ -207,7 +211,7 @@ jQuery(document).ready(function(){
                         missing_accessions_vals = missing_accessions_vals + response.missing_accessions[i] + '\n';
                     }
                     jQuery("#upload_seedlot_missing_accessions").html(missing_accessions_vals);
-                    addToListMenu('upload_seedlot_add_missing_accessions_html', 'upload_seedlot_missing_accessions', {
+                    addToListMenu('upload_seedlot_add_missing_accessions_div_html', 'upload_seedlot_missing_accessions', {
                         selectText: true,
                         listType: 'accessions'
                     });


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Minor bug in the error response of uploading seedlots. Now if you upload a file of seedlots and the accession names for those seedlots are missing, you can add those missing accessions to a list to ease addition of those accessions.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
