### PR TITLE
case sensitive exact uniquename

### DIFF
--- a/bin/merge_stocks.pl
+++ b/bin/merge_stocks.pl
@@ -69,7 +69,7 @@ eval {
 	    next();
 	}
 	
-	my $merge_row = $schema->resultset("Stock::Stock")->find( { uniquename => { $merge_stock_name } );
+	my $merge_row = $schema->resultset("Stock::Stock")->find( { uniquename => $merge_stock_name } );
 	if (!$merge_row) { 
 	    print STDERR "Stock $merge_stock_name not available for merging. Skipping\n";
 	    next();

--- a/bin/merge_stocks.pl
+++ b/bin/merge_stocks.pl
@@ -62,14 +62,14 @@ eval {
 	chomp;
 	my ($merge_stock_name, $good_stock_name) = split /\t/;
 	
-	my $stock_row = $schema->resultset("Stock::Stock")->find( { uniquename => { ilike => $good_stock_name } });
+	my $stock_row = $schema->resultset("Stock::Stock")->find( { uniquename => $good_stock_name } );
 	if (!$stock_row) { 
 	    print STDERR "Stock $good_stock_name not found. Skipping...\n";
 	    
 	    next();
 	}
 	
-	my $merge_row = $schema->resultset("Stock::Stock")->find( { uniquename => { ilike => $merge_stock_name } });
+	my $merge_row = $schema->resultset("Stock::Stock")->find( { uniquename => { $merge_stock_name } );
 	if (!$merge_row) { 
 	    print STDERR "Stock $merge_stock_name not available for merging. Skipping\n";
 	    next();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
merge stocks script works well, but it is much safer to do this for exact uniquenames.
also it is necessary to do exact uniquenames in the case of merging two case sensitive stocks (e.g. Mo17 vs Mo17)

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
