### PR TITLE
Fixes crash when there is a non-unique synonym in the database

### DIFF
--- a/js/CXGN/BreedersToolbox/Accessions.js
+++ b/js/CXGN/BreedersToolbox/Accessions.js
@@ -367,7 +367,6 @@ jQuery(document).ready(function ($) {
             if (response.error_string) {
                 fullParsedData = undefined;
                 alert(response.error_string);
-                return;
             }
             if (response.success) {
                 fullParsedData = response.full_data;
@@ -451,9 +450,8 @@ function verify_accession_list(accession_list_id) {
             enable_ui();
             if (response.error) {
                 alert(response.error);
-            } else {
-                review_verification_results(response, accession_list_id);
             }
+            review_verification_results(response, accession_list_id);
         },
         error: function () {
             enable_ui();
@@ -663,4 +661,3 @@ function process_fuzzy_options(accession_list_id) {
         }
     });
 }
-

--- a/lib/CXGN/BreedersToolbox/StocksFuzzySearch.pm
+++ b/lib/CXGN/BreedersToolbox/StocksFuzzySearch.pm
@@ -47,6 +47,7 @@ sub get_matches {
     my @absent_stocks;
     my @found_stocks;
     my %results;
+    my $error;
     print STDERR "FuzzySearch 1".localtime()."\n";
 
     my $synonym_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
@@ -74,7 +75,8 @@ sub get_matches {
     foreach my $stock_name (@stock_list) {
 
         if (exists($uniquename_hash{$stock_name}) && $uniquename_hash{$stock_name} > 1){
-            die "More than one uniquename match for $stock_name of type $stock_type. This should not happen!\n";
+            $error .= "More than one uniquename match for $stock_name of type $stock_type. This should not happen!";
+            next;
         }
 
         if (exists($uniquename_hash{$stock_name})){
@@ -86,7 +88,8 @@ sub get_matches {
             my %match_info = ( name => $stock_name, distance => 0 );
             if (scalar(@{$synonym_uniquename_lookup{$stock_name}}) > 1){
                 my $synonym_lookup_uniquename = join ',', @{$synonym_uniquename_lookup{$stock_name}};
-                die "This synonym $stock_name has more than one uniquename $synonym_lookup_uniquename. This should not happen!\n";
+                $error .= "This synonym $stock_name has more than one uniquename $synonym_lookup_uniquename. This should not happen!";
+                next;
             } elsif (scalar(@{$synonym_uniquename_lookup{$stock_name}}) == 1){
                 $match_info{'unique_names'} = [$stock_name];
                 $match_info{'is_synonym'} = 1;
@@ -120,7 +123,8 @@ sub get_matches {
                 my $synonym_lookup_of_matched_string = $synonym_uniquename_lookup{$matched_name} || [];
                 if (scalar(@$synonym_lookup_of_matched_string) > 1){
                     my $synonym_lookup_uniquename = join ',', @$synonym_lookup_of_matched_string;
-                    die "This synonym $matched_name has more than one uniquename $synonym_lookup_uniquename. This should not happen!\n";
+                    $error .= "This synonym $matched_name has more than one uniquename $synonym_lookup_uniquename. This should not happen!";
+                    next;
                 } elsif (scalar(@$synonym_lookup_of_matched_string) == 1){
                     $match_info{'unique_names'} = [$matched_name];
                     $match_info{'is_synonym'} = 1;
@@ -135,6 +139,10 @@ sub get_matches {
                 matches => \@matches
             };
         }
+    }
+
+    if ($error){
+        $results{'error'} = $error;
     }
 
     $results{'found'} = \@found_stocks;

--- a/lib/CXGN/List/FuzzySearch/Plugin/Accessions.pm
+++ b/lib/CXGN/List/FuzzySearch/Plugin/Accessions.pm
@@ -7,7 +7,7 @@ use Data::Dumper;
 use SGN::Model::Cvterm;
 use CXGN::BreedersToolbox::StocksFuzzySearch;
 
-sub name { 
+sub name {
     return "accessions";
 }
 
@@ -24,13 +24,18 @@ sub fuzzysearch {
     my $fuzzy_accessions = $fuzzy_search_result->{'fuzzy'};
     my $absent_accessions = $fuzzy_search_result->{'absent'};
 
-    return {
+    my %return = (
         success => "1",
         absent => $absent_accessions,
         fuzzy => $fuzzy_accessions,
         found => $found_accessions,
-    };
+    );
 
+    if ($fuzzy_search_result->{'error'}){
+        $return{error} = $fuzzy_search_result->{'error'};
+    }
+
+    return \%return;
 }
 
 1;

--- a/lib/CXGN/List/FuzzySearch/Plugin/Crosses.pm
+++ b/lib/CXGN/List/FuzzySearch/Plugin/Crosses.pm
@@ -7,7 +7,7 @@ use Data::Dumper;
 use SGN::Model::Cvterm;
 use CXGN::BreedersToolbox::StocksFuzzySearch;
 
-sub name { 
+sub name {
     return "crosses";
 }
 
@@ -24,13 +24,18 @@ sub fuzzysearch {
     my $fuzzy = $fuzzy_search_result->{'fuzzy'};
     my $absent = $fuzzy_search_result->{'absent'};
 
-    return {
+    my %return = (
         success => "1",
         absent => $absent,
         fuzzy => $fuzzy,
         found => $found,
-    };
+    );
 
+    if ($fuzzy_search_result->{'error'}){
+        $return{error} = $fuzzy_search_result->{'error'};
+    }
+
+    return \%return;
 }
 
 1;

--- a/lib/CXGN/List/FuzzySearch/Plugin/Plants.pm
+++ b/lib/CXGN/List/FuzzySearch/Plugin/Plants.pm
@@ -7,7 +7,7 @@ use Data::Dumper;
 use SGN::Model::Cvterm;
 use CXGN::BreedersToolbox::StocksFuzzySearch;
 
-sub name { 
+sub name {
     return "plants";
 }
 
@@ -24,13 +24,18 @@ sub fuzzysearch {
     my $fuzzy = $fuzzy_search_result->{'fuzzy'};
     my $absent = $fuzzy_search_result->{'absent'};
 
-    return {
+    my %return = (
         success => "1",
         absent => $absent,
         fuzzy => $fuzzy,
         found => $found,
-    };
+    );
 
+    if ($fuzzy_search_result->{'error'}){
+        $return{error} = $fuzzy_search_result->{'error'};
+    }
+
+    return \%return;
 }
 
 1;

--- a/lib/CXGN/List/FuzzySearch/Plugin/Plots.pm
+++ b/lib/CXGN/List/FuzzySearch/Plugin/Plots.pm
@@ -7,7 +7,7 @@ use Data::Dumper;
 use SGN::Model::Cvterm;
 use CXGN::BreedersToolbox::StocksFuzzySearch;
 
-sub name { 
+sub name {
     return "plots";
 }
 
@@ -24,13 +24,18 @@ sub fuzzysearch {
     my $fuzzy = $fuzzy_search_result->{'fuzzy'};
     my $absent = $fuzzy_search_result->{'absent'};
 
-    return {
+    my %return = (
         success => "1",
         absent => $absent,
         fuzzy => $fuzzy,
         found => $found,
-    };
+    );
 
+    if ($fuzzy_search_result->{'error'}){
+        $return{error} = $fuzzy_search_result->{'error'};
+    }
+
+    return \%return;
 }
 
 1;

--- a/lib/CXGN/List/FuzzySearch/Plugin/Populations.pm
+++ b/lib/CXGN/List/FuzzySearch/Plugin/Populations.pm
@@ -7,7 +7,7 @@ use Data::Dumper;
 use SGN::Model::Cvterm;
 use CXGN::BreedersToolbox::StocksFuzzySearch;
 
-sub name { 
+sub name {
     return "populations";
 }
 
@@ -24,13 +24,18 @@ sub fuzzysearch {
     my $fuzzy = $fuzzy_search_result->{'fuzzy'};
     my $absent = $fuzzy_search_result->{'absent'};
 
-    return {
+    my %return = (
         success => "1",
         absent => $absent,
         fuzzy => $fuzzy,
         found => $found,
-    };
+    );
 
+    if ($fuzzy_search_result->{'error'}){
+        $return{error} = $fuzzy_search_result->{'error'};
+    }
+
+    return \%return;
 }
 
 1;

--- a/lib/CXGN/List/FuzzySearch/Plugin/Seedlots.pm
+++ b/lib/CXGN/List/FuzzySearch/Plugin/Seedlots.pm
@@ -7,7 +7,7 @@ use Data::Dumper;
 use SGN::Model::Cvterm;
 use CXGN::BreedersToolbox::StocksFuzzySearch;
 
-sub name { 
+sub name {
     return "seedlots";
 }
 
@@ -24,13 +24,18 @@ sub fuzzysearch {
     my $fuzzy = $fuzzy_search_result->{'fuzzy'};
     my $absent = $fuzzy_search_result->{'absent'};
 
-    return {
+    my %return = (
         success => "1",
         absent => $absent,
         fuzzy => $fuzzy,
         found => $found,
-    };
+    );
 
+    if ($fuzzy_search_result->{'error'}){
+        $return{error} = $fuzzy_search_result->{'error'};
+    }
+
+    return \%return;
 }
 
 1;

--- a/lib/CXGN/List/FuzzySearch/Plugin/TissueSamples.pm
+++ b/lib/CXGN/List/FuzzySearch/Plugin/TissueSamples.pm
@@ -7,7 +7,7 @@ use Data::Dumper;
 use SGN::Model::Cvterm;
 use CXGN::BreedersToolbox::StocksFuzzySearch;
 
-sub name { 
+sub name {
     return "tissue_samples";
 }
 
@@ -24,13 +24,18 @@ sub fuzzysearch {
     my $fuzzy = $fuzzy_search_result->{'fuzzy'};
     my $absent = $fuzzy_search_result->{'absent'};
 
-    return {
+    my %return = (
         success => "1",
         absent => $absent,
         fuzzy => $fuzzy,
         found => $found,
-    };
+    );
 
+    if ($fuzzy_search_result->{'error'}){
+        $return{error} = $fuzzy_search_result->{'error'};
+    }
+
+    return \%return;
 }
 
 1;

--- a/lib/CXGN/List/FuzzySearch/Plugin/VectorConstructs.pm
+++ b/lib/CXGN/List/FuzzySearch/Plugin/VectorConstructs.pm
@@ -7,7 +7,7 @@ use Data::Dumper;
 use SGN::Model::Cvterm;
 use CXGN::BreedersToolbox::StocksFuzzySearch;
 
-sub name { 
+sub name {
     return "vector_constructs";
 }
 
@@ -24,13 +24,18 @@ sub fuzzysearch {
     my $fuzzy = $fuzzy_search_result->{'fuzzy'};
     my $absent = $fuzzy_search_result->{'absent'};
 
-    return {
+    my %return = (
         success => "1",
         absent => $absent,
         fuzzy => $fuzzy,
         found => $found,
-    };
+    );
 
+    if ($fuzzy_search_result->{'error'}){
+        $return{error} = $fuzzy_search_result->{'error'};
+    }
+
+    return \%return;
 }
 
 1;

--- a/lib/CXGN/Phenotypes/Search/Native.pm
+++ b/lib/CXGN/Phenotypes/Search/Native.pm
@@ -292,7 +292,7 @@ sub search {
     my $select_clause = "SELECT ".$columns{'year_id'}.", ".$columns{'trial_name'}.", ".$columns{'accession_name'}.", ".$columns{'location_name'}.", ".$columns{'trait_name'}.", ".$columns{'phenotype_value'}.", ".$columns{'plot_name'}.", ".$columns{'trait_id'}.", ".$columns{'trial_id'}.", ".$columns{'location_id'}.", ".$columns{'accession_id'}.", ".$columns{'plot_id'}.", phenotype.uniquename, ".$columns{'trial_design'}.", ".$columns{'plot_type'}.", ".$columns{'planting_date'}.", ".$columns{'harvest_date'}.", ".$columns{'breeding_program'}.", phenotype.phenotype_id, count(phenotype.phenotype_id) OVER() AS full_count ".$design_layout_select;
     my $from_clause = $columns{'from_clause'};
 
-    my $order_clause = " ORDER BY 2,7,16 DESC";
+    my $order_clause = " ORDER BY 2,7,19 DESC";
 
     my @where_clause;
 

--- a/lib/CXGN/Stock/ParseUpload/Plugin/AccessionsXLS.pm
+++ b/lib/CXGN/Stock/ParseUpload/Plugin/AccessionsXLS.pm
@@ -441,6 +441,10 @@ sub _parse_with_plugin {
         absent_organisms => $absent_organisms
     );
 
+    if ($fuzzy_search_result->{'error'}){
+        $return_data{error_string} = $fuzzy_search_result->{'error'};
+    }
+
     $self->_set_parsed_data(\%return_data);
     return 1;
 }

--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -118,7 +118,7 @@ sub do_fuzzy_search {
     print STDERR "DoFuzzySearch 3".localtime()."\n";
     #print STDERR Dumper $fuzzy_accessions;
 
-    $c->stash->{rest} = {
+    my %return = (
         success => "1",
         absent => $absent_accessions,
         fuzzy => $fuzzy_accessions,
@@ -126,7 +126,13 @@ sub do_fuzzy_search {
         absent_organisms => $absent_organisms,
         fuzzy_organisms => $fuzzy_organisms,
         found_organisms => $found_organisms
-    };
+    );
+
+    if ($fuzzy_search_result->{'error'}){
+        $return{error} = $fuzzy_search_result->{'error'};
+    }
+
+    $c->stash->{rest} = \%return;
     return;
 }
 
@@ -252,7 +258,7 @@ sub verify_accessions_file_POST : Args(0) {
     $list->add_bulk(\@accession_names);
     $list->type('accessions');
 
-    $c->stash->{rest} = {
+    my %return = (
         success => "1",
         list_id => $new_list_id,
         full_data => \%full_accessions,
@@ -262,7 +268,13 @@ sub verify_accessions_file_POST : Args(0) {
         absent_organisms => $parsed_data->{absent_organisms},
         fuzzy_organisms => $parsed_data->{fuzzy_organisms},
         found_organisms => $parsed_data->{found_organisms}
-    };
+    );
+
+    if ($parsed_data->{error_string}){
+        $return{error_string} = $parsed_data->{error_string};
+    }
+
+    $c->stash->{rest} = \%return;
 }
 
 sub verify_fuzzy_options : Path('/ajax/accession_list/fuzzy_options') : ActionClass('REST') { }

--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -86,6 +86,10 @@ sub add_stockprop_POST {
             #print STDERR Dumper $fuzzy_search_result;
             my $found_accessions = $fuzzy_search_result->{'found'};
             my $fuzzy_accessions = $fuzzy_search_result->{'fuzzy'};
+            if ($fuzzy_search_result->{'error'}){
+                $c->stash->{rest} = { error => "ERROR: ".$fuzzy_search_result->{'error'} };
+                $c->detach();
+            }
             if (scalar(@$found_accessions) > 0){
                 $c->stash->{rest} = { error => "Synonym not added: The synonym you are adding is already stored as its own unique stock or as a synonym." };
                 $c->detach();

--- a/t/unit_fixture/AJAX/BreedersToolbox/Population.t
+++ b/t/unit_fixture/AJAX/BreedersToolbox/Population.t
@@ -17,6 +17,13 @@ my $mech = Test::WWW::Mechanize->new;
 my $response;
 my $population_name = "ajax_test_pop_1";
 
+$mech->post_ok('http://localhost:3010/brapi/v1/token', [ "username"=> "janedoe", "password"=> "secretpw", "grant_type"=> "password" ]);
+$response = decode_json $mech->content;
+print STDERR Dumper $response;
+is($response->{'metadata'}->{'status'}->[2]->{'success'}, 'Login Successfull');
+is($response->{'userDisplayName'}, 'Jane Doe');
+is($response->{'expires_in'}, '7200');
+
 $mech->post_ok('http://localhost:3010/ajax/population/new', [ "population_name"=> $population_name, "accessions[]"=> ['test_accession1', 'test_accession2', 'test_accession3'] ]);
 $response = decode_json $mech->content;
 print STDERR Dumper $response;

--- a/t/unit_fixture/AJAX/Search/Stock.t
+++ b/t/unit_fixture/AJAX/Search/Stock.t
@@ -122,10 +122,10 @@ $response = decode_json $mech->content;
 is($response->{'metadata'}->{'status'}->[2]->{'success'}, 'Login Successfull');
 $mech->post_ok('http://localhost:3010/stock/prop/add',["stock_id"=>"38842", "prop"=>"organization_name_1", "prop_type"=>"organization"] );
 $response = decode_json $mech->content;
-#print STDERR Dumper $response;
+print STDERR Dumper $response;
 $mech->post_ok('http://localhost:3010/ajax/search/stocks',["editable_stockprop_values" => encode_json({"organization"=>"organization_name_1"})] );
 $response = decode_json $mech->content;
-#print STDERR Dumper $response;
+print STDERR Dumper $response;
 
 is_deeply($response, {'recordsFiltered' => 1,'recordsTotal' => 1,'draw' => undef,'data' => [['<a href="/stock/38842/view">test_accession3</a>','accession','Solanum lycopersicum','test_accession3_synonym1','']]}, 'test stock search 16');
 


### PR DESCRIPTION

Adds a warning message when there are non-unique synonyms in database, instead of crashing.
Used when uploading/adding accessions and when adding a single synonym from stock page.
However, it is important that there are not nonunique synonyms in the database.

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
