### PR TITLE
fuzzy search option

### DIFF
--- a/js/CXGN/BreedersToolbox/Accessions.js
+++ b/js/CXGN/BreedersToolbox/Accessions.js
@@ -24,6 +24,7 @@ var fullParsedData;
 var infoToAdd;
 var accessionListFound;
 var speciesNames;
+var doFuzzySearch;
 
 function disable_ui() {
     jQuery('#working_modal').modal("show");
@@ -370,7 +371,8 @@ jQuery(document).ready(function ($) {
             }
             if (response.success) {
                 fullParsedData = response.full_data;
-                review_verification_results(response, response.list_id);
+                doFuzzySearch = 1;
+                review_verification_results(doFuzzySearch, response, response.list_id);
             }
         }
     });
@@ -385,6 +387,7 @@ jQuery(document).ready(function ($) {
         infoToAdd;
         accessionListFound;
         speciesNames;
+        doFuzzySearch;
         $('#add_accessions_dialog').modal("show");
         $('#review_found_matches_dialog').modal("hide");
         $('#review_fuzzy_matches_dialog').modal("hide");
@@ -429,7 +432,7 @@ function openWindowWithPost(fuzzyResponse) {
 
 function verify_accession_list(accession_list_id) {
     accession_list = JSON.stringify(list.getList(accession_list_id));
-    doFuzzySearch = jQuery('#fuzzy_check').attr('checked'); //fuzzy search is always checked in a hidden input
+    doFuzzySearch = jQuery('#fuzzy_check').attr('checked');
     //alert("should be disabled");
     //alert(accession_list);
 
@@ -451,7 +454,7 @@ function verify_accession_list(accession_list_id) {
             if (response.error) {
                 alert(response.error);
             }
-            review_verification_results(response, accession_list_id);
+            review_verification_results(doFuzzySearch, response, accession_list_id);
         },
         error: function () {
             enable_ui();
@@ -460,7 +463,7 @@ function verify_accession_list(accession_list_id) {
     });
 }
 
-function review_verification_results(verifyResponse, accession_list_id){
+function review_verification_results(doFuzzySearch, verifyResponse, accession_list_id){
     var i;
     var j;
     accessionListFound = {};
@@ -493,7 +496,7 @@ function review_verification_results(verifyResponse, accession_list_id){
 
     }
 
-    if (verifyResponse.fuzzy.length > 0) {
+    if (verifyResponse.fuzzy.length > 0 && doFuzzySearch) {
         fuzzyResponse = verifyResponse.fuzzy;
         var fuzzy_html = '<table id="add_accession_fuzzy_table" class="table"><thead><tr><th class="col-xs-4">Name in Your List</th><th class="col-xs-4">Existing Name(s) in Database</th><th class="col-xs-4">Options&nbsp;&nbsp;&nbsp&nbsp;<input type="checkbox" id="add_accession_fuzzy_option_all"/> Use Same Option for All</th></tr></thead><tbody>';
         for( i=0; i < verifyResponse.fuzzy.length; i++) {
@@ -526,7 +529,7 @@ function review_verification_results(verifyResponse, accession_list_id){
     }
 
     jQuery('#review_found_matches_hide').click(function(){
-        if (verifyResponse.fuzzy.length > 0){
+        if (verifyResponse.fuzzy.length > 0 && doFuzzySearch){
             jQuery('#review_fuzzy_matches_dialog').modal('show');
         } else {
             jQuery('#review_fuzzy_matches_dialog').modal('hide');

--- a/js/CXGN/BreedersToolbox/AddTrial.js
+++ b/js/CXGN/BreedersToolbox/AddTrial.js
@@ -49,7 +49,6 @@ jQuery(document).ready(function ($) {
         var trial_name = $("#new_trial_name").val();
         var breeding_program = $("#select_breeding_program").val();
         var location = $("#add_project_location").val();
-        var trial_type = $("#add_project_type").val();
         var trial_year = $("#add_project_year").val();
         var description = $("#add_project_description").val();
         var design_type = $("#select_design_method").val();
@@ -61,9 +60,6 @@ jQuery(document).ready(function ($) {
         }
         else if (location === '') {
             alert("Please give a location");
-        }
-        else if (trial_type === '') {
-            alert("Please give a trial type");
         }
         else if (trial_year === '') {
             alert("Please give a trial year");

--- a/js/CXGN/BreedersToolbox/UploadTrial.js
+++ b/js/CXGN/BreedersToolbox/UploadTrial.js
@@ -39,7 +39,6 @@ jQuery(document).ready(function ($) {
         var trial_name = $("#trial_upload_name").val();
         var breeding_program = $("#trial_upload_breeding_program").val();
         var location = $("#trial_upload_location").val();
-        var trial_type = $("#trial_upload_trial_type").val();
         var trial_year = $("#trial_upload_year").val();
         var description = $("#trial_upload_description").val();
         var design_type = $("#trial_upload_design_method").val();
@@ -52,9 +51,6 @@ jQuery(document).ready(function ($) {
         }
         else if (location === '') {
             alert("Please give a location");
-        }
-        else if (trial_type === '') {
-            alert("Please give a trial type");
         }
         else if (trial_year === '') {
             alert("Please give a trial year");

--- a/lib/CXGN/BreedersToolbox/StocksFuzzySearch.pm
+++ b/lib/CXGN/BreedersToolbox/StocksFuzzySearch.pm
@@ -85,20 +85,17 @@ sub get_matches {
         }
 
         if (exists($synonym_uniquename_lookup{$stock_name})){
-            my %match_info = ( name => $stock_name, distance => 0 );
+            my %match_info;
             if (scalar(@{$synonym_uniquename_lookup{$stock_name}}) > 1){
                 my $synonym_lookup_uniquename = join ',', @{$synonym_uniquename_lookup{$stock_name}};
                 $error .= "This synonym $stock_name has more than one uniquename $synonym_lookup_uniquename. This should not happen!";
                 next;
             } elsif (scalar(@{$synonym_uniquename_lookup{$stock_name}}) == 1){
-                $match_info{'unique_names'} = [$stock_name];
-                $match_info{'is_synonym'} = 1;
-                $match_info{'synonym_of'} = $synonym_uniquename_lookup{$stock_name}->[0];
+                $match_info{matched_string} = $stock_name." (SYNONYM OF ".$synonym_uniquename_lookup{$stock_name}->[0].")";
+                $match_info{is_synonym} = 1;
+                $match_info{uniquename} = $synonym_uniquename_lookup{$stock_name}->[0];
             }
-            push @fuzzy_stocks, {
-                name => $stock_name,
-                matches => [\%match_info]
-            };
+            push @found_stocks, \%match_info;
             next;
         }
 

--- a/lib/CXGN/Trial/TrialDesignStore.pm
+++ b/lib/CXGN/Trial/TrialDesignStore.pm
@@ -214,6 +214,7 @@ sub validate_design {
         );
         #plot_name is tissue sample name in well. during store, the stock is saved as stock_type 'tissue_sample' with uniquename = plot_name
     } elsif ($design_type eq 'CRD' || $design_type eq 'Alpha' || $design_type eq 'Augmented' || $design_type eq 'RCBD' || $design_type eq 'p-rep' || $design_type eq 'splitplot' || $design_type eq 'Lattice' || $design_type eq 'MAD' || $design_type eq 'greenhouse' || $design_type eq 'westcott'){
+        # valid plot's properties
         @valid_properties = (
             'seedlot_name',
             'num_seed_per_plot',
@@ -667,6 +668,7 @@ sub store {
                         subject_id => $plot->stock_id()
                     });
                 }
+
                 # For genotyping trial, if the well tissue_sample is sourced from a plot, then we store relationships between the tissue_sample and the plot, and the tissue sample and the plot's accession if it exists.
                 if ($stock_type_checked == $plot_cvterm_id){
                     $parent_stock = $chado_schema->resultset("Stock::StockRelationship")->create({

--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -158,10 +158,13 @@ sub do_exact_search {
     }
 
     my $rest = {
-	success => "1",
-	absent => \@absent_accessions,
-	found => \@found_accessions,
-	fuzzy => \@fuzzy_accessions
+        success => "1",
+        absent => \@absent_accessions,
+        found => \@found_accessions,
+        fuzzy => \@fuzzy_accessions,
+        absent_organisms => [],
+        fuzzy_organisms => [],
+        found_organisms => []
     };
     #print STDERR Dumper($rest);
     $c->stash->{rest} = $rest;

--- a/mason/breeders_toolbox/add_accessions_dialogs.mas
+++ b/mason/breeders_toolbox/add_accessions_dialogs.mas
@@ -34,15 +34,14 @@ $editable_stock_props => {}
                                 <button name="lists_link" class="btn btn-info btn-sm" style="margin:6px 0px 0px 0px" type="button" >Manage Lists</button>
                             </div>
                         </div>
-                        <!--div class="form-group">
-                            <label class="col-sm-6 control-label">Use Fuzzy Search: </label>
-                            <div class="col-sm-6">
-                                <input type="checkbox" id="fuzzy_check" name="fuzzy_check"></input>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Use Fuzzy Search: </label>
+                            <div class="col-sm-8">
+                                <input type="checkbox" id="fuzzy_check" name="fuzzy_check" checked></input>
                                 <br/>
                                 <small>Note: Use the fuzzy search to match similar names to prevent uploading of duplicate accessions. Fuzzy searching is much slower than regular search.</small>
                             </div>
-                        </div-->
-                        <input type="hidden" id="fuzzy_check" name="fuzzy_check" value="true" checked></input>
+                        </div>
                     </form>
                 </div>
 

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -457,6 +457,7 @@ $locations
 jQuery(document).ready(function(){
     jQuery('#guided_help_trial_upload_format_button').click(function(){
         jQuery('#trial_upload_spreadsheet_info_dialog').modal('show');
+        return false;
     });
 })
 </script>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Allows option to bypass fuzzy search when adding accessions using list.
Also fixes an issue with how fuzzy search was marking exactly matched synonyms.

<!-- If there are relevant issues, link them here: -->
related to #1816 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
