### PR TITLE
Topic/http auth brapi apps

### DIFF
--- a/lib/SGN/Controller/BreedersToolbox/GraphicalFiltering.pm
+++ b/lib/SGN/Controller/BreedersToolbox/GraphicalFiltering.pm
@@ -35,6 +35,7 @@ sub graphical_filtering :Path('/tools/graphicalfiltering') {
   }
   print STDERR $ajaxRequestString;
   $c->stash->{ajaxRequestString} = $ajaxRequestString;
+  $c->stash->{main_production_site_url} = $c->config->{main_production_site_url};
 
   $c->stash->{template} = '/tools/graphicalfiltering/index.mas';
 }

--- a/lib/SGN/Controller/BreedersToolbox/TrialComparison.pm
+++ b/lib/SGN/Controller/BreedersToolbox/TrialComparison.pm
@@ -16,6 +16,7 @@ sub trial_comparison_input :Path('/tools/trial/comparison/list') Args(0) {
 	$c->res->redirect(uri( path => '/user/login', query => { goto_url => $c->req->uri->path_query } ) );
 	return;
     }
+    $c->stash->{main_production_site_url} = $c->config->{main_production_site_url};
     $c->stash->{template} = '/tools/trial_comparison/index.mas';
 
 }

--- a/lib/SGN/Controller/Stock.pm
+++ b/lib/SGN/Controller/Stock.pm
@@ -276,6 +276,7 @@ sub view_stock : Chained('get_stock') PathPart('view') Args(0) {
 	barcode_tempdir  => $barcode_tempdir,
 	barcode_tempuri   => $barcode_tempuri,
 	identifier_prefix => $c->config->{identifier_prefix},
+        main_production_site_url => $c->config->{main_production_site_url}
         );
 }
 

--- a/mason/pedigree/stock_pedigree.mas
+++ b/mason/pedigree/stock_pedigree.mas
@@ -27,6 +27,7 @@ $stock_id - the id of the stock for which pedigree information will be displayed
 
 <%args>
 $stock_id
+$main_production_site_url
 </%args>
 
 <style>
@@ -207,7 +208,7 @@ $stock_id
 (function() {
     'use strict';
     var STOCK_ID = "<% $stock_id %>";
-    var base_url="/brapi/v1";
+    var base_url="<% $main_production_site_url %>/brapi/v1";
     var pdg = PedigreeViewer(base_url,undefined,function(dbId){
         return "/stock/"+dbId+"/view";
     });

--- a/mason/stock/index.mas
+++ b/mason/stock/index.mas
@@ -53,7 +53,7 @@ $barcode_tempdir => undef
 $barcode_tempuri => undef
 $identifier_prefix => 'SGN'
 $organism_autocomplete_uri => '/ajax/organism/autocomplete/'
-
+$main_production_site_url
 </%args>
 
 
@@ -316,7 +316,7 @@ Remove a parent (this will only remove the link to the parent, not the parent ac
 % if ($type_name eq 'accession'){
 
 <&| /page/info_section.mas, title=>"Pedigree and Descendants" , collapsible=> $collapsible, collapsed=>0, subtitle=>"[$add_parent_link] [$remove_parent_link]" &>
-  <& /pedigree/stock_pedigree.mas, stock_id => $stock_id, has_pedigree => $has_pedigree &>
+  <& /pedigree/stock_pedigree.mas, stock_id => $stock_id, has_pedigree => $has_pedigree, main_production_site_url => $main_production_site_url &>
 </&>
 
 <& /pedigree/stock_pedigree_string.mas, stock_id => $stock_id &>

--- a/mason/tools/graphicalfiltering/index.mas
+++ b/mason/tools/graphicalfiltering/index.mas
@@ -6,6 +6,7 @@
 <%args>
 
 $ajaxRequestString => ""
+$main_production_site_url
 
 </%args>
 
@@ -76,7 +77,7 @@ $ajaxRequestString => ""
     var list_id = $("#filter_list_select").val(),
         unit = $("#type_list_select").val(),
         group = $('#accession_group').is(":checked"),
-        brapi = BrAPI("/brapi/v1");
+        brapi = BrAPI("<% $main_production_site_url %>/brapi/v1");
     if (!unit) return;
     var list_contents = list.transform2Ids(list_id),
         list_type = list.getListType(list_id);

--- a/mason/tools/trial_comparison/index.mas
+++ b/mason/tools/trial_comparison/index.mas
@@ -5,7 +5,7 @@
 </%doc>
 
 <%args> 
-
+$main_production_site_url
 </%args>
 
 <& '/page/page_title.mas', title => "Compare trials" &>
@@ -99,7 +99,7 @@
       var ids = list.transform2Ids(trial_list_id, item_data);
       console.log("ids: ",ids);
 
-      BrAPI("/brapi/v1")
+      BrAPI("<% $main_production_site_url %>/brapi/v1")
         .phenotypes_search({
             "studyDbIds" : ids,
             "observationLevel" : $('#unit_select').val(),


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
On sites that have HTTP auth (test sites, cassbase, etc) the main_production_site_url key should contain the http auth in it (e.g. https://username:password@mysite.org). this way the brapi apps (pedigree viewer, graphical filtering, trial comparison) can work.

<!-- If there are relevant issues, link them here: -->
closes #1888

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
