### PR TITLE
Make Slurm the default backend by adding it to sgn.conf.

### DIFF
--- a/sgn.conf
+++ b/sgn.conf
@@ -240,7 +240,7 @@ cross_properties Tag Number,Pollination Date,Number of Bags,Number of Flowers,Nu
 </feature>
 #
 cview_db_backend    cxgn
-
+backend Slurm
 
 #how to find blast stuff
 blast_path                ""


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Add Slurm as the default backend in sgn.conf. (the backend property will be Slurm by default, can be over-ruled by sgn_local.conf)

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [x] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
