### PR TITLE
Add a script to hard delete images

### DIFF
--- a/bin/delete_images.pl
+++ b/bin/delete_images.pl
@@ -1,0 +1,73 @@
+
+=head1 NAME
+
+delete_images.pl - a script to hard delete images from a CXGN database.
+
+=head1 DESCRIPTION
+
+perl delete_images.pl -h <dbhost> -d <dbname> -i <image_dir> file_with_image_ids
+
+=head1 NOTES
+
+Be careful with this script! Ids have to match the given database etc etc
+
+=head1 AUTHOR
+
+Lukas Mueller <lam87@cornell.edu>
+
+=cut
+
+use strict;
+
+use File::Slurp qw | slurp |;
+use Getopt::Std;
+
+use CXGN::Image;
+use CXGN::DB::InsertDBH;
+
+our ($opt_h, $opt_d, $opt_i, $opt_t);
+
+getopts('h:d:i:t');
+
+my $dbh = CXGN::DB::InsertDBH->new( { 
+    dbhost => $opt_h,
+    dbname => $opt_d,
+    });
+
+
+
+my $image_id_file = shift;
+
+my @image_ids = slurp($image_id_file);
+
+if ($opt_t) { 
+    print STDERR "Note: -t. Test mode. Will rollback after operations are done.\n";
+}
+
+eval { 
+    
+    foreach my $id (@image_ids) { 
+	my $image = CXGN::Image->new(dbh=>$dbh, image_id=>$id, image_dir=> $opt_i);
+	
+	print STDERR "Deleting image with id $id... (".$image->get_description().") ";
+	
+	$image->hard_delete($opt_t);
+	print STDERR "Done.\n";
+    }
+};
+
+if ($opt_t) { 
+    print STDERR " -t option (test mode): rolling back...";
+    $dbh->rollback();
+    print STDERR "Done.\n";
+    exit();
+}
+if ($@) { 
+    print STDERR "An unfortunate error occurred... ($@)";
+    $dbh->rollback();
+}
+else { 
+    print STDERR "Committing...\n"; 
+    $dbh->commit();
+}
+

--- a/bin/delete_images.pl
+++ b/bin/delete_images.pl
@@ -44,6 +44,8 @@ if ($opt_t) {
     print STDERR "Note: -t. Test mode. Will rollback after operations are done.\n";
 }
 
+my $deleted_image_count = 0;
+
 eval { 
     
     foreach my $id (@image_ids) { 
@@ -54,6 +56,8 @@ eval {
 	$image->hard_delete($opt_t);
 	print STDERR "Done.\n";
     }
+
+    $deleted_image_count++;
 };
 
 if ($opt_t) { 
@@ -71,3 +75,4 @@ else {
     $dbh->commit();
 }
 
+print STDERR "Deleted $deleted_image_count images. Done.\n";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

For wrongly uploaded batches of images, handy script to delete images by image ids. Be very careful!

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
