### PR TITLE
pedigree string works with custom pedigree

### DIFF
--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -223,7 +223,7 @@ __PACKAGE__->config(
        # if needed retrieve pedigrees in bulk
        my $pedigree_strings;
        foreach my $element (@$label_params) {
-           if ($element->{'value'} eq '{pedigree_string}') {
+           if ($element->{'value'} =~ m/{pedigree_string}/ ) {
                $pedigree_strings = get_all_pedigrees($schema, $design);
            }
        }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Pedigree label works when custom label applied.

<!-- If there are relevant issues, link them here: -->
closes #2043 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
