### PR TITLE
upload plants using plant index number

### DIFF
--- a/lib/CXGN/Trial.pm
+++ b/lib/CXGN/Trial.pm
@@ -2319,9 +2319,16 @@ sub save_plant_entries {
             my $parent_plot_organism = $plot_row->organism_id();
 
             my $plant_index_number = 1;
-            foreach my $plant_name (@{$val->{plant_names}}) {
-                $self->_save_plant_entry($chado_schema, $accession_cvterm, $parent_plot_organism, $parent_plot_name, $parent_plot, $plant_name, $plant_cvterm, $plant_index_number, $plant_index_number_cvterm, $block_cvterm, $plot_number_cvterm, $replicate_cvterm, $plant_relationship_cvterm, $field_layout_experiment, $field_layout_cvterm, $inherits_plot_treatments, $treatments, $plot_relationship_cvterm, \%treatment_plots, \%treatment_experiments, $treatment_cvterm);
+            my $plant_names = $val->{plant_names};
+            my $plant_index_numbers = $val->{plant_index_numbers};
+            my $increment = 0;
+            foreach my $plant_name (@$plant_names) {
+                my $given_plant_index_number = $plant_index_numbers->[$increment];
+                my $plant_index_number_save = $given_plant_index_number ? $given_plant_index_number : $plant_index_number;
+
+                $self->_save_plant_entry($chado_schema, $accession_cvterm, $parent_plot_organism, $parent_plot_name, $parent_plot, $plant_name, $plant_cvterm, $plant_index_number_save, $plant_index_number_cvterm, $block_cvterm, $plot_number_cvterm, $replicate_cvterm, $plant_relationship_cvterm, $field_layout_experiment, $field_layout_cvterm, $inherits_plot_treatments, $treatments, $plot_relationship_cvterm, \%treatment_plots, \%treatment_experiments, $treatment_cvterm);
                 $plant_index_number++;
+                $increment++;
             }
         }
 

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialPlantsWithPlantNumberXLS.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialPlantsWithPlantNumberXLS.pm
@@ -1,0 +1,203 @@
+package CXGN::Trial::ParseUpload::Plugin::TrialPlantsWithPlantNumberXLS;
+
+use Moose::Role;
+use Spreadsheet::ParseExcel;
+use CXGN::Stock::StockLookup;
+use SGN::Model::Cvterm;
+use Data::Dumper;
+use CXGN::List::Validate;
+
+sub _validate_with_plugin {
+    my $self = shift;
+
+    my $filename = $self->get_filename();
+    my $schema = $self->get_chado_schema();
+    my $parser = Spreadsheet::ParseExcel->new();
+    my @error_messages;
+    my %errors;
+    my %missing_accessions;
+
+    #try to open the excel file and report any errors
+    my $excel_obj = $parser->parse($filename);
+    if (!$excel_obj) {
+        push @error_messages, $parser->error();
+        $errors{'error_messages'} = \@error_messages;
+        $self->_set_parse_errors(\%errors);
+        return;
+    }
+
+    my $worksheet = ( $excel_obj->worksheets() )[0]; #support only one worksheet
+    if (!$worksheet) {
+        push @error_messages, "Spreadsheet must be on 1st tab in Excel (.xls) file";
+        $errors{'error_messages'} = \@error_messages;
+        $self->_set_parse_errors(\%errors);
+        return;
+    }
+    my ( $row_min, $row_max ) = $worksheet->row_range();
+    my ( $col_min, $col_max ) = $worksheet->col_range();
+    if (($col_max - $col_min)  < 1 || ($row_max - $row_min) < 1 ) { #must have header and at least one row of plot data
+        push @error_messages, "Spreadsheet is missing header or contains no rows";
+        $errors{'error_messages'} = \@error_messages;
+        $self->_set_parse_errors(\%errors);
+        return;
+    }
+
+    #get column headers
+    my $plot_name_head;
+    my $plant_index_number_head;
+
+    if ($worksheet->get_cell(0,0)) {
+        $plot_name_head  = $worksheet->get_cell(0,0)->value();
+    }
+    if ($worksheet->get_cell(0,1)) {
+        $plant_index_number_head  = $worksheet->get_cell(0,1)->value();
+    }
+    if (!$plot_name_head || $plot_name_head ne 'plot_name' ) {
+        push @error_messages, "Cell A1: plot_name is missing from the header";
+    }
+    if (!$plant_index_number_head || $plant_index_number_head ne 'plant_index_number') {
+        push @error_messages, "Cell B1: plant_index_number is missing from the header";
+    }
+
+    my %seen_plot_names;
+    my %seen_plant_names;
+    for my $row ( 1 .. $row_max ) {
+        my $row_name = $row+1;
+        my $plot_name;
+        my $plant_index_number;
+
+        if ($worksheet->get_cell($row,0)) {
+            $plot_name = $worksheet->get_cell($row,0)->value();
+        }
+        if ($worksheet->get_cell($row,1)) {
+            $plant_index_number = $worksheet->get_cell($row,1)->value();
+        }
+
+        if (!$plot_name || $plot_name eq '' ) {
+            push @error_messages, "Cell A$row_name: plot_name missing.";
+        }
+        elsif ($plot_name =~ /\s/ || $plot_name =~ /\// || $plot_name =~ /\\/ ) {
+            push @error_messages, "Cell A$row_name: plot_name must not contain spaces or slashes.";
+        }
+        else {
+            $seen_plot_names{$plot_name}=$row_name;
+        }
+
+        if (!$plant_index_number || $plant_index_number eq '') {
+            push @error_messages, "Cell B$row_name: plant_index_number missing";
+        } if (!($plant_index_number =~ /^\d+?$/)) {
+            push @error_messages, "Cell B$row_name: plant_indeX_number must be a number";
+        } else {
+            #file must not contain duplicate plot names
+            my $plant_name = $plot_name."_".$plant_index_number;
+            if ($seen_plant_names{$plant_name}) {
+                push @error_messages, "Cell B$row_name: duplicate plant_name at cell A".$seen_plant_names{$plant_name}.": $plant_name";
+            }
+            if (!$plant_name){
+                push @error_messages, "CellB$row_name: No plant name could be made!";
+            }
+            $seen_plant_names{$plant_name}++;
+        }
+
+    }
+
+    my @plots = keys %seen_plot_names;
+    my $plots_validator = CXGN::List::Validate->new();
+    my @plots_missing = @{$plots_validator->validate($schema,'plots',\@plots)->{'missing'}};
+
+    if (scalar(@plots_missing) > 0) {
+        push @error_messages, "The following plot_name are not in the database: ".join(',',@plots_missing);
+        $errors{'missing_plots'} = \@plots_missing;
+    }
+
+    my @plants = keys %seen_plant_names;
+    my $plant_rs = $schema->resultset('Stock::Stock')->search({ 'uniquename' => {-in => \@plants} });
+    while (my $r = $plant_rs->next){
+        push @error_messages, "The following plant_name is already in the database and is not unique ".$r->uniquename;
+    }
+
+    #store any errors found in the parsed file to parse_errors accessor
+    if (scalar(@error_messages) >= 1) {
+        $errors{'error_messages'} = \@error_messages;
+        $self->_set_parse_errors(\%errors);
+        return;
+    }
+
+    return 1; #returns true if validation is passed
+}
+
+
+sub _parse_with_plugin {
+    my $self = shift;
+    my $filename = $self->get_filename();
+    my $schema = $self->get_chado_schema();
+    my $parser   = Spreadsheet::ParseExcel->new();
+    my $excel_obj;
+    my $worksheet;
+    my %parsed_entries;
+
+    $excel_obj = $parser->parse($filename);
+    if ( !$excel_obj ) {
+        return;
+    }
+
+    $worksheet = ( $excel_obj->worksheets() )[0];
+    my ( $row_min, $row_max ) = $worksheet->row_range();
+    my ( $col_min, $col_max ) = $worksheet->col_range();
+
+    my %seen_plot_names;
+    my %seen_plant_names;
+    for my $row ( 1 .. $row_max ) {
+        my $plot_name;
+        if ($worksheet->get_cell($row,0)) {
+            $plot_name = $worksheet->get_cell($row,0)->value();
+            $seen_plot_names{$plot_name}++;
+        }
+        my $plant_index_number;
+        if ($worksheet->get_cell($row,1)) {
+            $plant_index_number = $worksheet->get_cell($row,1)->value();
+        }
+        my $plant_name = $plot_name."_".$plant_index_number;
+        $seen_plant_names{$plant_name}++;
+    }
+    my @plots = keys %seen_plot_names;
+    my $rs = $schema->resultset("Stock::Stock")->search({
+        'is_obsolete' => { '!=' => 't' },
+        'uniquename' => { -in => \@plots }
+    });
+    my %plot_lookup;
+    while (my $r=$rs->next){
+        $plot_lookup{$r->uniquename} = $r->stock_id;
+    }
+
+    for my $row ( 1 .. $row_max ) {
+        my $plot_name;
+        my $plant_index_number;
+
+        if ($worksheet->get_cell($row,0)) {
+            $plot_name = $worksheet->get_cell($row,0)->value();
+        }
+        if ($worksheet->get_cell($row,1)) {
+            $plant_index_number = $worksheet->get_cell($row,1)->value();
+        }
+        my $plant_name = $plot_name."_".$plant_index_number;
+
+        #skip blank lines
+        if (!$plot_name && !$plant_name) {
+            next;
+        }
+
+        push @{$parsed_entries{'data'}}, {
+            plot_name => $plot_name,
+            plot_stock_id => $plot_lookup{$plot_name},
+            plant_name => $plant_name,
+            plant_index_number => $plant_index_number
+        };
+    }
+
+    $self->_set_parsed_data(\%parsed_entries);
+    return 1;
+}
+
+
+1;

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -584,7 +584,7 @@ sub trial_upload_plants : Chained('trial') PathPart('upload_plants') Args(0) {
         my $dbh = $c->dbc->dbh;
         my @user_info = CXGN::Login->new($dbh)->query_from_cookie($session_id);
         if (!$user_info[0]){
-            $c->stash->{rest} = {error=>'You must be logged in to upload this seedlot info!'};
+            $c->stash->{rest} = {error=>'You must be logged in to upload this plants info!'};
             $c->detach();
         }
         $user_id = $user_info[0];
@@ -593,7 +593,7 @@ sub trial_upload_plants : Chained('trial') PathPart('upload_plants') Args(0) {
         $user_name = $p->get_username;
     } else{
         if (!$c->user){
-            $c->stash->{rest} = {error=>'You must be logged in to upload this seedlot info!'};
+            $c->stash->{rest} = {error=>'You must be logged in to upload this plants info!'};
             $c->detach();
         }
         $user_id = $c->user()->get_object()->get_sp_person_id();
@@ -658,6 +658,116 @@ sub trial_upload_plants : Chained('trial') PathPart('upload_plants') Args(0) {
         foreach (@$parsed_entries){
             $plot_plant_hash{$_->{plot_stock_id}}->{plot_name} = $_->{plot_name};
             push @{$plot_plant_hash{$_->{plot_stock_id}}->{plant_names}}, $_->{plant_name};
+        }
+        my $t = CXGN::Trial->new( { bcs_schema => $c->dbic_schema("Bio::Chado::Schema"), trial_id => $c->stash->{trial_id} });
+        $t->save_plant_entries(\%plot_plant_hash, $plants_per_plot, $inherits_plot_treatments);
+
+        my $layout = $c->stash->{trial_layout};
+        $layout->generate_and_cache_layout();
+    };
+    eval {
+        $schema->txn_do($upload_plants_txn);
+    };
+    if ($@) {
+        $c->stash->{rest} = { error => $@ };
+        print STDERR "An error condition occurred, was not able to upload trial plants. ($@).\n";
+        $c->detach();
+    }
+
+    my $dbh = $c->dbc->dbh();
+    my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
+    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath});
+
+    $c->stash->{rest} = { success => 1 };
+}
+
+sub trial_upload_plants_with_index_number : Chained('trial') PathPart('upload_plants_with_plant_index_number') Args(0) {
+    my $self = shift;
+    my $c = shift;
+    my $user_id;
+    my $user_name;
+    my $user_role;
+    my $session_id = $c->req->param("sgn_session_id");
+
+    if ($session_id){
+        my $dbh = $c->dbc->dbh;
+        my @user_info = CXGN::Login->new($dbh)->query_from_cookie($session_id);
+        if (!$user_info[0]){
+            $c->stash->{rest} = {error=>'You must be logged in to upload this plant info!'};
+            $c->detach();
+        }
+        $user_id = $user_info[0];
+        $user_role = $user_info[1];
+        my $p = CXGN::People::Person->new($dbh, $user_id);
+        $user_name = $p->get_username;
+    } else{
+        if (!$c->user){
+            $c->stash->{rest} = {error=>'You must be logged in to upload this plant info!'};
+            $c->detach();
+        }
+        $user_id = $c->user()->get_object()->get_sp_person_id();
+        $user_name = $c->user()->get_object()->get_username();
+        $user_role = $c->user->get_object->get_user_type();
+    }
+
+    my $schema = $c->dbic_schema("Bio::Chado::Schema");
+    my $upload = $c->req->upload('trial_upload_plants_with_index_number_file');
+    my $inherits_plot_treatments = $c->req->param('upload_plants_with_index_number_inherit_treatments');
+    my $plants_per_plot = $c->req->param('upload_plants_with_index_number_per_plot_number');
+
+    my $subdirectory = "trial_plants_upload";
+    my $upload_original_name = $upload->filename();
+    my $upload_tempfile = $upload->tempname;
+    my $time = DateTime->now();
+    my $timestamp = $time->ymd()."_".$time->hms();
+
+    ## Store uploaded temporary file in archive
+    my $uploader = CXGN::UploadFile->new({
+        tempfile => $upload_tempfile,
+        subdirectory => $subdirectory,
+        archive_path => $c->config->{archive_path},
+        archive_filename => $upload_original_name,
+        timestamp => $timestamp,
+        user_id => $user_id,
+        user_role => $user_role
+    });
+    my $archived_filename_with_path = $uploader->archive();
+    my $md5 = $uploader->get_md5($archived_filename_with_path);
+    if (!$archived_filename_with_path) {
+        $c->stash->{rest} = {error => "Could not save file $upload_original_name in archive",};
+        $c->detach();
+    }
+    unlink $upload_tempfile;
+    my $parser = CXGN::Trial::ParseUpload->new(chado_schema => $schema, filename => $archived_filename_with_path);
+    $parser->load_plugin('TrialPlantsWithPlantNumberXLS');
+    my $parsed_data = $parser->parse();
+    #print STDERR Dumper $parsed_data;
+
+    if (!$parsed_data) {
+        my $return_error = '';
+        my $parse_errors;
+        if (!$parser->has_parse_errors() ){
+            $c->stash->{rest} = {error_string => "Could not get parsing errors"};
+            $c->detach();
+        } else {
+            $parse_errors = $parser->get_parse_errors();
+            #print STDERR Dumper $parse_errors;
+
+            foreach my $error_string (@{$parse_errors->{'error_messages'}}){
+                $return_error .= $error_string."<br>";
+            }
+        }
+        $c->stash->{rest} = {error_string => $return_error, missing_plots => $parse_errors->{'missing_plots'}};
+        $c->detach();
+    }
+
+    my $upload_plants_txn = sub {
+        my %plot_plant_hash;
+        my $parsed_entries = $parsed_data->{data};
+        foreach (@$parsed_entries){
+            $plot_plant_hash{$_->{plot_stock_id}}->{plot_name} = $_->{plot_name};
+            push @{$plot_plant_hash{$_->{plot_stock_id}}->{plant_names}}, $_->{plant_name};
+            push @{$plot_plant_hash{$_->{plot_stock_id}}->{plant_index_numbers}}, $_->{plant_index_number};
         }
         my $t = CXGN::Trial->new( { bcs_schema => $c->dbic_schema("Bio::Chado::Schema"), trial_id => $c->stash->{trial_id} });
         $t->save_plant_entries(\%plot_plant_hash, $plants_per_plot, $inherits_plot_treatments);

--- a/mason/breeders_toolbox/trial/add_plants_per_plot.mas
+++ b/mason/breeders_toolbox/trial/add_plants_per_plot.mas
@@ -65,7 +65,7 @@ $trial_name => undef
                             </div>
                         </div>
                         <div class="form-group">
-                            <label class="col-sm-4 control-label">Number of plants per plot: </label>
+                            <label class="col-sm-4 control-label">Maximum number of plants per plot: </label>
                             <div class="col-sm-8" >
                                 <input name="upload_plants_per_plot_number" id="upload_plants_per_plot_number" class="form-control" type="number" />
                             </div>
@@ -132,6 +132,99 @@ $trial_name => undef
 </div>
 
 
+<div class="modal fade" id="upload_plants_with_index_number_dialog" name="upload_plants_with_index_number_dialog" tabindex="-1" role="dialog" aria-labelledby="uploadPlantsWithIndexNumberDialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="uploadPlantsWithIndexNumberDialog">Upload plants to <% $trial_name %> with plant index number</h4>
+            </div>
+            <div class="modal-body">
+                <div class="container-fluid">
+
+                    <&| /page/explanation.mas, title=>'Template information' &>
+                        <p>
+                            <b>File format information</b>
+                            <br>
+                            <a id="trial_upload_plants_with_index_number_spreadsheet_info_format">Spreadsheet format</a>
+                        </p>
+                    </&>
+
+                    <form class="form-horizontal" role="form" method="post" enctype="multipart/form-data" encoding="multipart/form-data" id="upload_plants_with_index_number_dialog_form" name="upload_plants_with_index_number_dialog_form">
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Upload File (.xls): </label>
+                            <div class="col-sm-8" >
+                                <input type="file" name="trial_upload_plants_with_index_number_file" id="trial_upload_plants_with_index_number_file" encoding="multipart/form-data" />
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Maximum number of plants per plot: </label>
+                            <div class="col-sm-8" >
+                                <input name="upload_plants_with_index_number_per_plot_number" id="upload_plants_with_index_number_per_plot_number" class="form-control" type="number" />
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Inherits Management Factor(s) From Plots: </label>
+                            <div class="col-sm-8" >
+                                <input name="upload_plants_with_index_number_inherit_treatments" id="upload_plants_with_index_number_inherit_treatments" type="checkbox" checked disabled/>
+                            </div>
+                        </div>
+                    </form><br/>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" name="upload_plants_with_index_number_cancel_button" id="upload_plants_with_index_number_cancel_button" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" name="upload_plants_with_index_number_save_button" id="upload_plants_with_index_number_save_button" title="Upload">Upload</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="upload_plants_with_index_number_spreadsheet_info_dialog" name="upload_plants_with_index_number_spreadsheet_info_dialog" tabindex="-1" role="dialog" aria-labelledby="uploadPlantsWithIndexNumberInfoDialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header" style="text-align: center">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="uploadPlantsWithIndexNumberInfoDialog">Upload Template Information</h4>
+            </div>
+            <div class="modal-body">
+                <div class="container-fluid">
+                    <b>This is for recording individual plants in a plot. The plant name will be saved as a concatenation of plot_name + _ + plant_index_number</b>
+                    <br/>
+                    <b>May be uploaded in an Excel file (.xls)</b>
+                    <br />
+                    (.xlsx format not supported)
+                    <br /><br />
+                    <b>Header:</b>
+                    <br>
+                    The first row (header) should contain the following:
+                    <br />
+
+                    <table class="table table-hover table-bordered table-condensed" >
+                        <thead></thead>
+                        <tbody>
+                            <tr>
+                                <td>plot_name</td>
+                                <td>plant_index_number</td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+                    <b>Required fields:</b>
+                    <br/>
+                    plot_name (must exist in the database)
+                    <br />
+                    plant_index_number (must be a number. the saved plant name will be a concatenation of plot_name + plant_index_number)
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="close_upload_plants_with_index_number_info_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+
 <script>
 
 jQuery(document).ready(function() {
@@ -144,8 +237,16 @@ jQuery(document).ready(function() {
         jQuery('#upload_plants_dialog').modal("show");
     });
 
+    jQuery('#upload_plant_entries_with_index_number_button').click( function () {
+        jQuery('#upload_plants_with_index_number_dialog').modal("show");
+    });
+
     jQuery('#trial_upload_plants_spreadsheet_info_format').click( function () {
         jQuery('#upload_plants_spreadsheet_info_dialog').modal("show");
+    });
+
+    jQuery('#trial_upload_plants_with_index_number_spreadsheet_info_format').click( function () {
+        jQuery('#upload_plants_with_index_number_spreadsheet_info_dialog').modal("show");
     });
 
     jQuery('#add_plants_save_button').click( function () {
@@ -154,6 +255,10 @@ jQuery(document).ready(function() {
 
     jQuery('#upload_plants_save_button').click( function () {
         upload_plants_to_trial();
+    });
+
+    jQuery('#upload_plants_with_index_number_save_button').click( function () {
+        upload_plants_with_index_number_to_trial();
     });
 
     function upload_plants_to_trial() {
@@ -169,9 +274,44 @@ jQuery(document).ready(function() {
     jQuery('#upload_plants_dialog_form').iframePostForm({
         json: true,
         post: function () {
-            var uploadedSeedlotFile = jQuery("#trial_upload_plants_file").val();
+            var uploadedPlantsFile = jQuery("#trial_upload_plants_file").val();
             jQuery('#working_modal').modal("show");
-            if (uploadedSeedlotFile === '') {
+            if (uploadedPlantsFile === '') {
+                jQuery('#working_modal').modal("hide");
+                alert("No file selected");
+            }
+        },
+        complete: function (response) {
+            console.log(response);
+            jQuery('#working_modal').modal("hide");
+
+            if (response.error_string) {
+                alert(response.error_string);
+                return;
+            }
+            if (response.success) {
+                alert("File uploaded successfully");
+                window.location.replace('/breeders/trial/'+<% $trial_id %>);
+            }
+        }
+    });
+
+    function upload_plants_with_index_number_to_trial() {
+        var uploadFile = jQuery("#trial_upload_plants_with_index_number_file").val();
+        jQuery('#upload_plants_with_index_number_dialog_form').attr("action", "/ajax/breeders/trial/<% $trial_id %>/upload_plants_with_plant_index_number");
+        if (uploadFile === '') {
+            alert("Please select a file");
+            return;
+        }
+        jQuery("#upload_plants_with_index_number_dialog_form").submit();
+    }
+
+    jQuery('#upload_plants_with_index_number_dialog_form').iframePostForm({
+        json: true,
+        post: function () {
+            var uploadedPlantsFile = jQuery("#trial_upload_plants_with_index_number_file").val();
+            jQuery('#working_modal').modal("show");
+            if (uploadedPlantsFile === '') {
                 jQuery('#working_modal').modal("hide");
                 alert("No file selected");
             }

--- a/mason/breeders_toolbox/trial/design_section.mas
+++ b/mason/breeders_toolbox/trial/design_section.mas
@@ -38,7 +38,8 @@ $has_tissue_sample_entries
 
 % if (!$has_plant_entries) {
            <button class="btn btn-default" id="create_plant_entries_button">Add plant entries</button>
-           <button class="btn btn-default" id="upload_plant_entries_button">Upload plant entries</button>
+           <button class="btn btn-default" id="upload_plant_entries_button">Upload plant entries using plant_name</button>
+           <button class="btn btn-default" id="upload_plant_entries_with_index_number_button">Upload plant entries using plant index number</button>
 % } else {
             <& /breeders_toolbox/trial/trial_plants.mas, trial_id => $trial_id &>
 % }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
New option to upload plant entries from the trial detail page using the following formatted xls file:
plot_name | plant_index_number

The database will create plant names by concatenating the plot_name + _ + plant_index_number

<!-- If there are relevant issues, link them here: -->
closes #2075 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
