### PR TITLE
prevent get siblings if no male and female parents

### DIFF
--- a/lib/CXGN/BrAPI/v1/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v1/Germplasm.pm
@@ -254,7 +254,7 @@ sub germplasm_pedigree {
         my $cross_type = $cross_info ? $cross_info->[2] : '';
 
         my @siblings;
-        if ($female_name && $male_name){
+        if ($female_name || $male_name){
             my $progenies = CXGN::Cross->get_progeny_info($self->bcs_schema, $female_name, $male_name);
             #print STDERR Dumper $progenies;
             foreach (@$progenies){

--- a/lib/CXGN/BrAPI/v1/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v1/Germplasm.pm
@@ -253,16 +253,18 @@ sub germplasm_pedigree {
         my $cross_year = $cross_info ? $cross_info->[3] : '';
         my $cross_type = $cross_info ? $cross_info->[2] : '';
 
-        my $progenies = CXGN::Cross->get_progeny_info($self->bcs_schema, $female_name, $male_name);
-        #print STDERR Dumper $progenies;
         my @siblings;
-        foreach (@$progenies){
-            if ($_->[5] ne $uniquename){
-                my $germplasm_id = $_->[4];
-                push @siblings, {
-                    germplasmDbId => qq|$germplasm_id|,
-                    defaultDisplayName => $_->[5]
-                };
+        if ($female_name && $male_name){
+            my $progenies = CXGN::Cross->get_progeny_info($self->bcs_schema, $female_name, $male_name);
+            #print STDERR Dumper $progenies;
+            foreach (@$progenies){
+                if ($_->[5] ne $uniquename){
+                    my $germplasm_id = $_->[4];
+                    push @siblings, {
+                        germplasmDbId => qq|$germplasm_id|,
+                        defaultDisplayName => $_->[5]
+                    };
+                }
             }
         }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Prevents brapi pedigree from fetching siblings if there are no female and male parents.
@dauglyon will speed up the pedigree search

<!-- If there are relevant issues, link them here: -->
closes #2052 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
