### PR TITLE
Flexible number of treatments in splitplot design

### DIFF
--- a/js/CXGN/BreedersToolbox/AddTrial.js
+++ b/js/CXGN/BreedersToolbox/AddTrial.js
@@ -295,6 +295,20 @@ jQuery(document).ready(function ($) {
         }
     });
 
+    jQuery(document).on('click', '#create_trial_with_treatment_additional_treatment_buton', function(){
+        var count = jQuery('#create_trial_with_treatment_additional_count').val();
+        var new_count = parseInt(count) + 1;
+        var return_count = new_count + 4;
+        var html = '';
+        for (var i=0; i<new_count; i++){
+            var display_count = i + 5;
+            html = html + '<div class="form-group form-group-sm" ><label class="col-sm-7 control-label">Subplot '+display_count+ 'Treatment Name: </label><div class="col-sm-5" ><input class="form-control" id="create_trial_with_treatment_name_input'+display_count+'" name="create_trial_with_treatment_name_input'+display_count+'" type="text" placeholder="Optional Treatment '+display_count+'"/></div></div>';
+        }
+        html = html + '<input type="hidden" id="create_trial_with_treatment_additional_count" value='+return_count+'><div class="form-group form-group-sm" ><label class="col-sm-7 control-label">Add Another Treatment: </label><div class="col-sm-5" ><button class="btn btn-info btn-sm" id="create_trial_with_treatment_additional_treatment_buton">+ Treatment</button></div></div>';
+        jQuery('#create_trial_with_treatment_additional_treatment').html(html);
+        return false;
+    });
+
     var num_plants_per_plot = 0;
     var num_subplots_per_plot = 0;
     function generate_experimental_design() {
@@ -383,13 +397,14 @@ jQuery(document).ready(function ($) {
 
         var treatments = []
         if (design_type == 'splitplot'){
-            for(var i=1; i<5; i++){
-                var treatment_value = $('#create_trial_with_treatment_name_input'+i).val();
+            var count = jQuery('#create_trial_with_treatment_additional_count').val();
+            var int_count = parseInt(count);
+            for(var i=1; i<=int_count; i++){
+                var treatment_value = jQuery('#create_trial_with_treatment_name_input'+i).val();
                 if(treatment_value != ''){
                     treatments.push(treatment_value);
                 }
             }
-            //console.log(treatments);
             var num_plants_per_treatment = $('#num_plants_per_treatment').val();
             num_plants_per_plot = 0;
             if (num_plants_per_treatment){

--- a/lib/SGN/Controller/AJAX/Trial.pm
+++ b/lib/SGN/Controller/AJAX/Trial.pm
@@ -152,10 +152,6 @@ sub generate_experimental_design_POST : Args(0) {
             $c->stash->{rest} = { error => "You need to provide number of plants per treatment for a splitplot design."};
             return;
         }
-        if (($num_plants_per_plot%(scalar(@treatments)))!=0){
-            $c->stash->{rest} = {error => "Number of plants per plot needs to divide evenly by the number of treatments. For example: if you have two treatments and there are 3 plants per treatment, that means you have 6 plants per plot." };
-            return;
-        }
     }
 
     my $row_in_design_number = $c->req->param('row_in_design_number');

--- a/mason/breeders_toolbox/trial/trial_create_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_create_dialogs.mas
@@ -416,6 +416,15 @@ rect.bordered {
                                                 <input class="form-control" id="create_trial_with_treatment_name_input4" name="create_trial_with_treatment_name_input4" type="text" placeholder="Optional Treatment 4"/>
                                             </div>
                                         </div>
+                                        <div id="create_trial_with_treatment_additional_treatment">
+                                            <input type="hidden" id="create_trial_with_treatment_additional_count" value=0>
+                                            <div class="form-group form-group-sm" >
+                                                <label class="col-sm-7 control-label">Add Another Treatment: </label>
+                                                <div class="col-sm-5" >
+                                                    <button class="btn btn-info btn-sm" id="create_trial_with_treatment_additional_treatment_buton">+ Treatment</button>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
 
                                     <div class="form-group form-group-sm" id="num_plants_per_plot_section" style="display: none">


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
When designing splitplot design, you can give as many treatments as you need

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
