### PR TITLE
Allow image order to be specified on stock and locus detail pages

### DIFF
--- a/db/00101/AddImageDisplayOrderColumns.pm
+++ b/db/00101/AddImageDisplayOrderColumns.pm
@@ -1,0 +1,76 @@
+#!/usr/bin/env perl
+
+
+=head1 NAME
+
+    AddImageDisplayOrderColumns.pm
+
+=head1 SYNOPSIS
+
+mx-run ThisPackageName [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This is a test dummy patch.
+This subclass uses L<Moose>. The parent class uses L<MooseX::Runnable>
+
+=head1 AUTHOR
+
+ Naama Menda<nm249@cornell.edu>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2010 Boyce Thompson Institute for Plant Research
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+
+package AddImageDisplayOrderColumns;
+
+use Moose;
+
+extends 'CXGN::Metadata::Dbpatch';
+
+has '+description' => ( default => <<'');
+Adds a display_order columns to phenome.locus_image and phenome.stock_image tables
+
+
+has '+prereq' => (
+    default => sub {
+        [],
+    },
+  );
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    $self->dbh->do(<<EOSQL);
+--do your SQL here
+--
+
+ALTER TABLE phenome.stock_image ADD COLUMN display_order int default(50);
+    
+    ALTER TABLE phenome.locus_image ADD COLUMN display_order int default(50);
+    
+
+EOSQL
+
+print "You're done!\n";
+}
+
+
+####
+1; #
+####

--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -517,7 +517,7 @@ sub set_species {
 sub get_image_ids {
     my $self = shift;
     my @ids;
-    my $q = "select distinct image_id, cvterm.name FROM phenome.stock_image JOIN stock USING(stock_id) JOIN cvterm ON(type_id=cvterm_id) WHERE stock_id = ?";
+    my $q = "select distinct image_id, cvterm.name FROM phenome.stock_image JOIN stock USING(stock_id) JOIN cvterm ON(type_id=cvterm_id) WHERE stock_id = ? ORDER BY stock_image.display_order ASC";
     my $h = $self->schema->storage->dbh()->prepare($q);
     $h->execute($self->stock_id);
     while (my ($image_id, $stock_type) = $h->fetchrow_array()){

--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -1,0 +1,229 @@
+
+=head1 NAME
+
+    SGN::Controller::AJAX::Image - image ajax requests
+
+=head1 DESCRIPTION
+
+Implements the following endpoints:
+
+ GET /ajax/image/<image_id> 
+
+ GET /ajax/image/<image_id>/stock/<stock_id>/display_order
+
+ POST /ajax/image/<image_id>/stock/<stock_id>/display_order/<display_order>
+
+ GET /ajax/image/<image_id>/locus/<locus_id>/display_order
+
+ POST /ajax/image/<image_id>/locus/<locus_id>/display_order/<display_order>
+
+=head1 AUTHOR
+
+Lukas Mueller <lam87@cornell.edu>
+
+=cut
+
+package SGN::Controller::AJAX::Image;
+
+use Moose;
+
+BEGIN { extends 'Catalyst::Controller::REST' };
+
+__PACKAGE__->config(
+    default   => 'application/json',
+    stash_key => 'rest',
+    map       => { 'application/json' => 'JSON', 'text/html' => 'JSON' },
+   );
+
+
+# parse /ajax/image/<image_id>
+#
+sub basic_ajax_image :Chained('/') PathPart('ajax/image') CaptureArgs(1) ActionClass('REST') {  }
+
+sub basic_ajax_image_GET { 
+    my $self = shift;
+    my $c = shift;
+    
+    $c->stash->{image_id} = shift;
+    print STDERR "Stashing image...\n";
+    $c->stash->{image} = SGN::Image->new($c->dbc->dbh(), $c->stash->{image_id});    
+}
+
+sub basic_ajax_image_POST { 
+    my $self = shift;
+    my $c = shift;
+    $c->stash->{image_id} = shift;
+
+    print STDERR "Stashing image...\n";
+    $c->stash->{image} = SGN::Image->new($c->dbc->dbh(), $c->stash->{image_id});
+}
+
+# endpoint /ajax/image/<image_id>
+#    
+sub image_info :Chained('basic_ajax_image') PathPart('') Args(0) ActionClass('REST') {}
+
+sub image_info_GET { 
+    my $self = shift;
+    my $c = shift;
+
+    my @display_order_info = $c->stash->{image}->get_display_order_info();
+    
+    
+    my $response = { 
+	thumbnail => $c->stash->{image}->get_image_url("thumbnail"),
+	small => $c->stash->{image}->get_image_url("small"),
+	medium => $c->stash->{image}->get_image_url("medium"),
+	large => $c->stash->{image}->get_image_url("large"),
+	sp_person_id => $c->stash->{image}->get_sp_person_id(),
+        md5sum => $c->stash->{image}->get_md5sum(),	    
+	display_order => \@display_order_info
+    };
+    
+    $c->stash->{rest} = $response;
+}
+
+
+# parse /ajax/image/<image_id>/stock/<stock_id>
+#
+sub image_stock_connection :Chained('basic_ajax_image') PathPart('stock') CaptureArgs(1) ActionClass('REST') { }
+
+sub image_stock_connection_GET { 
+    my $self = shift;
+    my $c = shift;
+    my $stock_id = shift;
+
+    $self->image_stock_connection_POST($c, $stock_id);
+}
+
+sub image_stock_connection_POST {  
+    my $self = shift;
+    my $c = shift;
+
+    $c->stash->{stock_id} = shift;
+}
+
+# GET endpoint /ajax/image/<image_id>/stock/<stock_id>/display_order
+#
+sub get_image_stock_display_order : Chained('image_stock_connection') PathPart('display_order') Args(0) ActionClass('REST') { }
+
+sub get_image_stock_display_order_GET { 
+    my $self = shift;
+    my $c = shift;
+    
+    my $do = $c->stash->{image}->get_stock_page_display_order($c->stash->{stock_id});
+    $c->stash->{rest} = { stock_id => $c->stash->{stock_id},
+                          image_id => $c->stash->{image_id},
+			  display_order => $do,
+    };
+}
+
+# POST endpoint /ajax/image/<image_id>/stock/<stock_id>/display_order/<display_order>
+#
+sub add_image_stock_display_order :Chained('image_stock_connection') PathPart('display_order') Args(1) ActionClass('REST') { }
+
+sub add_image_stock_display_order_GET { 
+    my $self = shift;
+    my $c = shift;
+    my $display_order = shift;
+
+    $self->add_image_stock_display_order_POST($c, $display_order);
+}
+
+sub add_image_stock_display_order_POST { 
+    my $self = shift;
+    my $c = shift;
+    my $display_order = shift;
+
+    if (!$c->user()) { 
+	$c->stash->{rest} = { error => "you need to be logged in to modify the display order of images"};
+	return;
+    }
+    
+    if (!$c->user()->check_roles("curator") && $c->stash->{image}->get_sp_person_id() != $c->user()->get_object()->get_sp_person_id()) { 
+	$c->stash->{rest} = { error => "You cannot modify an image that you don't own.\n" };
+	return;
+    }
+
+    my $error = $c->stash->{image}->set_stock_page_display_order($c->stash->{stock_id}, $display_order);    
+    if ($error) { 
+	$c->stash->{rest} = { error => $error };
+    }
+    else { 
+	$c->stash->{rest} = { success => 1 };
+    }    
+}
+
+# parse /ajax/image/<image_id>/locus/<locus_id>
+#
+sub image_locus_connection :Chained('basic_ajax_image') PathPart('locus') CaptureArgs(1) ActionClass('REST') { }
+
+sub image_locus_connection_GET { 
+    my $self = shift;
+    my $c = shift;
+    my $stock_id = shift;
+
+    $self->image_locus_connection_POST($c, $stock_id);
+}
+
+sub image_locus_connection_POST {  
+    my $self = shift;
+    my $c = shift;
+
+    $c->stash->{locus_id} = shift;
+
+    if (!$c->user()) { 
+	$c->stash->{rest} = { error => "you need to be logged in to modify the display order of images"};
+	return;
+    }
+    
+    if (!$c->user()->check_roles("curator") && $c->stash->{image}->get_sp_person_id() != $c->user()->get_object()->get_sp_person_id()) { 
+	$c->stash->{rest} = { error => "You cannot modify an image that you don't own.\n" };
+	return;
+    }
+}
+
+# GET endpoint /ajax/image/<image_id>/locus/<locus_id>/display_order
+#
+sub get_image_locus_display_order :Chained('image_locus_connection') PathPart('display_order') Args(0) ActionClass('REST') { }
+
+sub get_image_locus_display_order_GET { 
+    my $self = shift;
+    my $c = shift;
+    
+    my $do = $c->stash->{image}->get_locus_page_display_order($c->stash->{locus_id});
+    $c->stash->{rest} = { locus_id => $c->stash->{locus_id},
+                          image_id => $c->stash->{image_id},
+			  display_order => $do,
+    };
+}
+
+# POST endpoint /ajax/image/<image_id>/locus/<locus_id>/display_order/<display_order>
+#
+sub add_image_locus_display_order :Chained('image_locus_connection') PathPart('display_order') Args(1) ActionClass('REST') { }
+
+sub add_image_locus_display_order_GET { 
+    my $self = shift;
+    my $c = shift;
+    my $display_order = shift;
+
+    $self->add_image_locus_display_order_POST($c, $display_order);
+}
+
+sub add_image_locus_display_order_POST { 
+    my $self = shift;
+    my $c = shift;
+
+    my $display_order = shift;
+    
+    my $error = $c->stash->{image}->set_locus_page_display_order($c->stash->{image_id}, $display_order);
+
+    if ($error) { 
+	$c->stash->{rest} = { error => $error };
+    }
+    else { 
+	$c->stash->{rest} = { success => 1 };
+    }
+}
+
+
+1;

--- a/lib/SGN/Controller/Image.pm
+++ b/lib/SGN/Controller/Image.pm
@@ -29,6 +29,7 @@ sub view :Path('/image/view/') Args(1) {
 
         object_id => $image_id,
         dbh       => $dbh,
+        size      => $c->req->param("size")
        );
 }
 
@@ -132,6 +133,20 @@ sub store :Path('/image/store') {
     # go to the image detail page
     # open for editing.....
     $c->res->redirect( $c->uri_for('view',$image_id )->relative() );
+}
+
+sub image_display_order :Path('/image/display_order') Args(0) { 
+    my $self  = shift;
+    my $c = shift;
+
+    $c->stash->{image_id} = $c->req->param("image_id");
+    $c->stash->{type} = $c->req->param("type");
+    $c->stash->{id} = $c->req->param("id");
+    $c->stash->{display_order} = $c->req->param("display_order");
+    
+    print STDERR "image_id = ".$c->stash->{image_id}."\n";
+    
+    $c->stash->{template} = '/image/display_order.mas';
 }
 
 sub validate_image_filename :Private {

--- a/lib/SGN/Controller/Stock.pm
+++ b/lib/SGN/Controller/Stock.pm
@@ -862,7 +862,7 @@ sub _stock_pubs {
 sub _stock_images {
     my ($self, $stock) = @_;
     my @ids;
-    my $q = "select distinct image_id, cvterm.name FROM phenome.stock_image JOIN stock USING(stock_id) JOIN cvterm ON(type_id=cvterm_id) WHERE stock_id = ?";
+    my $q = "select distinct image_id, cvterm.name, stock_image.display_order FROM phenome.stock_image JOIN stock USING(stock_id) JOIN cvterm ON(type_id=cvterm_id) WHERE stock_id = ? ORDER BY stock_image.display_order ASC";
     my $h = $self->schema->storage->dbh()->prepare($q);
     $h->execute($stock->get_stock_id);
     while (my ($image_id, $stock_type) = $h->fetchrow_array()){

--- a/mason/image/display_image.mas
+++ b/mason/image/display_image.mas
@@ -40,63 +40,12 @@ Lukas Mueller <lam87@cornell.edu>
 $image => undef
 $person_id => undef
 $size => 'medium'
+$display_order => undef
 </%args>
 
-<& /util/import_javascript.mas, classes => [ 'CXGN.Image', 'Prototype' ] &>
+<& /util/import_javascript.mas, classes => [ 'CXGN.Image', 'jquery', 'jqueryui' ] &>
 
 
-<div id="image_size_toolbar">
-</div>
-<br />
-<div id="image_div">
-</div>
-
-<script language="javascript">
-
-
-  function renderContent(image_id, size) { 
-     showTabsMenu(image_id, size);
-  //alert('Im there');
-     getImage(image_id, size);
-  
-  }
-
-  function getImage(image_id, size) { 
-
-     var image = new CXGN.Image;
-  
-     image.set_image_id(image_id);
-     image.image_html('image_div', size);
-  }
-
-  function showTabsMenu(image_id, size) { 
-//          alert('size = '+size);
-    var html = "<center>";
-    var mydiv = document.getElementById('image_size_toolbar');
-    var tabList = new Array('thumbnail', 'small', 'medium', 'large', 'original');
-	  
-    var item = '';
-
-    for (var i=0; i<tabList.length; i++ ) { 
-				 item=tabList[i];
-  //alert('I = '+i);
-      if (size == item) { 
-
-        html = html + item + " ";
-      }
-      else { 
-        html = html + '<a href=\"javascript:renderContent('+image_id+', \''+item+'\'); ">'+item+'</a>'+ ' ';
-      }
-    }
-    html = html + "</center>";
-    mydiv.innerHTML = html;
-
-  }
-  
-    
-
-  
-</script>
 
 <%perl>
 
@@ -104,34 +53,122 @@ $size => 'medium'
 use SGN::Image;
 use CXGN::Phenome::Individual;
 
-my $image_full_size_url = $image->get_image_url("large");
+my $thumbnail_img = $image->get_img_src_tag("thumbnail");
+my $small_img = $image->get_img_src_tag("small");
+my $medium_img = $image->get_img_src_tag("medium");
+my $large_img = $image->get_img_src_tag("large");
+my $original_img = $image->get_img_src_tag("original");
+
 my $object_id = $image->get_image_id();
 
-if ($size!~/thumbnail|small|medium|large|original/ ) { $size="medium"; }
+if ($size!~/thumbnail|small|medium|large|original/i ) { $size="medium"; }
+
+my $active = 0;
+if ($size eq "small") { $active = 1;}
+if ($size eq "medium") { $active = 2;}
+if ($size eq "large") { $active = 3; }
+if ($size eq "original") { $active = 4; }
 
 </%perl>
 
-<br />
 
-<script language="javascript">
-//  alert('im here');
-  renderContent(<% $object_id %>, '<% $size %>' ); 
-</script>
+<style>
+.ui-tabs .ui-tabs-nav
+{
+background: white;
+}
+.ui-tabs { 
+  border: none;
+}
 
-<!-- <br /><a href="<% $image_full_size_url %>"> -->
-<!-- <center><% $image->get_img_src_tag($size) %></center> -->
-<!-- </a><br /><br /> -->
+</style>
 
+<div id="image_tabs">
+<ul>
+    <li><a href="#tabs-1">thumbnail</a></li>
+    <li><a href="#tabs-2">small</a></li>
+    <li><a href="#tabs-3">medium</a></li>
+    <li><a href="#tabs-4">large</a></li>
+    <li><a href="#tabs-5">original</a></li>
+  </ul>
+  <div id="tabs-1">
+    <p><center><% $thumbnail_img %></center></p>
+  </div>
+  <div id="tabs-2">
+    <p><center><% $small_img %></center></p>
+  </div>
+  <div id="tabs-3">
+    <p><center><% $medium_img %></center></p>
+  </div>
+  <div id="tabs-4">
+    <p><center><% $large_img %></center></p>
+  </div>
+  <div id="tabs-5">
+    <p><center><% $original_img %></center></p>
+  </div>
+</div>
+
+
+
+
+<br /><br />
 <center><table><tr><td class="boxbgcolor5"><b>Note:</b> The above image may be subject to copyright. Please contact the submitter about permissions to use the image.</td></tr></table></center><br />
 
+
 % my $tag_count = scalar($image->get_tags());
+
+<&| /page/info_section.mas, title=>"Associated tags" &>
 <br><b>Associated tags</b> [<a href="/tag/index.pl?image_id=<% $object_id %>&amp;action=new">add/remove</a>]: <% $tag_count %>
+
 
 % foreach my $tag ($image->get_tags()) { 
 %    print $tag->get_name()."  ";
 % }
 
-<br /><br /><b>Associated objects</b>: <br />
+</&>
+
+
+<&| /page/info_section.mas, title=>"Associated objects" &>
 
 % print $image->get_associated_object_links();
 
+</&>
+
+<&| /page/info_section.mas, title=>"Display properties",  collapsible => 1, collapsed => 1 &>
+  
+  <div id="display_properties_div">
+    
+          
+  </div>
+  
+  
+</&>
+
+
+
+<script>
+  
+  jQuery(window).ready( function() { 
+    jQuery('#image_tabs').tabs({ active: <% $active %> }); 
+
+    // fetch display order data
+    jQuery.ajax( { 
+       url: '/ajax/image/<% $object_id %>',
+       error: function(r,x,error) { alert('An error occurred retrieving the image display order data.'+r.status+' '+error); },
+       success: function(r)  { 
+          if (r.error) { alert('Error: '+r.error); return; }
+          var html = "";
+          alert(JSON.stringify(r));
+          for (var i=0; i<r.display_order.length; i++) { 
+	    html += r.display_order[i]['name']+'&nbsp;<b>'+r.display_order[i]['display_order']+'</b>&nbsp;<a href="/image/display_order?image_id='+r.display_order[i].image_id+'&amp;type='+r.display_order[i].type+'&amp;id='+r.display_order[i].id+'&amp;display_order='+r.display_order[i].display_order+'">change</button></a><br />';
+	    
+          }
+	  alert(html);
+          jQuery('#display_properties_div').html(html);
+	  
+       }
+    });
+
+  });
+
+</script>

--- a/mason/image/display_order.mas
+++ b/mason/image/display_order.mas
@@ -1,0 +1,35 @@
+
+<%args>
+$image_id
+$type
+$id
+$display_order
+</%args>
+
+<center>
+<h4>Change display order for image</h4>
+
+
+Display order: <input id="display_order" value="<% $display_order %>" >
+
+<br />
+<button id="submit_display_order">change</button>
+
+<script>
+  jQuery(window).ready( function() {
+  
+  
+     jQuery('#submit_display_order').click( function() { 
+        var display_order = jQuery('#display_order').val();
+        jQuery.ajax( { 
+           url: '/ajax/image/<% $image_id %>/<% $type %>/<% $id %>/display_order/'+display_order,
+           error: function(e) { alert('an error occurred'); },
+           success: function(r) {
+             if (r.error) { alert(r.error); return; }
+             alert('Successfully changed display_order');
+           }
+        });
+     });
+  });
+
+</script>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

On the stock and locus detail pages, images are listed in load order. This pull request will allow image order to be defined using an display_order property in the phenome.locus_image and phenome.stock_image tables (see db patch). 

Tests will be implemented later, as this is only a display issue.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [x] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
