### PR TITLE
on label designer select number of labels to print

### DIFF
--- a/js/tools/LabelDesigner.js
+++ b/js/tools/LabelDesigner.js
@@ -278,15 +278,15 @@ $(document).ready(function($) {
                     jQuery('#page_format').focus();
                 },
                 success: function(response) {
-                    var html = '<select class="form-control" id="label_designer_data_level" ><option value="plots">Plots</option>';
+                    var html = '<select class="form-control" id="label_designer_data_level" ><option value="plots">Plot</option>';
                     if(response.has_plants){
-                        html = html + '<option value="plants">Plants</option>';
+                        html = html + '<option value="plants">Plant</option>';
                     }
                     if(response.has_subplots){
-                        html = html + '<option value="subplots">Subplots</option>';
+                        html = html + '<option value="subplots">Subplot</option>';
                     }
                     if(response.has_tissue_samples){
-                        html = html + '<option value="tissue_samples">Tissue Samples</option>';
+                        html = html + '<option value="tissue_samples">Tissue Sample</option>';
                     }
                     html = html + '</select>';
                     jQuery('#label_designer_data_level_select_div').html(html);
@@ -438,6 +438,8 @@ $(document).ready(function($) {
         design.label_elements = label_elements.filter(checkIfVisible).map(getLabelDetails);
         var design_json = JSON.stringify(design);
 
+        var labels_to_download = jQuery('#label_designer_labels_to_print').val();
+
         //send to server to build pdf file
         jQuery.ajax({
             url: '/tools/label_designer/download',
@@ -447,7 +449,8 @@ $(document).ready(function($) {
                 'download_type': download_type,
                 'data_type' : data_type,
                 'value': value,
-                'design_json': design_json
+                'design_json': design_json,
+                'labels_to_download': labels_to_download
             },
             beforeSend: function() {
                 console.log("Downloading "+download_type+" file . . . ");

--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -159,7 +159,7 @@ __PACKAGE__->config(
        my $data_type = $c->req->param("data_type");
        my $value = $c->req->param("value");
        my $design_json = $c->req->param("design_json");
-       my $labels_to_download = $c->req->param("labels_to_download");
+       my $labels_to_download = $c->req->param("labels_to_download") || 10000000000;
        my $conversion_factor = 2.83; # for converting from 8 dots per mmm to 2.83 per mm (72 per inch)
 
        # decode json

--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -159,6 +159,7 @@ __PACKAGE__->config(
        my $data_type = $c->req->param("data_type");
        my $value = $c->req->param("value");
        my $design_json = $c->req->param("design_json");
+       my $labels_to_download = $c->req->param("labels_to_download");
        my $conversion_factor = 2.83; # for converting from 8 dots per mmm to 2.83 per mm (72 per inch)
 
        # decode json
@@ -252,6 +253,10 @@ __PACKAGE__->config(
 
            # loop through plot data in design hash
            foreach my $key ( sort { versioncmp( $design{$a}{$sort_order} , $design{$b}{$sort_order} ) or  $a <=> $b } keys %design) {
+
+               if ($key_number >= $labels_to_download){
+                   last;
+               }
 
                 #print STDERR "Design key is $key\n";
                 my %design_info = %{$design{$key}};
@@ -380,6 +385,11 @@ __PACKAGE__->config(
            $zpl_obj->end_sequence();
            my $zpl_template = $zpl_obj->render();
            foreach my $key ( sort { versioncmp( $design{$a}{$sort_order} , $design{$b}{$sort_order} ) or  $a <=> $b } keys %design) {
+
+               if ($key_number >= $labels_to_download){
+                   last;
+               }
+
             #    print STDERR "Design key is $key\n";
                my %design_info = %{$design{$key}};
                $design_info{'trial_name'} = $trial_name;

--- a/mason/tools/label_designer.mas
+++ b/mason/tools/label_designer.mas
@@ -47,6 +47,17 @@
             <div class="col-md-4">
                 <div id="label_designer_data_level_select_div"></div>
             </div>
+            <div class="col-md-2">
+                <label>Labels to Print:</label>
+            </div>
+            <div class="col-md-4">
+                <select class="form-control" id="label_designer_labels_to_print" >
+                    <option value="100000000000000000">All</option>
+                    <option value="1">First 1</option>
+                    <option value="5">First 5</option>
+                    <option value="10">First 10</option>
+                </select>
+            </div>
         </div>
         <div class="col-md-12" id="d3-custom-dimensions-div" style="display:none;">
             <div class="col-md-6" id="d3-page-custom-dimensions-div" style="visibility:hidden">


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
On label designer, it is useful to be able to download only the first 5 or 10 labels for testing. This PR adds a select for printing All, First1, First5, or First10 labels

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
