### PR TITLE
curator can set public lists back to private

### DIFF
--- a/js/CXGN/List.js
+++ b/js/CXGN/List.js
@@ -400,15 +400,19 @@ CXGN.List.prototype = {
         var html = '';
 
         html += '<table id="public_list_data_table" class="table table-hover table-condensed">';
-        html += '<thead><tr><th>List Name</th><th>Count</th><th>Type</th><th>Validate</th><th>View</th><th>Download</th><th>Copy To Your Lists</th></tr></thead><tbody>';
+        html += '<thead><tr><th>List Name</th><th>Count</th><th>Type</th><th>Validate</th><th>View</th><th>Download</th><th>Copy To Your Lists</th><th>Owner</th><th>Make Private</th></tr></thead><tbody>';
         for (var i = 0; i < lists.length; i++) {
-            html += '<tr><td><b>'+lists[i][1]+'</b></td>';
+            html += '<tr>';
+            html += '<td><b>'+lists[i][1]+'</b></td>';
             html += '<td>'+lists[i][3]+'</td>';
             html += '<td>'+lists[i][5]+'</td>';
             html += '<td><a onclick="(new CXGN.List()).validate(\''+lists[i][0]+'\',\''+lists[i][5]+'\')"><span class="glyphicon glyphicon-ok"></span></a></td>';
             html += '<td><a title="View" id="view_public_list_'+lists[i][1]+'" href="javascript:showPublicListItems(\'list_item_dialog\','+lists[i][0]+')"><span class="glyphicon glyphicon-th-list"></span></a></td>';
             html += '<td><a target="_blank" title="Download" id="download_public_list_'+lists[i][1]+'" href="/list/download?list_id='+lists[i][0]+'"><span class="glyphicon glyphicon-arrow-down"></span></a></td>';
             html += '<td><a title="Copy to Your Lists" id="copy_public_list_'+lists[i][1]+'" href="javascript:copyPublicList('+lists[i][0]+')"><span class="glyphicon glyphicon-plus"></span></a></td>';
+            html += '<td>'+lists[i][6]+'</td>';
+            html += '<td><a title="Make Private" href="javascript:togglePublicList('+lists[i][0]+')"><span class="glyphicon glyphicon-ban-circle"></span></a></td>';
+            html += '</tr>';
         }
         html = html + '</tbody></table>';
 

--- a/lib/CXGN/List.pm
+++ b/lib/CXGN/List.pm
@@ -135,21 +135,20 @@ sub available_public_lists {
     my $dbh = shift;
     my $requested_type = shift;
 
-    my $q = "SELECT list_id, list.name, description, count(distinct(list_item_id)), type_id, cvterm.name FROM sgn_people.list left join sgn_people.list_item using(list_id) LEFT JOIN cvterm ON (type_id=cvterm_id) WHERE is_public='t' GROUP BY list_id, list.name, description, type_id, cvterm.name ORDER BY list.name";
+    my $q = "SELECT list_id, list.name, description, count(distinct(list_item_id)), type_id, cvterm.name, sp_person.username FROM sgn_people.list LEFT JOIN sgn_people.sp_person AS sp_person ON (sgn_people.list.owner=sp_person.sp_person_id) LEFT JOIN sgn_people.list_item using(list_id) LEFT JOIN cvterm ON (type_id=cvterm_id) WHERE is_public='t' GROUP BY list_id, list.name, description, type_id, cvterm.name, sp_person.username ORDER BY list.name";
     my $h = $dbh->prepare($q);
     $h->execute();
 
     my @lists = ();
-    while (my ($id, $name, $desc, $item_count, $type_id, $type) = $h->fetchrow_array()) { 
-	if ($requested_type) {
-	    if ($type && ($type eq $requested_type)) { 
-		push @lists, [ $id, $name, $desc, $item_count, $type_id, $type ];
-	    }
-	}
-	else { 
-	    
-	    push @lists, [ $id, $name, $desc, $item_count, $type_id, $type ];
-	}
+    while (my ($id, $name, $desc, $item_count, $type_id, $type, $username) = $h->fetchrow_array()) {
+        if ($requested_type) {
+            if ($type && ($type eq $requested_type)) { 
+                push @lists, [ $id, $name, $desc, $item_count, $type_id, $type, $username ];
+            }
+        }
+        else { 
+            push @lists, [ $id, $name, $desc, $item_count, $type_id, $type, $username ];
+        }
     }
     return \@lists;
 }

--- a/lib/SGN/Controller/AJAX/List.pm
+++ b/lib/SGN/Controller/AJAX/List.pm
@@ -268,8 +268,8 @@ sub available_public_lists : Path('/list/available_public') Args(0) {
 
     my $user_id = $self->get_user($c);
     if (!$user_id) {
-	$c->stash->{rest} = { error => "You must be logged in to use lists.", };
-	return;
+        $c->stash->{rest} = { error => "You must be logged in to use lists." };
+        $c->detach();
     }
 
     my $lists = CXGN::List::available_public_lists($c->dbc->dbh(), $requested_type);
@@ -323,8 +323,8 @@ sub toggle_public_list : Path('/list/public/toggle') Args(0) {
 
     my $error = $self->check_user($c, $list_id);
     if ($error) {
-	$c->stash->{rest} = { error => $error };
-	return;
+        $c->stash->{rest} = { error => $error };
+        $c->detach();
     }
 
     my $list = CXGN::List->new( { dbh => $c->dbc->dbh, list_id=>$list_id });
@@ -868,11 +868,10 @@ sub check_user : Private {
     my $error = "";
 
     if (!$user_id) {
-	$error = "You must be logged in to manipulate this list.";
+        $error = "You must be logged in to manipulate this list.";
     }
-
-    elsif ($self->get_list_owner($c, $list_id) != $user_id) {
-	$error = "You have insufficient privileges to manipulate this list.";
+    elsif ($c->user->get_object->get_user_type() ne 'curator' && $self->get_list_owner($c, $list_id) != $user_id) {
+        $error = "You have insufficient privileges to manipulate this list.";
     }
     return $error;
 }

--- a/mason/site/list.mas
+++ b/mason/site/list.mas
@@ -23,7 +23,7 @@
 </div>
 
 <div class="modal fade" id="public_list_dialog" name="public_list_dialog" tabindex="-1" role="dialog" aria-labelledby="publicListDialog">
-  <div class="modal-dialog modal-lg" role="document">
+  <div class="modal-dialog modal-xl" role="document">
     <div class="modal-content">
       <div class="modal-header" style="text-align:center">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Public lists now shows the owner username, and gives option to curators to return public lists to private lists.

<!-- If there are relevant issues, link them here: -->
closes #1974 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
