### PR TITLE
trial deletion checks

### DIFF
--- a/js/CXGN/BreedersToolbox/GenotypingTrial.js
+++ b/js/CXGN/BreedersToolbox/GenotypingTrial.js
@@ -379,28 +379,10 @@ jQuery(document).ready(function ($) {
                         alert(response.error);
                     }
                     else {
-                        jQuery.ajax({
-                            url: '/ajax/breeders/trial/'+trial_id+'/delete/entry',
-                            beforeSend: function(){
-                                jQuery('#working_msg').html("Removing the project entry...");
-                            },
-                            success: function(response) {
-                                jQuery('#working_modal').modal("hide");
-                                jQuery('#working_msg').html('');
-                                if (response.error) {
-                                    alert(response.error);
-                                }
-                                else {
-                                    alert('The project entry has been deleted.'); // to do: give some idea how many items were deleted.
-                                    window.location.href="/breeders/trial/"+trial_id;
-                                }
-                            },
-                            error: function(response) {
-                                jQuery('#working_modal').modal("hide");
-                                jQuery('#working_msg').html('');
-                                alert("An error occurred.");
-                            }
-                        });
+                        jQuery('#working_modal').modal("hide");
+                        jQuery('#working_msg').html('');
+                        alert('The genotyping plate has been deleted.'); // to do: give some idea how many items were deleted.
+                        window.location.href="/breeders/trial/"+trial_id;
                     }
                 },
                 error: function(response) {

--- a/js/CXGN/Trial.js
+++ b/js/CXGN/Trial.js
@@ -43,28 +43,10 @@ function delete_layout_data_by_trial_id(trial_id) {
                     alert(response.error);
                 }
                 else {
-                    jQuery.ajax({
-                        url: '/ajax/breeders/trial/'+trial_id+'/delete/entry',
-                        beforeSend: function(){
-                            jQuery('#working_msg').html("Deleting trial entry...<br />");
-                        },
-                        success: function(response) {
-                            jQuery('#working_modal').modal('hide');
-                            jQuery('#working_msg').html('');
-                            if (response.error) {
-                                alert(response.error);
-                            }
-                            else {
-                                alert('The project entry has been deleted.'); // to do: give some idea how many items were deleted.
-                                window.location.href="/breeders/trial/"+trial_id;
-                            }
-                        },
-                        error: function(response) {
-                            jQuery('#working_modal').modal('hide');
-                            jQuery('#working_msg').html('');
-                            alert("An error occurred.");
-                        }
-                    });
+                    jQuery('#working_modal').modal('hide');
+                    jQuery('#working_msg').html('');
+                    alert('The field trial has been deleted.'); // to do: give some idea how many items were deleted.
+                    window.location.href="/breeders/trial/"+trial_id;
                 }
             },
             error: function(response) {

--- a/lib/CXGN/Trial.pm
+++ b/lib/CXGN/Trial.pm
@@ -618,11 +618,11 @@ sub set_crossing_trials_from_field_trial {
 sub get_crossing_trials_from_field_trial {
     my $self = shift;
     my $schema = $self->bcs_schema;
-    my $genotyping_trial_from_field_trial_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'crossing_trial_from_field_trial', 'project_relationship')->cvterm_id();
+    my $crossing_trial_from_field_trial_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'crossing_trial_from_field_trial', 'project_relationship')->cvterm_id();
 
     my $trial_rs= $self->bcs_schema->resultset('Project::ProjectRelationship')->search({
         'me.subject_project_id' => $self->get_trial_id(),
-        'me.type_id' => $genotyping_trial_from_field_trial_cvterm_id
+        'me.type_id' => $crossing_trial_from_field_trial_cvterm_id
     }, {
         join => 'object_project', '+select' => ['object_project.name'], '+as' => ['source_trial_name']
     });
@@ -637,7 +637,7 @@ sub get_crossing_trials_from_field_trial {
 =head2 function get_field_trials_source_of_crossing_trial()
 
  Usage:
- Desc:         return associated crossing trials for athe current field trial
+ Desc:         return associated field trials for the current crossing trial
  Ret:          returns an arrayref [ id, name ] of arrayrefs
  Args:
  Side Effects:
@@ -648,11 +648,11 @@ sub get_crossing_trials_from_field_trial {
 sub get_field_trials_source_of_crossing_trial {
     my $self = shift;
     my $schema = $self->bcs_schema;
-    my $genotyping_trial_from_field_trial_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'crossing_trial_from_field_trial', 'project_relationship')->cvterm_id();
+    my $crossing_trial_from_field_trial_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'crossing_trial_from_field_trial', 'project_relationship')->cvterm_id();
 
     my $trial_rs= $self->bcs_schema->resultset('Project::ProjectRelationship')->search({
         'me.object_project_id' => $self->get_trial_id(),
-        'me.type_id' => $genotyping_trial_from_field_trial_cvterm_id
+        'me.type_id' => $crossing_trial_from_field_trial_cvterm_id
     }, {
         join => 'subject_project', '+select' => ['subject_project.name'], '+as' => ['source_trial_name']
     });
@@ -1388,6 +1388,19 @@ sub delete_field_layout {
 
     my $trial_id = $self->get_trial_id();
 
+    if (scalar(@{$self->get_genotyping_trials_from_field_trial}) > 0) {
+        return 'This field trial has been linked to genotyping trials already, and cannot be easily deleted.';
+    }
+    if (scalar(@{$self->get_field_trials_source_of_genotyping_trial}) > 0) {
+        return 'This genotyping trial has been linked to field trials already, and cannot be easily deleted.';
+    }
+    if (scalar(@{$self->get_crossing_trials_from_field_trial}) >0) {
+        return 'This field trial has been linked to crossing trials already, and cannot be easily deleted.';
+    }
+    if (scalar(@{$self->get_field_trials_source_of_crossing_trial}) >0) {
+        return 'This crossing trial has been linked to field trials already, and cannot be easily deleted.';
+    }
+
     # Note: metadata entries need to be deleted separately using delete_metadata()
     #
     my $error = '';
@@ -1515,6 +1528,19 @@ sub delete_metadata {
     if (!$metadata_schema || !$phenome_schema) { die "Need metadata schema parameter\n"; }
 
     my $trial_id = $self->get_trial_id();
+
+    if (scalar(@{$self->get_genotyping_trials_from_field_trial}) > 0) {
+        return 'This field trial has been linked to genotyping trials already, and cannot be easily deleted.';
+    }
+    if (scalar(@{$self->get_field_trials_source_of_genotyping_trial}) > 0) {
+        return 'This genotyping trial has been linked to field trials already, and cannot be easily deleted.';
+    }
+    if (scalar(@{$self->get_crossing_trials_from_field_trial}) >0) {
+        return 'This field trial has been linked to crossing trials already, and cannot be easily deleted.';
+    }
+    if (scalar(@{$self->get_field_trials_source_of_crossing_trial}) >0) {
+        return 'This crossing trial has been linked to field trials already, and cannot be easily deleted.';
+    }
 
     #print STDERR "Deleting metadata for trial $trial_id...\n";
 
@@ -1710,6 +1736,19 @@ sub delete_project_entry {
     if (my $count = $self->get_experiment_count() > 0) {
 	print STDERR "Cannot delete trial with associated experiments ($count)\n";
 	return "Cannot delete entry because of associated experiments";
+    }
+
+    if (scalar(@{$self->get_genotyping_trials_from_field_trial}) > 0) {
+        return 'This field trial has been linked to genotyping trials already, and cannot be easily deleted.';
+    }
+    if (scalar(@{$self->get_field_trials_source_of_genotyping_trial}) > 0) {
+        return 'This genotyping trial has been linked to field trials already, and cannot be easily deleted.';
+    }
+    if (scalar(@{$self->get_crossing_trials_from_field_trial}) >0) {
+        return 'This field trial has been linked to crossing trials already, and cannot be easily deleted.';
+    }
+    if (scalar(@{$self->get_field_trials_source_of_crossing_trial}) >0) {
+        return 'This crossing trial has been linked to field trials already, and cannot be easily deleted.';
     }
 
     eval {

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -95,35 +95,36 @@ sub delete_trial_data_GET : Chained('trial') PathPart('delete') Args(1) {
     my $datatype = shift;
 
     if ($self->privileges_denied($c)) {
-	$c->stash->{rest} = { error => "You have insufficient access privileges to delete trial data." };
-	return;
+        $c->stash->{rest} = { error => "You have insufficient access privileges to delete trial data." };
+        return;
     }
 
     my $error = "";
 
     if ($datatype eq 'phenotypes') {
-	$error = $c->stash->{trial}->delete_phenotype_metadata($c->dbic_schema("CXGN::Metadata::Schema"), $c->dbic_schema("CXGN::Phenome::Schema"));
-	$error .= $c->stash->{trial}->delete_phenotype_data();
+        $error = $c->stash->{trial}->delete_phenotype_metadata($c->dbic_schema("CXGN::Metadata::Schema"), $c->dbic_schema("CXGN::Phenome::Schema"));
+        $error .= $c->stash->{trial}->delete_phenotype_data();
     }
 
     elsif ($datatype eq 'layout') {
         $error = $c->stash->{trial}->delete_metadata();
-        $error = $c->stash->{trial}->delete_field_layout();
+        $error .= $c->stash->{trial}->delete_field_layout();
+        $error .= $c->stash->{trial}->delete_project_entry();
 
         my $dbh = $c->dbc->dbh();
         my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
         my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath});
     }
     elsif ($datatype eq 'entry') {
-	$error = $c->stash->{trial}->delete_project_entry();
+        $error = $c->stash->{trial}->delete_project_entry();
     }
     else {
-	$c->stash->{rest} = { error => "unknown delete action for $datatype" };
-	return;
+        $c->stash->{rest} = { error => "unknown delete action for $datatype" };
+        return;
     }
     if ($error) {
-	$c->stash->{rest} = { error => $error };
-	return;
+        $c->stash->{rest} = { error => $error };
+        return;
     }
     $c->stash->{rest} = { message => "Successfully deleted trial data.", success => 1 };
 }


### PR DESCRIPTION
When a genotyping plate is uploaded and it uses field entities as its source observation units (plots/plants/tissue samples), the database automatically creates linkage between the genotyping plate and those field trial(s) (i.e. the trial linkage section). Trial deletion will now check if a field trial / genotyping plate has linkage to genotyping plates / field trials before allowing deletion (on either the web interface or the backend script).
Trial deletion will now always delete the layout and the project entry, preventing #2185 from happening

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
closes #2221 
closes #2185

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
