### PR TITLE
seedlot inventory upload works for 0

### DIFF
--- a/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotInventoryCSV.pm
+++ b/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotInventoryCSV.pm
@@ -90,7 +90,7 @@ sub _validate_with_plugin {
         if (!$columns[3] || $columns[3] eq ''){
             push @error_messages, 'The fourth column must contain an inventory_person on row: '.$row;
         }
-        if (!$columns[4] || $columns[4] eq ''){
+        if (!defined($columns[4]) || $columns[4] eq ''){
             push @error_messages, 'The fifth column must contain weight_gram on row: '.$row;
         }
     }

--- a/t/data/stock/seedlot_inventory_android_app
+++ b/t/data/stock/seedlot_inventory_android_app
@@ -1,4 +1,4 @@
 box_id,seed_id,inventory_date,inventory_person,weight_gram
 box1,test_accession4_001,2018-04-01-02-04-34,nmorales,10
 box2,test_accession3_001,2018-04-01-02-04-33,nmorales,12
-box2,test_accession2_001,2018-04-01-02-04-32,some user,34
+box2,test_accession2_001,2018-04-01-02-04-32,some user,0


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Allows 0 as a value for seedlot inventory upload. Test now covers this use case.

<!-- If there are relevant issues, link them here: -->
closes #2273

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
