### PR TITLE
Topic/stock obsolete catalyst

### DIFF
--- a/lib/CXGN/Pedigree/AddPopulations.pm
+++ b/lib/CXGN/Pedigree/AddPopulations.pm
@@ -22,24 +22,27 @@ use MooseX::FollowPBP;
 use Moose::Util::TypeConstraints;
 use Try::Tiny;
 use SGN::Model::Cvterm;
+use Data::Dumper;
 
 has 'schema' => (
-		 is       => 'rw',
-		 isa      => 'DBIx::Class::Schema',
-		 predicate => 'has_schema',
-		 required => 1,
-		);
+    is       => 'rw',
+    isa      => 'DBIx::Class::Schema',
+    predicate => 'has_schema',
+    required => 1,
+);
 has 'name' => (isa => 'Str', is => 'rw', predicate => 'has_name', required => 1,);
 has 'members' => (isa =>'ArrayRef[Str]', is => 'rw', predicate => 'has_members', required => 1,);
 
 sub add_population {
-	my $self = shift;
-	my $schema = $self->get_schema();
-	my $population_name = $self->get_name();
-	my @members = @{$self->get_members()};
-	my $error;
+    my $self = shift;
+    my $schema = $self->get_schema();
+    my $population_name = $self->get_name();
+    my @members = @{$self->get_members()};
+    my $error;
 
+    my $accession_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
     my $population_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'population', 'stock_type')->cvterm_id();
+    my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
     my $member_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'member_of', 'stock_relationship')->cvterm_id();
     my $population_id;
 
@@ -51,37 +54,57 @@ sub add_population {
         return { error => "$population_name already used in the database! Use another name or use the existing population entry." };
     }
 
-	# create population stock entry
-	try {
-	my $pop_rs = $schema->resultset("Stock::Stock")->create(
-{
-		name => $population_name,
-		uniquename => $population_name,
-		type_id => $population_cvterm_id,
-});
-    $population_id = $pop_rs->stock_id();
+    my $acc_synonym_rs = $schema->resultset("Stock::Stock")->search({
+        'me.is_obsolete' => { '!=' => 't' },
+        'stockprops.value' => { -in => \@members},
+        'me.type_id' => $accession_cvterm_id,
+        'stockprops.type_id' => $synonym_cvterm_id
+    },{join => 'stockprops', '+select'=>['stockprops.value'], '+as'=>['synonym']});
+    my %acc_synonyms_lookup;
+    while (my $r=$acc_synonym_rs->next){
+        $acc_synonyms_lookup{$r->get_column('synonym')}->{$r->uniquename} = $r->stock_id;
+    }
 
-	 # generate population connections to the members
-	foreach my $m (@members) {
-my $m_row = $schema->resultset("Stock::Stock")->find({ uniquename => $m });
-my $connection = $schema->resultset("Stock::StockRelationship")->create(
-		{
-	subject_id => $m_row->stock_id,
-	object_id => $pop_rs->stock_id,
-	type_id => $member_of_cvterm_id,
-		});
-	}
-}
-catch {
-	$error =  $_;
-};
-if ($error) {
-	print STDERR "Error creating population $population_name: $error\n";
-	return { error => "Error creating population $population_name: $error" };
-} else {
-	print STDERR "population $population_name added successfully\n";
-	return { success => "Success! Population $population_name created", population_id=>$population_id };
-}
+    # create population stock entry
+    my $coderef = sub {
+        my $pop_rs = $schema->resultset("Stock::Stock")->create({
+            name => $population_name,
+            uniquename => $population_name,
+            type_id => $population_cvterm_id,
+        });
+        $population_id = $pop_rs->stock_id();
+
+        # generate population connections to the members
+        foreach my $m (@members) {
+            if (exists($acc_synonyms_lookup{$m})) {
+                my @accession_names = keys %{$acc_synonyms_lookup{$m}};
+                if (scalar(@accession_names)>1){
+                    print STDERR "There is more than one uniquename for this synonym $m. this should not happen!\n";
+                }
+                $m = $accession_names[0];
+            }
+            my $m_row = $schema->resultset("Stock::Stock")->find({ uniquename => $m });
+            my $connection = $schema->resultset("Stock::StockRelationship")->find_or_create({
+                subject_id => $m_row->stock_id,
+                object_id => $pop_rs->stock_id,
+                type_id => $member_of_cvterm_id,
+            });
+        }
+    };
+
+    try {
+        $schema->txn_do($coderef);
+    }
+    catch {
+        $error =  $_;
+    };
+    if ($error) {
+        print STDERR "Error creating population $population_name: $error\n";
+        return { error => "Error creating population $population_name: $error" };
+    } else {
+        print STDERR "population $population_name added successfully\n";
+        return { success => "Success! Population $population_name created", population_id=>$population_id };
+    }
 }
 
 sub add_accessions {

--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -282,9 +282,9 @@ sub store {
                 $self->_store_stockprop('organization', $self->organization_name());
             }
             if ($self->population_name){
-		print STDERR "**STOCK.PM This stock has population name " . $self->population_name . "\n\n";
-		#DO NOT INSERT POPULATION RELATIONSHIP FROM THE STOCK STORE FUNCTION
-		##$self->_store_population_relationship();
+                print STDERR "**STOCK.PM This stock has population name " . $self->population_name . "\n\n";
+                #DO NOT INSERT POPULATION RELATIONSHIP FROM THE STOCK STORE FUNCTION
+                $self->_store_population_relationship();
             }
 
         }
@@ -309,9 +309,9 @@ sub store {
             $self->_update_stockprop('organization', $self->organization_name());
         }
         if ($self->population_name){
-	    print STDERR "**STOCK.PM This stock has population name " . $self->population_name . "\n\n";
+            print STDERR "**STOCK.PM This stock has population name " . $self->population_name . "\n\n";
             #DO NOT INSERT POPULATION RELATIONSHIP FROM THE STOCK STORE FUNCTION
-            ##$self->_update_population_relationship();
+            $self->_update_population_relationship();
         }
     }
     $self->associate_owner($self->sp_person_id, $self->sp_person_id, $self->user_name, $self->modification_note);

--- a/mason/page/detail_page_2_col_section.mas
+++ b/mason/page/detail_page_2_col_section.mas
@@ -234,6 +234,9 @@ $sample_observation_unit_type_name => undef
 % if ($info_section_id eq 'stock_comments_section'){
                                 <& /page/comments.mas, object_type=>'stock', object_id=>$stock_id, referer=>$referer &>
 % } #End stock_comments_section
+% if ($info_section_id eq 'stock_delete_section'){
+                                <& /stock/delete.mas, stock_id=>$stock_id &>
+% } #End stock_delete_section
 
 
 % if ($info_section_id eq 'manage_tissue_samples_field_trials'){

--- a/mason/stock/delete.mas
+++ b/mason/stock/delete.mas
@@ -1,0 +1,33 @@
+
+<%args>
+$stock_id
+</%args>
+
+<& /util/import_javascript.mas, classes => [  ] &>
+
+<button class="btn btn-primary" id="stock_detail_page_obsolete_stock">Obsolete This Stock</button>
+
+<script>
+
+    jQuery(document).ready(function () {
+        jQuery('#stock_detail_page_obsolete_stock').click(function(){
+            jQuery.ajax ({
+                url : '/stock/obsolete?stock_id=<% $stock_id %>&is_obsolete=1',
+                beforeSend : function() {
+                    jQuery('#working_modal').modal('show');
+                },
+                success: function(response){
+                    console.log(response);
+                    jQuery('#working_modal').modal('hide');
+                    alert('Successfully obsoleted!');
+                    location.reload();
+                },
+                error: function(response){
+                    jQuery('#working_modal').modal('hide');
+                    alert("Error obsoleting stock.");
+                }
+            });
+        });
+    });
+
+</script>

--- a/mason/stock/index.mas
+++ b/mason/stock/index.mas
@@ -222,7 +222,10 @@ function jqueryStuff() {
                         js_object_name=> 'stockForm',
                         page_url => "/stock/$stock_id/view/" ,
                         #alternate_new_button => '<a class="btn btn-sm btn-default" href ="/stock/0/new">New</a>'
-                        alternate_new_button => ''
+                        alternate_new_button => '',,
+                        alternate_ghosted_new_button => '',
+                        alternate_delete_button => '',
+                        alternate_ghosted_delete_button => ''
                     &>
 
                 </div>
@@ -285,6 +288,8 @@ function jqueryStuff() {
     <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, info_section_title => "<h4 style='display:inline'>JBrowse Genome Alignments</h4>", info_section_subtitle => 'View JBrowse tracks for this stock.', icon_class => "glyphicon glyphicon-align-left", info_section_id => "stock_jbrowse_section" &>
 
     <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, info_section_title => "<h4 style='display:inline'>Comments</h4>", info_section_subtitle => 'View and add comments to this stock.', icon_class => "glyphicon glyphicon-pencil", info_section_id => "stock_comments_section", referer => $this_page &>
+
+    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, info_section_title => "<h4 style='display:inline'>Obsolete This Stock</h4>", info_section_subtitle => 'Make a stock obsolete so that it does not show in searches.', icon_class => "glyphicon glyphicon-trash", info_section_id => "stock_delete_section" &>
 
 </&>
 

--- a/t/unit_fixture/CXGN/VerifyDeletion/StockObsoletion.t
+++ b/t/unit_fixture/CXGN/VerifyDeletion/StockObsoletion.t
@@ -1,0 +1,54 @@
+
+
+# Tests trial deletion functions as they are used from the trial detail page through AJAX requests
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use SGN::Test::Fixture;
+use Test::More;
+use Test::WWW::Mechanize;
+
+#Needed to update IO::Socket::SSL
+use Data::Dumper;
+use JSON;
+use URI::Encode qw(uri_encode uri_decode);
+use CXGN::Chado::Stock;
+use LWP::UserAgent;
+use CXGN::List;
+use CXGN::Stock::Accession;
+use CXGN::Trial;
+local $Data::Dumper::Indent = 0;
+
+my $f = SGN::Test::Fixture->new();
+my $schema = $f->bcs_schema;
+my $metadata_schema = $f->metadata_schema;
+my $phenome_schema = $f->phenome_schema;
+
+my $mech = Test::WWW::Mechanize->new;
+my $response;
+my $json = JSON->new->allow_nonref;
+
+$mech->post_ok('http://localhost:3010/brapi/v1/token', [ "username"=> "janedoe", "password"=> "secretpw", "grant_type"=> "password" ]);
+$response = decode_json $mech->content;
+print STDERR Dumper $response;
+my $sgn_session_id = $response->{access_token};
+
+my $previous_stock_count_all = $schema->resultset("Stock::Stock")->search({})->count();
+my $previous_stock_count_obsolete = $schema->resultset("Stock::Stock")->search({is_obsolete=>1})->count();
+
+my $stock_id = $schema->resultset("Stock::Stock")->find({name=>'test_accession1'})->stock_id;
+
+$mech->get_ok('http://localhost:3010/stock/obsolete?stock_id='.$stock_id.'&is_obsolete=1');
+$response = decode_json $mech->content;
+print STDERR Dumper $response;
+is_deeply($response, { message => "Stock obsoleted" }, 'obsolete stock via ajax catalyst controller');
+
+my $after_stock_count_all = $schema->resultset("Stock::Stock")->search({})->count();
+my $after_stock_count_obsolete = $schema->resultset("Stock::Stock")->search({is_obsolete=>1})->count();
+
+is($after_stock_count_all, $previous_stock_count_all);
+is($after_stock_count_obsolete, $previous_stock_count_obsolete + 1);
+
+done_testing();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Making a stock obsolete from the stock detail page now uses a catalyst rest controller instead of the cgi-bin script.
Also, adding a population (on the manage accessions page) now works with a list of accessions that contains synonyms.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
