### PR TITLE
fix issue with new location geojson format and metadata.

### DIFF
--- a/lib/SGN/Controller/BreedersToolbox.pm
+++ b/lib/SGN/Controller/BreedersToolbox.pm
@@ -89,7 +89,7 @@ sub manage_trials : Path("/breeders/trials") Args(0) {
     $c->stash->{preferred_species} = $c->config->{preferred_species};
     $c->stash->{timestamp} = localtime;
 
-    my $locations = decode_json $projects->get_location_geojson();
+    my $locations = decode_json($projects->get_location_geojson());
 
     #print STDERR "Locations are ".Dumper($locations)."\n";
 
@@ -297,6 +297,7 @@ sub manage_upload :Path("/breeders/upload") Args(0) {
 
     my $projects = CXGN::BreedersToolbox::Projects->new( { schema=> $schema } );
     my $breeding_programs = $projects->get_breeding_programs();
+    $c->stash->{geojson_locations} = decode_json($projects->get_location_geojson());
     $c->stash->{locations} = $projects->get_all_locations();
     $c->stash->{breeding_programs} = $breeding_programs;
     $c->stash->{timestamp} = localtime;

--- a/lib/SGN/Controller/Seedlot.pm
+++ b/lib/SGN/Controller/Seedlot.pm
@@ -7,6 +7,7 @@ BEGIN { extends 'Catalyst::Controller'; }
 
 use CXGN::Stock::Seedlot;
 use Data::Dumper;
+use JSON;
 
 sub seedlots :Path('/breeders/seedlots') :Args(0) { 
     my $self = shift;
@@ -23,7 +24,7 @@ sub seedlots :Path('/breeders/seedlots') :Args(0) {
     my $projects = CXGN::BreedersToolbox::Projects->new( { schema=> $schema } );
     my $breeding_programs = $projects->get_breeding_programs();
     $c->stash->{crossing_trials} = $projects->get_crossing_trials();
-    $c->stash->{locations} = $projects->get_all_locations();
+    $c->stash->{locations} = decode_json($projects->get_location_geojson());
     $c->stash->{programs} = $breeding_programs;
     $c->stash->{template} = '/breeders_toolbox/seedlots.mas';
 }

--- a/mason/breeders_toolbox/manage_upload.mas
+++ b/mason/breeders_toolbox/manage_upload.mas
@@ -1,5 +1,6 @@
 <%args>
 $locations
+$geojson_locations
 $breeding_programs
 $timestamp
 $preferred_species => ""
@@ -62,8 +63,8 @@ $editable_stock_props => {}
 </tbody>
 </table>
 </div>
-<& /breeders_toolbox/trial/trial_create_dialogs.mas, locations => $locations, breeding_programs => $breeding_programs &>
-<& /breeders_toolbox/trial/trial_upload_dialogs.mas, locations => $locations, breeding_programs => $breeding_programs &>
+<& /breeders_toolbox/trial/trial_create_dialogs.mas, locations => $geojson_locations, breeding_programs => $breeding_programs &>
+<& /breeders_toolbox/trial/trial_upload_dialogs.mas, locations => $geojson_locations, breeding_programs => $breeding_programs &>
 
 <div class="well well-sm">
 <h1>Genotyping Plates</h1><br/>
@@ -234,8 +235,8 @@ $editable_stock_props => {}
 </table>
 </div>
 <& /breeders_toolbox/cross_wishlist.mas &>
-<& /breeders_toolbox/add_cross_dialogs.mas, programs=>$breeding_programs, locations=>$locations &>
-<& /breeders_toolbox/upload_crosses_dialogs.mas, programs=>$breeding_programs, locations=>$locations &>
+<& /breeders_toolbox/add_cross_dialogs.mas, programs=>$breeding_programs, locations=>$geojson_locations &>
+<& /breeders_toolbox/upload_crosses_dialogs.mas, programs=>$breeding_programs, locations=>$geojson_locations &>
 <& /breeders_toolbox/cross/upload_update_crosses.mas &>
 
 

--- a/mason/breeders_toolbox/upload_crosses_dialogs.mas
+++ b/mason/breeders_toolbox/upload_crosses_dialogs.mas
@@ -75,7 +75,7 @@ $locations
     #     print "<option value=".'"'.@$location[1].'"'.">".@$location[1]."</option>";
     # }
     foreach my $location_hashref (@$locations) {
-        my $properties = $location_hashref->{'properties'};
+        my $properties = exists($location_hashref->{'properties'}) ? $location_hashref->{properties} : "";
         my $program = $properties->{'Program'};
         my $name = $properties->{'Name'};
         print "<option value=\"$name\" data-program=\"$program\">".$name."</option>";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

The manage seedlot page crashes because the old format for geolocation data was fed to it, and it expected the new geojson format.

This was fixed for the seedlot page, but similar misalignments may still exist on other pages, and will have to be checked carefully. Stay tuned.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
