### PR TITLE
refine cluster shared dir naming for ip address using site (in-house site)

### DIFF
--- a/lib/SGN/Role/Site/Files.pm
+++ b/lib/SGN/Role/Site/Files.pm
@@ -338,11 +338,11 @@ sub uri_for_file {
 sub site_cluster_shared_dir { 
     my $self = shift;
 
-    my $host = $self->req->base; 
-    $host    =~ s/(https?)|[:\/\d+]//g;
+    my $host = $self->req->base;
+    $host    =~ s/(https?)|(:\d+)|\/|://g;
     $host    =~ s/(www\.)//;
     $host    = File::Spec->catdir($self->config->{cluster_shared_tempdir}, $host);
-
+   
     return $host;
 
 }


### PR DESCRIPTION
--fixes site- specific directory creation problem for in-house sites. 


