### PR TITLE
contactform body message includes website

### DIFF
--- a/lib/SGN/Controller/AJAX/Contact.pm
+++ b/lib/SGN/Controller/AJAX/Contact.pm
@@ -52,6 +52,8 @@ sub submit_contact_form_POST : Args(0) {
     my $req = HTTP::Request->new(POST => $server_endpoint);
     $req->header('content-type' => 'application/json');
 
+    $body .= "\n\nSent from website: $website_name";
+    $body .= "\n\nPlease remember to include the contact person's email in any replies which are directed to them. Please include the github.reply email address as a recipient in all messages, so that they are logged with the open ticket.";
     my $post_data = { "title"=>$title, "body"=> $body, "labels"=>[$website_name] };
     $req->content( encode_json $post_data);
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Contact form message includes the name of the website that the message originated from. Also includes a helper message reminding people to include the recipient's email and the github.reply email during email replying.

<!-- If there are relevant issues, link them here: -->
closes #2429 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
