### PR TITLE
Fix Genotype Protocol lists on Download Page

### DIFF
--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -41,7 +41,7 @@ sub breeder_download : Path('/breeders/download/') Args(0) {
 
     if (!$c->user()) {
 	# redirect to login page
-	$c->res->redirect( uri( path => '/usr/login', query => { goto_url => $c->req->uri->path_query } ) );
+	$c->res->redirect( uri( path => '/user/login', query => { goto_url => $c->req->uri->path_query } ) );
 	return;
     }
 

--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -341,7 +341,7 @@ $(document).ready(function() {
       var lo = new CXGN.List();
 
       $('#accession_list2').html(lo.listSelect('genotype_accession_list', [ 'accessions' ], 'select'));
-      get_select_box("genotyping_protocols", "protocol_list");
+      get_select_box("genotyping_protocol", "protocol_list");
 
       $('#genotype').click(function() {
 
@@ -397,6 +397,9 @@ $(document).ready(function() {
       Accessions
     </th>
     <th>
+      Genotyping Protocol
+    </th>
+    <th>
       Action
     </th>
   </tr>
@@ -434,7 +437,7 @@ $(document).ready(function() {
 
       $('#accession_list3').html(lo.listSelect('genotype_qc_accession_list', [ 'accessions' ], 'select'));
       $('#trial_list3').html(lo.listSelect('genotype_trial_list', [ 'trials' ], 'select' ));
-      get_select_box("genotyping_protocols", "protocol_list2", {'id':'protocol_list2_select', 'name':'protocol_list2_select'});
+      get_select_box("genotyping_protocol", "protocol_list2", {'id':'protocol_list2_select', 'name':'protocol_list2_select'});
 
       $('#genotype_qc').click(function() {
 


### PR DESCRIPTION
Description
-----------------------------------------------------
change 'genotyping_protocols' to 'genotyping_protocol' argument in getSelectBox()
Add 'Genotyping Protocol' Header to 'GBS Genotype QC' section

Fixes #2440 


Checklist 
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
