### PR TITLE
Fix listing of genetic maps

### DIFF
--- a/lib/CXGN/BrAPI/v1/GenomeMaps.pm
+++ b/lib/CXGN/BrAPI/v1/GenomeMaps.pm
@@ -54,7 +54,8 @@ has 'status' => (
 =cut
 
 sub list {
-        my $self = shift;
+    my $self = shift;
+    my $inputs = shift;
 	my $page_size = $self->page_size;
 	my $page = $self->page;
 	my $status = $self->status;
@@ -62,7 +63,7 @@ sub list {
 	my $start = $page_size*$page;
 	my $end = $page_size*($page+1)-1;
 
-	my $map_factory = CXGN::Cview::MapFactory->new($self->bcs_schema()->storage->dbh());
+	my $map_factory = CXGN::Cview::MapFactory->new($self->bcs_schema()->storage->dbh(), $inputs->{config});
 
 	my @maps = $map_factory->get_all_maps();
 	my @data;

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -2147,7 +2147,10 @@ sub maps_list_GET {
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $brapi = $self->brapi_module;
 	my $brapi_module = $brapi->brapi_wrapper('GenomeMaps');
-	my $brapi_package_result = $brapi_module->list();
+	my $brapi_package_result = $brapi_module->list({
+        config => $c->config
+    });
+
 	_standard_response_construction($c, $brapi_package_result);
 }
 

--- a/lib/SGN/Controller/Cview.pm
+++ b/lib/SGN/Controller/Cview.pm
@@ -60,7 +60,7 @@ sub index :Path("/cview") :Args(0) {
     
     $c->stash->{template} = '/cview/index.mas';
 
-    my $map_factory = CXGN::Cview::MapFactory->new($c->dbc->dbh, $c);
+    my $map_factory = CXGN::Cview::MapFactory->new($c->dbc->dbh, $c->config);
     my @maps = $map_factory->get_system_maps();
     
     my %map_by_species;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

**The Problem:**

On triticumbase and cassavabase, when listing all of the system genetic maps (https://cassavabase.org/cview/ and in the [new Comparative Map Viewer](https://maps.triticeaetoolbox.org/Map/map_list/)) a Tomato Pachytene Chromosomes map is included in the list.

------

The default SGN CView DB backend for the `CXGN::Cview::MapFactory` was always being used, which has some hard-coded maps for demonstration purposes.

This passes a hashref of the local config properties to the `CXGN::Cview::MapFactory` constructor so the `cview_db_backend` property will be used.



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
