### PR TITLE
listSelect can hide public lists. useful for addToListMenu

### DIFF
--- a/js/source/legacy/CXGN/BreederSearch.js
+++ b/js/source/legacy/CXGN/BreederSearch.js
@@ -451,7 +451,7 @@ function reset_downstream_sections(this_section) {  // clear downstream selects,
 
 function create_list_start(message) {
     var lo = new CXGN.List();
-    var listhtml = lo.listSelect('paste_list', '', message, 'refresh');
+    var listhtml = lo.listSelect('paste_list', '', message, 'refresh', undefined);
     jQuery('#paste_list').html(listhtml);
     jQuery('#paste_list_list_select').change(
       function() {

--- a/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
@@ -37,7 +37,7 @@ function enable_ui() {
 jQuery(document).ready(function ($) {
 
     jQuery('#manage_accessions_populations_new').click(function(){
-        jQuery("#create_population_list_div").html(list.listSelect("create_population_list_div", ["accessions"] ));
+        jQuery("#create_population_list_div").html(list.listSelect("create_population_list_div", ["accessions"], undefined, undefined, undefined ));
         jQuery('#manage_populations_add_population_dialog').modal('show');
     });
 
@@ -139,7 +139,7 @@ jQuery(document).ready(function ($) {
     jQuery(document).on("click", "a[name='manage_populations_add_accessions']", function(){
         population_id = jQuery(this).data('population_id');
         population_name = jQuery(this).data('population_name');
-        jQuery("#add_accession_to_population_list_div").html(list.listSelect("add_accession_to_population_list_div", ["accessions"] ));
+        jQuery("#add_accession_to_population_list_div").html(list.listSelect("add_accession_to_population_list_div", ["accessions"], undefined, undefined, undefined));
         jQuery('#add_accession_population_name').html(population_name);
         jQuery('#manage_populations_add_accessions_dialog').modal('show');
     });
@@ -392,7 +392,7 @@ jQuery(document).ready(function ($) {
         $('#review_found_matches_dialog').modal("hide");
         $('#review_fuzzy_matches_dialog').modal("hide");
         $('#review_absent_dialog').modal("hide");
-        $("#list_div").html(list.listSelect("list_div", ["accessions"] ));
+        $("#list_div").html(list.listSelect("list_div", ["accessions"], undefined, undefined, undefined));
     });
 
     jQuery('#accessions_upload_spreadsheet_format_info').click(function(){

--- a/js/source/legacy/CXGN/BreedersToolbox/AddTrial.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/AddTrial.js
@@ -1339,14 +1339,14 @@ jQuery(document).ready(function ($) {
         $('#add_project_dialog').modal("show");
 
         //add lists to the list select and list of checks select dropdowns.
-        document.getElementById("select_list").innerHTML = list.listSelect("select_list", [ 'accessions' ], '', 'refresh');
-        document.getElementById("select_seedlot_list").innerHTML = list.listSelect("select_seedlot_list", [ 'seedlots' ], 'none', 'refresh');
-        document.getElementById("list_of_checks_section").innerHTML = list.listSelect("list_of_checks_section", [ 'accessions' ], '', 'refresh');
+        document.getElementById("select_list").innerHTML = list.listSelect("select_list", [ 'accessions' ], '', 'refresh', undefined);
+        document.getElementById("select_seedlot_list").innerHTML = list.listSelect("select_seedlot_list", [ 'seedlots' ], 'none', 'refresh', undefined);
+        document.getElementById("list_of_checks_section").innerHTML = list.listSelect("list_of_checks_section", [ 'accessions' ], '', 'refresh', undefined);
 
         //add lists to the list select and list of checks select dropdowns for CRBD.
-        document.getElementById("crbd_list_of_checks_section").innerHTML = list.listSelect("crbd_list_of_checks_section", [ 'accessions' ], "select optional check list", 'refresh');
-        document.getElementById("list_of_unrep_accession").innerHTML = list.listSelect("list_of_unrep_accession", [ 'accessions' ], "Required: e.g. 200", 'refresh');
-        document.getElementById("list_of_rep_accession").innerHTML = list.listSelect("list_of_rep_accession", [ 'accessions' ], "Required: e.g. 119", 'refresh');
+        document.getElementById("crbd_list_of_checks_section").innerHTML = list.listSelect("crbd_list_of_checks_section", [ 'accessions' ], "select optional check list", 'refresh', undefined);
+        document.getElementById("list_of_unrep_accession").innerHTML = list.listSelect("list_of_unrep_accession", [ 'accessions' ], "Required: e.g. 200", 'refresh', undefined);
+        document.getElementById("list_of_rep_accession").innerHTML = list.listSelect("list_of_rep_accession", [ 'accessions' ], "Required: e.g. 119", 'refresh', undefined);
 
         //add a blank line to location select dropdown that dissappears when dropdown is opened
         $("#add_project_location").prepend("<option value=''></option>").val('');

--- a/js/source/legacy/CXGN/BreedersToolbox/Crosses.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/Crosses.js
@@ -66,10 +66,10 @@ jQuery(document).ready(function($) {
         });
 
         var lo = new CXGN.List();
-        $('#polycross_accession_list').html(lo.listSelect('polycross_accessions', ['accessions'], 'select'));
-        $('#reciprocal_accession_list').html(lo.listSelect('reciprocal_accessions', ['accessions'], 'select'));
-        $('#maternal_accession_list').html(lo.listSelect('maternal_accessions', ['accessions'], 'select'));
-        $('#paternal_accession_list').html(lo.listSelect('paternal_accessions', ['accessions'], 'select'));
+        $('#polycross_accession_list').html(lo.listSelect('polycross_accessions', ['accessions'], 'select', undefined, undefined));
+        $('#reciprocal_accession_list').html(lo.listSelect('reciprocal_accessions', ['accessions'], 'select', undefined, undefined));
+        $('#maternal_accession_list').html(lo.listSelect('maternal_accessions', ['accessions'], 'select', undefined, undefined));
+        $('#paternal_accession_list').html(lo.listSelect('paternal_accessions', ['accessions'], 'select', undefined, undefined));
 
         get_select_box('crosses', 'upload_crosses_select_crossingtrial_3', {'id':'upload_crosses_select_crossingtrial_3_sel', 'name':'upload_crosses_select_crossingtrial_3_sel', 'multiple':0});
         get_select_box('crosses', 'upload_crosses_select_crossingtrial_4', {'id':'crossing_trial', 'name':'crossing_trial', 'multiple':0});

--- a/js/source/legacy/CXGN/BreedersToolbox/FieldBook.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/FieldBook.js
@@ -30,7 +30,7 @@ jQuery(document).ready(function($) {
 
     jQuery('#create_new_trait_file_link').click(function() {
         var list = new CXGN.List();
-        var trait_lists = list.listSelect('select_list', ['traits'], 'Select a list');
+        var trait_lists = list.listSelect('select_list', ['traits'], 'Select a list', undefined, undefined);
         jQuery('#select_list_div').html(trait_lists);
         if (document.getElementById("html_select_traits_for_trait_file")) {
             show_list_counts('trait_select_count', document.getElementById("html_select_traits_for_trait_file").length);

--- a/js/source/legacy/CXGN/BreedersToolbox/GenotypingTrial.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/GenotypingTrial.js
@@ -100,7 +100,7 @@ jQuery(document).ready(function ($) {
 
     jQuery('#genotyping_trial_dialog').on('show.bs.modal', function (e) {
         var l = new CXGN.List();
-        var html = l.listSelect('accession_select_box', [ 'accessions', 'plots', 'plants', 'tissue_samples' ]);
+        var html = l.listSelect('accession_select_box', [ 'accessions', 'plots', 'plants', 'tissue_samples' ], undefined, undefined, undefined);
         jQuery('#accession_select_box_span').html(html);
     })
 

--- a/js/source/legacy/CXGN/BreedersToolbox/MarkerSet.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/MarkerSet.js
@@ -4,10 +4,10 @@ jQuery(document).ready(function (){
     get_select_box('genotyping_protocol','selected_protocol', {'empty':1});
 
     var lo = new CXGN.List();
-    jQuery('#selected_marker_set1').html(lo.listSelect('selected_marker_set1', ['markers'], 'Select a marker set', 'refresh'));
+    jQuery('#selected_marker_set1').html(lo.listSelect('selected_marker_set1', ['markers'], 'Select a marker set', 'refresh', undefined));
 
     var list = new CXGN.List();
-    jQuery('#selected_marker_set2').html(list.listSelect('selected_marker_set2', ['markers'], 'Select a marker set', 'refresh'));
+    jQuery('#selected_marker_set2').html(list.listSelect('selected_marker_set2', ['markers'], 'Select a marker set', 'refresh', undefined));
 
 
     jQuery("#save_marker_set").click(function(){

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -649,7 +649,7 @@ CXGN.List.prototype = {
            provided text as description
     */
 
-    listSelect: function(div_name, types, empty_element, refresh) {
+    listSelect: function(div_name, types, empty_element, refresh, hide_public_lists) {
         var lists = new Array();
         var public_lists = new Array();
 
@@ -682,9 +682,11 @@ CXGN.List.prototype = {
         for (var n=0; n<lists.length; n++) {
             html += '<option value='+lists[n][0]+'>'+lists[n][1]+'</option>';
         }
-        html += '<option disabled>--------PUBLIC LISTS BELOW--------</option>';
-        for (var n=0; n<public_lists.length; n++) {
-            html += '<option value='+public_lists[n][0]+'>'+public_lists[n][1]+'</option>';
+        if (hide_public_lists == undefined) {
+            html += '<option disabled>--------PUBLIC LISTS BELOW--------</option>';
+            for (var n=0; n<public_lists.length; n++) {
+                html += '<option value='+public_lists[n][0]+'>'+public_lists[n][1]+'</option>';
+            }
         }
 
         if (refresh) {
@@ -1065,9 +1067,9 @@ function pasteListMenu (div_name, menu_div, button_name, list_type) {
         button_name = 'paste';
     }
     if (list_type){
-        html = lo.listSelect(div_name, [list_type]);
+        html = lo.listSelect(div_name, [list_type], undefined, undefined, undefined);
     }else {
-        html = lo.listSelect(div_name);
+        html = lo.listSelect(div_name, undefined, undefined, undefined, undefined);
     }
     html = html + '<button class="btn btn-info btn-sm" type="button" value="'+button_name+'" onclick="javascript:pasteList(\''+div_name+'\')" >'+button_name+'</button>';
 
@@ -1097,7 +1099,7 @@ function pasteList(div_name) {
 function refreshListSelect(div_name, types) {
     var lo = new CXGN.List();
     var types = types.split(",");
-    document.getElementById(div_name).innerHTML = (lo.listSelect(div_name, types, 'Options refreshed.', 'refresh'));
+    document.getElementById(div_name).innerHTML = (lo.listSelect(div_name, types, 'Options refreshed.', 'refresh', undefined));
     //console.log("List options refreshed!");
 }
 
@@ -1151,7 +1153,7 @@ function addToListMenu(listMenuDiv, dataDiv, options) {
     html += '</div><div class="col-sm-6" style="margin-left:0px; padding-left:0px; margin-right:0px; padding-right:0px;"><input type="hidden" id="'+dataDiv+'_addition_type" value="'+addition_type+'" /><input type="hidden" id="'+dataDiv+'_list_type" value="'+type+'" />';
     html += '<input class="btn btn-primary btn-sm" id="'+dataDiv+'_add_to_new_list" type="button" value="add to new list" /></div></div><br />';
 
-    html += '<div class="row"><div class="col-sm-6" style="margin-right:0px; padding-right:0px;">'+lo.listSelect(dataDiv, [ type ]);
+    html += '<div class="row"><div class="col-sm-6" style="margin-right:0px; padding-right:0px;">'+lo.listSelect(dataDiv, [ type ], undefined, undefined, 1);
 
     html += '</div><div class="col-sm-6" style="margin-left:0px; padding-left:0px; margin-right:0px; padding-right:0px;"><input class="btn btn-primary btn-sm" id="'+dataDiv+'_button" type="button" value="add to list" /></div></div>';
 
@@ -1242,7 +1244,7 @@ function getData(id, selectText) {
 /* deprecated */
 function addTextToListMenu(div) {
     var lo = new CXGN.List();
-    var html = lo.listSelect(div);
+    var html = lo.listSelect(div, undefined, undefined, undefined, undefined);
     html = html + '<input id="'+div+'_button" type="button" value="add to list" />';
 
     document.write(html);
@@ -1258,7 +1260,7 @@ function addTextToListMenu(div) {
 /* deprecated */
 function addSelectToListMenu(div) {
     var lo = new CXGN.List();
-    var html = lo.listSelect(div);
+    var html = lo.listSelect(div, undefined, undefined, undefined, undefined);
     html = html + '<input id="'+div+'_button" type="button" value="add to list" />';
 
     document.write(html);

--- a/js/source/legacy/CXGN/Trial.js
+++ b/js/source/legacy/CXGN/Trial.js
@@ -100,7 +100,7 @@ function open_create_DataCollector_dialog() {
     //jQuery('#working').dialog("open");
     jQuery('#working_modal').modal("show");
     var list = new CXGN.List();
-    jQuery("#trait_list_dc").html(list.listSelect("trait_list", [ 'traits' ]));
+    jQuery("#trait_list_dc").html(list.listSelect("trait_list", [ 'traits' ], undefined, undefined, undefined));
     //jQuery('#working').dialog("close");
     jQuery('#working_modal').modal("hide");
     jQuery('#create_DataCollector_dialog').dialog("open");

--- a/js/source/legacy/solGS/cluster.js
+++ b/js/source/legacy/solGS/cluster.js
@@ -542,7 +542,7 @@ jQuery(document).ready( function() {
     
         var list = new CXGN.List();
         
-        var listMenu = list.listSelect("cluster_genotypes", ['accessions','plots', 'trials']);
+        var listMenu = list.listSelect("cluster_genotypes", ['accessions','plots', 'trials'], undefined, undefined, undefined);
 
 	var dType = ['accessions', 'trials'];
 	var dMenu = solGS.getDatasetsMenu(dType);

--- a/js/source/legacy/solGS/listTypeSelectionPopulation.js
+++ b/js/source/legacy/solGS/listTypeSelectionPopulation.js
@@ -15,7 +15,7 @@ JSAN.use("jquery.blockUI");
 
 jQuery(document).ready( function() {
     var list = new CXGN.List();
-    var listMenu = list.listSelect("list_type_selection_pops", ["accessions"]);
+    var listMenu = list.listSelect("list_type_selection_pops", ["accessions"], undefined, undefined, undefined);
     var relevant =[]; 	
         
     if (listMenu.match(/option/) != null) {

--- a/js/source/legacy/solGS/listTypeTrainingPopulation.js
+++ b/js/source/legacy/solGS/listTypeTrainingPopulation.js
@@ -15,7 +15,7 @@ jQuery(document).ready( function() {
        
     var list = new CXGN.List();
         
-    var listMenu = list.listSelect("list_type_training_pops", ['plots', 'trials']);
+    var listMenu = list.listSelect("list_type_training_pops", ['plots', 'trials'], undefined, undefined, undefined);
        
     if (listMenu.match(/option/) != null) {           
         jQuery("#list_type_training_pops_list").append(listMenu);

--- a/js/source/legacy/solGS/pca.js
+++ b/js/source/legacy/solGS/pca.js
@@ -14,7 +14,7 @@ jQuery(document).ready( function() {
     
         var list = new CXGN.List();
         
-        var listMenu = list.listSelect("pca_genotypes", ['accessions', 'trials']);
+        var listMenu = list.listSelect("pca_genotypes", ['accessions', 'trials'], undefined, undefined, undefined);
        
 	if (listMenu.match(/option/) != null) {
             

--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -1279,7 +1279,7 @@ function showLoadOption() {
     document.getElementById('design_label').style.display = "inline";
     document.getElementById('design_list').style.display = "inline";
     var lo = new CXGN.List();
-    $('#design_list').html(lo.listSelect('design_list', ['label_design'], 'Select a saved design', 'refresh'));
+    $('#design_list').html(lo.listSelect('design_list', ['label_design'], 'Select a saved design', 'refresh', undefined));
     $('#design_list_list_select').change(
       function() {
         disable_ui();

--- a/mason/breeders_toolbox/accessions/find_trials_by_accessions.mas
+++ b/mason/breeders_toolbox/accessions/find_trials_by_accessions.mas
@@ -68,7 +68,7 @@ jQuery('#shared_trials_2_lists').hide();
 
     var lo = new CXGN.List();
 
-    jQuery('#accession_list').html(lo.listSelect('accession_list', [ 'accessions' ], 'select'));
+    jQuery('#accession_list').html(lo.listSelect('accession_list', [ 'accessions' ], 'select', undefined, undefined));
 
     addToListMenu('c1_to_list_menu', 'c1_data', {
 		selectText: true,

--- a/mason/breeders_toolbox/cross_wishlist.mas
+++ b/mason/breeders_toolbox/cross_wishlist.mas
@@ -261,8 +261,8 @@ jQuery(document).ready(function($) {
 
     jQuery("#create_cross_wishlist").click(function() {
         jQuery("#create_cross_wishlist_dialog").modal("show");
-        jQuery("#female_accession_list_div").html(lo.listSelect('female_accession_list_div', ["accessions"] ));
-        jQuery("#male_accession_list_div").html(lo.listSelect('male_accession_list_div', ["accessions"] ));
+        jQuery("#female_accession_list_div").html(lo.listSelect('female_accession_list_div', ["accessions"], undefined, undefined, undefined ));
+        jQuery("#male_accession_list_div").html(lo.listSelect('male_accession_list_div', ["accessions"], undefined, undefined, undefined ));
         var female_accessions = lo.getList(jQuery('#female_accession_list_div_list_select').val());
         var male_accessions = lo.getList(jQuery('#male_accession_list_div_list_select').val());
 

--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -138,10 +138,10 @@ $(document).ready(function() {
 
     var lo = new CXGN.List();
 
-    $('#accession_list').html(lo.listSelect('accession_list', [ 'accessions' ], 'select'));
-    $('#trial_list').html(lo.listSelect('trial_list', [ 'trials' ], 'select' ));
-    $('#trait_list').html(lo.listSelect('trait_list', [ 'traits' ], 'select'  ));
-    $('#trial_metadata_list').html(lo.listSelect('trial_metadata_list', ['trials'], 'select'));
+    $('#accession_list').html(lo.listSelect('accession_list', [ 'accessions' ], 'select', undefined, undefined));
+    $('#trial_list').html(lo.listSelect('trial_list', [ 'trials' ], 'select', undefined, undefined ));
+    $('#trait_list').html(lo.listSelect('trait_list', [ 'traits' ], 'select', undefined, undefined  ));
+    $('#trial_metadata_list').html(lo.listSelect('trial_metadata_list', ['trials'], 'select', undefined, undefined));
 
     $('#metadata').click(function() { 
       var trial_list_id = $('#trial_metadata_list_list_select').val();
@@ -262,7 +262,7 @@ $(document).ready(function() {
 
     var lo = new CXGN.List();
 
-    $('#accession_list4').html(lo.listSelect('pedigree_accession_list', [ 'accessions' ], 'select'));
+    $('#accession_list4').html(lo.listSelect('pedigree_accession_list', [ 'accessions' ], 'select', undefined, undefined));
 
     $('#pedigree').click(function() {
 
@@ -340,7 +340,7 @@ $(document).ready(function() {
 
       var lo = new CXGN.List();
 
-      $('#accession_list2').html(lo.listSelect('genotype_accession_list', [ 'accessions' ], 'select'));
+      $('#accession_list2').html(lo.listSelect('genotype_accession_list', [ 'accessions' ], 'select', undefined, undefined));
       get_select_box("genotyping_protocol", "protocol_list");
 
       $('#genotype').click(function() {
@@ -435,8 +435,8 @@ $(document).ready(function() {
 
       var lo = new CXGN.List();
 
-      $('#accession_list3').html(lo.listSelect('genotype_qc_accession_list', [ 'accessions' ], 'select'));
-      $('#trial_list3').html(lo.listSelect('genotype_trial_list', [ 'trials' ], 'select' ));
+      $('#accession_list3').html(lo.listSelect('genotype_qc_accession_list', [ 'accessions' ], 'select', undefined, undefined));
+      $('#trial_list3').html(lo.listSelect('genotype_trial_list', [ 'trials' ], 'select', undefined, undefined ));
       get_select_box("genotyping_protocol", "protocol_list2", {'id':'protocol_list2_select', 'name':'protocol_list2_select'});
 
       $('#genotype_qc').click(function() {

--- a/mason/breeders_toolbox/manage_plot_phenotyping.mas
+++ b/mason/breeders_toolbox/manage_plot_phenotyping.mas
@@ -62,7 +62,7 @@ $type_name => "plot"
           function pasteTraitListMenu (div_name, menu_div, button_name) {
               var list = new CXGN.List();
               var html='';
-              html = list.listSelect(div_name, ['traits']);
+              html = list.listSelect(div_name, ['traits'], undefined, undefined, undefined);
               html = html + '<button class="btn btn-info btn-sm" type="button" id="paste_button_id" value="'+button_name+'" onclick="javascript:pasteTraitList(\''+div_name+'\')" >'+button_name+'</button>';
               jQuery('#'+menu_div).html(html);
           }

--- a/mason/breeders_toolbox/manage_trial_phenotyping.mas
+++ b/mason/breeders_toolbox/manage_trial_phenotyping.mas
@@ -95,7 +95,7 @@ $trial_name
                         function pasteTraitListMenu (div_name, menu_div, button_name) {
                             var list = new CXGN.List();
                             var html='';
-                            html = list.listSelect(div_name, ['traits']);
+                            html = list.listSelect(div_name, ['traits'], undefined, undefined, undefined);
                             html = html + '<button class="btn btn-info btn-sm" type="button" id="paste_button_id" value="'+button_name+'" onclick="javascript:pasteTraitList(\''+div_name+'\')" >'+button_name+'</button>';
                             jQuery('#'+menu_div).html(html);
                         }

--- a/mason/breeders_toolbox/selection_index.mas
+++ b/mason/breeders_toolbox/selection_index.mas
@@ -156,7 +156,7 @@ $trial_name => undef
         jQuery('#ranking_formula').html("<center><i>Select a trial, then pick traits and weights (or load a saved formula).</i></center>");
         get_select_box('trials', 'select_trial_for_selection_index', { 'name' : 'html_select_trial_for_selection_index', 'id' : 'html_select_trial_for_selection_index' , 'empty' : 1 });
         var lo = new CXGN.List();
-        jQuery('#sin_list').html(lo.listSelect('sin_list', ['dataset'], 'Select a formula', 'refresh'));
+        jQuery('#sin_list').html(lo.listSelect('sin_list', ['dataset'], 'Select a formula', 'refresh', undefined));
         jQuery('#sin_list_list_select').change(
           function() {
             load_sin();

--- a/mason/breeders_toolbox/trial/create_datacollector_dialog.mas
+++ b/mason/breeders_toolbox/trial/create_datacollector_dialog.mas
@@ -51,7 +51,7 @@ jQuery(document).ready(function() {
   jQuery('#create_DataCollector_link').click( function () {
     jQuery('#download_datacollector_dialog').modal("show");
     var list = new CXGN.List();
-    jQuery("#trait_list_dc").html(list.listSelect("trait_list_dc", [ 'traits' ]));
+    jQuery("#trait_list_dc").html(list.listSelect("trait_list_dc", [ 'traits' ], undefined, undefined, undefined));
   });
   
   jQuery('#create_DataCollector_submit_button').click( function () {

--- a/mason/breeders_toolbox/trial/create_spreadsheet_dialog.mas
+++ b/mason/breeders_toolbox/trial/create_spreadsheet_dialog.mas
@@ -100,7 +100,7 @@ jQuery(document).ready(function() {
     jQuery("[name='create_spreadsheet_link']").click( function () {
         jQuery('#create_spreadsheet_dialog').modal("show");
         var list = new CXGN.List();
-        jQuery("#trait_list_spreadsheet").html(list.listSelect("trait_list_spreadsheet", [ 'traits' ]));
+        jQuery("#trait_list_spreadsheet").html(list.listSelect("trait_list_spreadsheet", [ 'traits' ], undefined, undefined, undefined));
     });
 
     jQuery(document).on('change', '#create_spreadsheet_data_level', function(){

--- a/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
@@ -153,7 +153,7 @@ jQuery(document).ready(function() {
     jQuery("#trial_download_layout_button").click( function () {
         show_available_columns_TrialLayout('plots');
         var lo = new CXGN.List();
-        jQuery('#create_fieldbook_with_trait_list_TrialLayout').html(lo.listSelect('create_fieldbook_with_trait_list_select_TrialLayout', [ 'traits' ], 'select'));
+        jQuery('#create_fieldbook_with_trait_list_TrialLayout').html(lo.listSelect('create_fieldbook_with_trait_list_select_TrialLayout', [ 'traits' ], 'select', undefined, undefined));
         jQuery('#accession_average_performance').css("display", "inline-block");
         jQuery('#selected_columns_well').css("display", "inline-block");
         jQuery('#management_factore').css("display", "inline-block");
@@ -168,7 +168,7 @@ jQuery(document).ready(function() {
         jQuery("#create_fieldbook_data_level_TrialFieldMapLayout").prop('disabled', 'disabled');
         show_available_columns_TrialFieldMapLayout('plots');
         var lo = new CXGN.List();
-        jQuery('#create_fieldbook_with_trait_list_TrialFieldMapLayout').html(lo.listSelect('create_fieldbook_with_trait_list_select_TrialFieldMapLayout', [ 'traits' ], 'select'));
+        jQuery('#create_fieldbook_with_trait_list_TrialFieldMapLayout').html(lo.listSelect('create_fieldbook_with_trait_list_select_TrialFieldMapLayout', [ 'traits' ], 'select', undefined, undefined));
         jQuery('#accession_average_performance').css("display", "none");
         jQuery('#selected_columns_well').css("display", "none");
         jQuery('#create_fieldbook_dialog_TrialFieldMapLayout').modal('show');
@@ -178,7 +178,7 @@ jQuery(document).ready(function() {
     jQuery("[name='create_fieldbook_link']").click( function () {
         show_available_columns_Fieldbook('plots');
         var lo = new CXGN.List();
-        jQuery('#create_fieldbook_with_trait_list_Fieldbook').html(lo.listSelect('create_fieldbook_with_trait_list_select_Fieldbook', [ 'traits' ], 'select'));
+        jQuery('#create_fieldbook_with_trait_list_Fieldbook').html(lo.listSelect('create_fieldbook_with_trait_list_select_Fieldbook', [ 'traits' ], 'select', undefined, undefined));
         jQuery('#create_fieldbook_dialog_Fieldbook').modal('show');
         show_fieldbook_treatments_Fieldbook();
     });

--- a/mason/breeders_toolbox/trial/download_trials_phenotypes_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_trials_phenotypes_dialog.mas
@@ -130,10 +130,10 @@ jQuery(document).ready(function() {
     var opened_already = 0;
     jQuery('#trials_download_phenotypes_button').click( function () {
         if (opened_already == 0) {
-            jQuery("#download_trials_phenotypes_traits").append(list.listSelect("download_trials_phenotypes_traits", [ 'traits' ], 'None' ));
-            jQuery("#download_trials_phenotypes_accessions").append(list.listSelect("download_trials_phenotypes_accessions", [ 'accessions' ], 'None' ));
-            jQuery("#download_trials_phenotypes_plots").append(list.listSelect("download_trials_phenotypes_plots", [ 'plots' ], 'None' ));
-            jQuery("#download_trials_phenotypes_plants").append(list.listSelect("download_trials_phenotypes_plants", [ 'plants' ], 'None' ));
+            jQuery("#download_trials_phenotypes_traits").append(list.listSelect("download_trials_phenotypes_traits", [ 'traits' ], 'None', undefined, undefined));
+            jQuery("#download_trials_phenotypes_accessions").append(list.listSelect("download_trials_phenotypes_accessions", [ 'accessions' ], 'None', undefined, undefined));
+            jQuery("#download_trials_phenotypes_plots").append(list.listSelect("download_trials_phenotypes_plots", [ 'plots' ], 'None', undefined, undefined));
+            jQuery("#download_trials_phenotypes_plants").append(list.listSelect("download_trials_phenotypes_plants", [ 'plants' ], 'None', undefined, undefined));
             opened_already = 1;
         }
         jQuery('#download_trials_phenotypes_dialog').modal("show");

--- a/mason/search/genotype.mas
+++ b/mason/search/genotype.mas
@@ -67,7 +67,7 @@ jQuery(document).ready(function (){
     var lo = new CXGN.List();
 
     get_select_box('datasets','selected_dataset');
-    jQuery('#selected_markerset').html(lo.listSelect('selected_markerset', ['markers'], 'Select a marker set'));
+    jQuery('#selected_markerset').html(lo.listSelect('selected_markerset', ['markers'], 'Select a marker set', undefined, undefined));
 
     jQuery("#search_genotypes_accessions").click(function(){
 

--- a/mason/search/stocks_using_genotypes.mas
+++ b/mason/search/stocks_using_genotypes.mas
@@ -67,7 +67,7 @@ jQuery(document).ready(function (){
     var lo = new CXGN.List();
 
     get_select_box('datasets','selected_dataset');
-    jQuery('#selected_markerset').html(lo.listSelect('selected_markerset', ['markers'], 'Select a marker set'));
+    jQuery('#selected_markerset').html(lo.listSelect('selected_markerset', ['markers'], 'Select a marker set', undefined, undefined));
 
     jQuery("#search_genotypes_accessions").click(function(){
 

--- a/mason/search/traits.mas
+++ b/mason/search/traits.mas
@@ -110,7 +110,7 @@ jQuery(document).ready(function () {
     get_select_box('trait_variable_ontologies', 'trait_search_ontology_select', { 'name' : 'trait_search_ontology_select_id', 'cvprop_type_name':JSON.stringify(['trait_ontology','composed_trait_ontology','attribute_ontology']) });
 
     var lo = new CXGN.List();
-    jQuery('#trait_search_list_select').html(lo.listSelect('trait_search_list_select', [ 'traits' ], 'Leave blank to see all traits'));
+    jQuery('#trait_search_list_select').html(lo.listSelect('trait_search_list_select', [ 'traits' ], 'Leave blank to see all traits', undefined, undefined));
 
     jQuery(document).on('change', '#trait_search_list_select', function(){
         _draw_trait_search_result_table();

--- a/mason/tools/graphicalfiltering/index.mas
+++ b/mason/tools/graphicalfiltering/index.mas
@@ -126,7 +126,7 @@ $ajaxRequestString => ""
     $('#select_div').show();
 
     // set up list
-    var filter_list_select_html = list.listSelect('filter', ['trials'/*,'plots','plants'*/], 'Choose a List:');
+    var filter_list_select_html = list.listSelect('filter', ['trials'/*,'plots','plants'*/], 'Choose a List:', undefined, undefined);
     $('#filter_list_select_container').html(filter_list_select_html);
     $('#filter_list_select>option:first-of-type').prop('disabled', true);
     

--- a/mason/tools/trial_comparison/index.mas
+++ b/mason/tools/trial_comparison/index.mas
@@ -70,7 +70,7 @@
   $(document).ready(function(){
     if (isLoggedIn()) {
       list = new CXGN.List();
-      var select_html = list.listSelect('trials', ['trials'], ' ');
+      var select_html = list.listSelect('trials', ['trials'], ' ', undefined, undefined);
       $('#trials_list_select_container').html(select_html);
       if (d3.select('#trials_list_select').selectAll("option").size()<2){
         d3.select('#trials_list_select').html("<option>No trial lists! (Create one using the wizard.)</option>");

--- a/mason/util/styleguide.mas
+++ b/mason/util/styleguide.mas
@@ -64,7 +64,7 @@
   &lt;div id="select_div_id"&gt;&lt;/div&gt;
   &lt;script type="text/javascript"&gt;
     var list_obj = new CXGN.List();
-    var listhtml = list_obj.listSelect('select_div_id', ['accessions'], "Select an Accession List");
+    var listhtml = list_obj.listSelect('select_div_id', ['accessions'], "Select an Accession List", undefined, undefined);
     jQuery('#select_div_id').html(listhtml);
   &lt;/script&gt;
 </pre>
@@ -73,7 +73,7 @@
 <div id="select_div_id"></div>
 <script type="text/javascript">
   var lo = new CXGN.List();
-  var listhtml = lo.listSelect('select_div_id', ['accessions'], "Select an Accession List");
+  var listhtml = lo.listSelect('select_div_id', ['accessions'], "Select an Accession List", undefined, undefined);
   jQuery('#select_div_id').html(listhtml);
 </script>
 <hr>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The public lists needed to be hidden in the addToListMenu interface.
Standardizes the listSelect to include all passed parameters in all uses.

<!-- If there are relevant issues, link them here: -->
closes #1557 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
