### PR TITLE
Fixes cookie popup expiration and path

### DIFF
--- a/mason/cookie_popup.mas
+++ b/mason/cookie_popup.mas
@@ -25,7 +25,9 @@
     jQuery(document).ready(function(){
 
         jQuery('#cookie_agree_submit').click( function () {
-            jQuery.cookie("cookies_approved", "1", { expires: 1000000000 } );
+            var expDate = new Date();
+            expDate.setTime(expDate.getTime() + (50000 * 60 * 1000)); //about 30 days
+            jQuery.cookie("cookies_approved", "1", { expires: expDate, path: '/' } );
             jQuery('#cookie_popup_content_div').html('<div class="panel panel-success"><div class="panel-body bg-success"><center><h3>Thank you :-)</h3></center></div></div>');
             setTimeout(function() {
                 jQuery('#cookie_popup').hide('slow');


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The cookie popup will now expire in 30 days and is set to the browser's global path.

<!-- If there are relevant issues, link them here: -->
closes #2464 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
