### PR TITLE
Stock detail page genotype data table is asynchronous

### DIFF
--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -32,6 +32,7 @@ use Scalar::Util 'reftype';
 use CXGN::BreedersToolbox::StocksFuzzySearch;
 use CXGN::Stock::RelatedStocks;
 use CXGN::BreederSearch;
+use CXGN::Genotype::Search;
 
 use Bio::Chado::Schema;
 
@@ -1790,6 +1791,38 @@ sub get_stock_for_tissue:Chained('/stock/get_stock') PathPart('datatables/stock_
 
     $c->stash->{rest}={data=>\@stocks};
 
+}
+
+sub get_stock_datatables_genotype_data : Chained('/stock/get_stock') :PathPart('datatables/genotype_data') : ActionClass('REST') { }
+
+sub get_stock_datatables_genotype_data_GET  {
+    my $self = shift;
+    my $c = shift;
+    my $stock_id = $c->stash->{stock_row}->stock_id();
+
+    my $schema = $c->dbic_schema("Bio::Chado::Schema", 'sgn_chado');
+
+    my $genotypes_search = CXGN::Genotype::Search->new({
+        bcs_schema=>$schema,
+        accession_list=>[$stock_id],
+        genotypeprop_hash_select=>[],
+        protocolprop_top_key_select=>[],
+        protocolprop_marker_hash_select=>[]
+    });
+    my ($total_count, $genotypes) = $genotypes_search->get_genotype_info();
+
+    my @result;
+    foreach (@$genotypes){
+        push @result, [
+            '<a href = "/breeders_toolbox/trial/'.$_->{genotypingDataProjectDbId}.'">'.$_->{genotypingDataProjectName}.'</a>',
+            $_->{genotypingDataProjectDescription},
+            $_->{analysisMethod},
+            $_->{genotypeDescription},
+            '<a href="/stock/'.$stock_id.'/genotypes?genotypeprop_id='.$_->{markerProfileDbId}.'">Download</a>'
+        ];
+    }
+
+    $c->stash->{rest} = {data => \@result};
 }
 
 =head2 make_stock_obsolete

--- a/lib/SGN/Controller/Stock.pm
+++ b/lib/SGN/Controller/Stock.pm
@@ -264,7 +264,6 @@ sub view_stock : Chained('get_stock') PathPart('view') Args(0) {
             pubs      => $pubs,
             members_phenotypes => $c->stash->{members_phenotypes},
             direct_phenotypes  => $c->stash->{direct_phenotypes},
-            direct_genotypes   => $c->stash->{direct_genotypes},
             has_qtl_data   => $c->stash->{has_qtl_data},
             cview_tmp_dir  => $cview_tmp_dir,
             cview_basepath => $c->get_conf('basepath'),
@@ -500,20 +499,9 @@ sub get_stock_extended_info : Private {
     my ($members_phenotypes, $has_members_genotypes)  = (undef, undef); #$stock ? $self->_stock_members_phenotypes( $c->stash->{stock_row} ) : undef;
     $c->stash->{members_phenotypes} = $members_phenotypes;
 
-    my $genotypes_search = CXGN::Genotype::Search->new({
-        bcs_schema=>$self->schema,
-        accession_list=>[$c->stash->{stock_row}->stock_id],
-        genotypeprop_hash_select=>[],
-        protocolprop_top_key_select=>[],
-        protocolprop_marker_hash_select=>[]
-    });
-    my ($total_count, $genotypes) = $genotypes_search->get_genotype_info();
-    $c->stash->{direct_genotypes} = $genotypes;
-
     my $stock_type;
     $stock_type = $stock->get_object_row->type->name if $stock->get_object_row;
     if ( ( grep { /^$stock_type/ } ('f2 population', 'backcross population') ) &&  $members_phenotypes && $has_members_genotypes ) { $c->stash->{has_qtl_data} = 1 ; }
-
 }
 
 ############## HELPER METHODS ######################3

--- a/lib/SGN/Controller/Stock.pm
+++ b/lib/SGN/Controller/Stock.pm
@@ -354,8 +354,8 @@ sub download_genotypes : Chained('get_stock') PathPart('genotypes') Args(0) {
             my $protocol_full = $g->{selected_protocol_hash};
             my $project_name = $g->{genotypingDataProjectName};
             my $marker_info = $protocol_full->{markers};
-            print STDERR Dumper $protocol_full;
-            print STDERR Dumper $marker_info;
+            #print STDERR Dumper $protocol_full;
+            #print STDERR Dumper $marker_info;
             my $stock_name = $g->{stock_name};
             my $stock_type_name = $g->{stock_type_name};
             my $synonym_string = join ',', @{$g->{synonyms}};
@@ -503,6 +503,9 @@ sub get_stock_extended_info : Private {
     my $genotypes_search = CXGN::Genotype::Search->new({
         bcs_schema=>$self->schema,
         accession_list=>[$c->stash->{stock_row}->stock_id],
+        genotypeprop_hash_select=>[],
+        protocolprop_top_key_select=>[],
+        protocolprop_marker_hash_select=>[]
     });
     my ($total_count, $genotypes) = $genotypes_search->get_genotype_info();
     $c->stash->{direct_genotypes} = $genotypes;

--- a/mason/page/detail_page_2_col_section.mas
+++ b/mason/page/detail_page_2_col_section.mas
@@ -57,7 +57,6 @@ $new_locus_link => undef
 $allele_div => undef
 $is_owner => undef
 $map_html => undef
-$direct_genotypes => {}
 $has_pedigree => undef
 $image_ids => undef
 $related_image_ids => undef
@@ -183,7 +182,7 @@ $sample_observation_unit_type_name => undef
                                 <& /stock/traits.mas, stock_id => $stock_id &>
 % } #End stock_traits_section
 % if ($info_section_id eq 'stock_genotypes_section'){
-                                <& /stock/direct_genotypes.mas, stock_id => $stock_id, map_html => $map_html, direct_genotypes => $direct_genotypes &>
+                                <& /stock/direct_genotypes.mas, stock_id => $stock_id, map_html => $map_html &>
 % } #End stock_genotypes_section
 % if ($info_section_id eq 'stock_pedigree_section'){
                                 <&| /page/info_section.mas, title=>"Pedigree and Descendants" , collapsible=> 1, collapsed=>0 &>

--- a/mason/stock/direct_genotypes.mas
+++ b/mason/stock/direct_genotypes.mas
@@ -1,12 +1,11 @@
 <%args>
 $stock_id
 $map_html => undef
-$direct_genotypes => {}
 </%args>
 
 % print $map_html;
 
-<table class="table table-hover table-bordered">
+<table class="table table-hover table-bordered" id="stock_direct_genotypes_datatable">
     <thead>
         <tr>
             <th>Genotyping Data Project Name</th>
@@ -16,13 +15,19 @@ $direct_genotypes => {}
             <th>Download</th>
         </tr>
     </thead>
-    <tbody>
-
-% foreach (@$direct_genotypes){
-        <tr>
-            <td><a href="/breeders_toolbox/trial/<% $_->{genotypingDataProjectDbId} %>"><% $_->{genotypingDataProjectName} %></a></td><td><% $_->{genotypingDataProjectDescription} %></td><td><% $_->{analysisMethod} %></td><td><% $_->{genotypeDescription} %></td><td><a href="/stock/<% $stock_id %>/genotypes?genotypeprop_id=<% $_->{markerProfileDbId} %>">Download</a></td>
-        </tr>
-% }
-
-    </tbody>
 </table>
+
+<script>
+
+jQuery(document).ready(function () {
+
+    jQuery('#stock_genotypes_section_onswitch').one("click", function() {
+        var stock_genotypes_table = jQuery('#stock_direct_genotypes_datatable').DataTable({
+            'ajax': '/stock/<% $stock_id %>/datatables/genotype_data',
+            "scrollX": true
+        });
+    });
+
+});
+
+</script>

--- a/mason/stock/index.mas
+++ b/mason/stock/index.mas
@@ -137,8 +137,7 @@ my $direct_phenotypes = $stockref->{direct_phenotypes} || undef;
 # get all phenotypes of subjects
 my $members_phenotypes = $stockref->{members_phenotypes};
 my $p_download_link = '<a class="btn btn-sm btn-default" style="margin:3px" target="_blank" href = "/breeders/trials/phenotype/download?format=csv&timestamp=1&dataLevel=all&'.$type_name.'_list=['.$stock_id.']&search_type=complete&">Download All Phenotypes</a>';
-my $direct_genotypes = $stockref->{direct_genotypes};
-my $g_download_link = scalar(@$direct_genotypes) > 0 ? qq|<a class="btn btn-default btn-sm" style="margin:3px" href =  "/stock/$stock_id/genotypes">Download All Genotypes</a>| : 'No genotypes available!' ;
+
 ############################
 my $map_html = $stockref->{map_html};
 my $map;
@@ -259,7 +258,7 @@ function jqueryStuff() {
 % }
 
 % if ($type_name eq 'accession' || $type_name eq 'plant' || $type_name eq 'plot' || $type_name eq 'tissue_sample'){
-    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, info_section_title => "<h4 style='display:inline'>Genotype Marker Data</h4>", info_section_subtitle => 'View and download phenotypic data for this stock.', icon_class => "glyphicon glyphicon-map-marker", info_section_id => "stock_genotypes_section", buttons_html => $g_download_link, map_html => $map_html, direct_genotypes => $direct_genotypes &>
+    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, info_section_title => "<h4 style='display:inline'>Genotype Marker Data</h4>", info_section_subtitle => 'View and download phenotypic data for this stock.', icon_class => "glyphicon glyphicon-map-marker", info_section_id => "stock_genotypes_section", buttons_html => '<a class="btn btn-default btn-sm" style="margin:3px" href = "/stock/'.$stock_id.'/genotypes">Download All Genotypes</a>', map_html => $map_html &>
 % }
 
 % if ($type_name eq 'accession'){

--- a/t/unit_fixture/CXGN/Uploading/VCFGenotypes.t
+++ b/t/unit_fixture/CXGN/Uploading/VCFGenotypes.t
@@ -228,4 +228,10 @@ $response = decode_json $mech->content;
 print STDERR Dumper $response;
 is_deeply($response, {'recordsFiltered' => 18,'recordsTotal' => 18,'data' => [['S1_27861','1','27861','T','C','.','PASS','AR2=0.876;DR2=0.897;AF=0.003','GT:AD:DP:GQ:DS:PL'],['S1_75644','1','75644','T','C','.','PASS','AR2=0.816;DR2=0.834;AF=0.023','GT:AD:DP:GQ:DS:PL']]});
 
+my $stock_id = $schema->resultset("Stock::Stock")->find({uniquename => 'SRLI1_90'})->stock_id();
+$mech->get_ok('http://localhost:3010/stock/'.$stock_id.'/datatables/genotype_data');
+$response = decode_json $mech->content;
+print STDERR Dumper $response;
+is_deeply($response, {'data' => [['<a href = "/breeders_toolbox/trial/166">Test genotype project</a>','Diversity panel genotype study','Cassava GBS v7 2018','SNP genotypes for stock (name = SRLI1_90, id = 41797)','<a href="/stock/41797/genotypes?genotypeprop_id=2157">Download</a>'],['<a href = "/breeders_toolbox/trial/167">Test genotype project2</a>','Diversity panel genotype study','Cassava GBS v7 2018','SNP genotypes for stock (name = SRLI1_90, id = 41797)','<a href="/stock/41797/genotypes?genotypeprop_id=2199">Download</a>'],['<a href = "/breeders_toolbox/trial/167">Test genotype project2</a>','Diversity panel genotype study','Cassava GBS v7 2019','SNP genotypes for stock (name = SRLI1_90, id = 41797)','<a href="/stock/41797/genotypes?genotypeprop_id=2241">Download</a>'],['<a href = "/breeders_toolbox/trial/167">Test genotype project2</a>','Diversity panel genotype study','Cassava GBS v7 2018','SNP genotypes for stock (name = SRLI1_90, id = 41797)','<a href="/stock/41797/genotypes?genotypeprop_id=2283">Download</a>']]});
+
 done_testing();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The genotype data table on the stock detail page is now asynchronous. Does not request all markers and actual genotype values for populating this table.

<!-- If there are relevant issues, link them here: -->
closes #2438 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
