### PR TITLE
Cached tree moved to static content path out of tmp

### DIFF
--- a/lib/SGN/Controller/AJAX/Trials.pm
+++ b/lib/SGN/Controller/AJAX/Trials.pm
@@ -63,6 +63,10 @@ sub get_trials_with_folders_cached : Path('/ajax/breeders/get_trials_with_folder
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
 
     my $dir = catdir($c->config->{static_content_path}, "folder");
+    eval { make_path($dir) };
+    if ($@) {
+        print "Couldn't create $dir: $@";
+    }
     my $filename = $dir."/entire_jstree_html_$tree_type.txt";
     my $html = '';
     open(my $fh, '<', $filename) or warn "cannot open file $filename";

--- a/lib/SGN/Controller/AJAX/Trials.pm
+++ b/lib/SGN/Controller/AJAX/Trials.pm
@@ -42,8 +42,48 @@ sub get_trials_with_folders : Path('/ajax/breeders/get_trials_with_folders') Arg
     my $self = shift;
     my $c = shift;
     my $tree_type = $c->req->param('type') || 'trial'; #can be 'trial' or 'genotyping_trial', 'cross'
-
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
+
+    my $dir = catdir($c->config->{static_content_path}, "folder");
+    eval { make_path($dir) };
+    if ($@) {
+        print "Couldn't create $dir: $@";
+    }
+    my $filename = $dir."/entire_jstree_html_$tree_type.txt";
+
+    _write_cached_folder_tree($schema, $tree_type, $filename);
+
+    $c->stash->{rest} = { status => 1 };
+}
+
+sub get_trials_with_folders_cached : Path('/ajax/breeders/get_trials_with_folders_cached') Args(0) {
+    my $self = shift;
+    my $c = shift;
+    my $tree_type = $c->req->param('type') || 'trial'; #can be 'trial' or 'genotyping_trial', 'cross'
+    my $schema = $c->dbic_schema("Bio::Chado::Schema");
+
+    my $dir = catdir($c->config->{static_content_path}, "folder");
+    my $filename = $dir."/entire_jstree_html_$tree_type.txt";
+    my $html = '';
+    open(my $fh, '<', $filename) or warn "cannot open file $filename";
+    {
+        local $/;
+        $html = <$fh>;
+    }
+    close($fh);
+
+    if (!$html) {
+        $html = _write_cached_folder_tree($schema, $tree_type, $filename);
+    }
+
+    #print STDERR $html;
+    $c->stash->{rest} = { html => $html };
+}
+
+sub _write_cached_folder_tree {
+    my $schema = shift;
+    my $tree_type = shift;
+    my $filename = shift;
     my $p = CXGN::BreedersToolbox::Projects->new( { schema => $schema  } );
 
     my $projects = $p->get_breeding_programs();
@@ -58,38 +98,12 @@ sub get_trials_with_folders : Path('/ajax/breeders/get_trials_with_folders') Arg
     }
     print STDERR "Finished get trials $tree_type at time ".localtime()."\n";
 
-    my $dir = catdir($c->site_cluster_shared_dir, "folder");
-    eval { make_path($dir) };
-    if ($@) {
-        print "Couldn't create $dir: $@";
-    }
-    my $filename = $dir."/entire_jstree_html_$tree_type.txt";
-
     my $OUTFILE;
     open $OUTFILE, '>', $filename or die "Error opening $filename: $!";
     print { $OUTFILE } $html or croak "Cannot write to $filename: $!";
     close $OUTFILE or croak "Cannot close $filename: $!";
 
-    $c->stash->{rest} = { status => 1 };
-}
-
-sub get_trials_with_folders_cached : Path('/ajax/breeders/get_trials_with_folders_cached') Args(0) {
-    my $self = shift;
-    my $c = shift;
-    my $tree_type = $c->req->param('type') || 'trial'; #can be 'trial' or 'genotyping_trial', 'cross'
-
-    my $dir = catdir($c->site_cluster_shared_dir, "folder");
-    my $filename = $dir."/entire_jstree_html_$tree_type.txt";
-    my $html = '';
-    open(my $fh, '<', $filename) or die "cannot open file $filename";
-    {
-        local $/;
-        $html = <$fh>;
-    }
-    close($fh);
-
-    #print STDERR $html;
-    $c->stash->{rest} = { html => $html };
+    return $html;
 }
 
 sub trial_autocomplete : Local : ActionClass('REST') { }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Cached trees on manage trials, genotyping plates, and crosses is now stored in static_content_path instead of tmp directory.
Cached trees are regenerated automatically if it is not available already.

<!-- If there are relevant issues, link them here: -->
closes #2456 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [x] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
