### PR TITLE
different html ids for the two different image sections on stock page

### DIFF
--- a/mason/image/print_images.mas
+++ b/mason/image/print_images.mas
@@ -43,6 +43,7 @@ Naama Menda <nm249@cornell.edu>
 
 <%args>
 
+$additional_image_button_id => 'Images'
 $images => undef
 $dbh    => undef
 $image_objects => undef
@@ -126,7 +127,7 @@ $m_image_html .= "</tbody></table>";    #close tabletag for the hidden figures
 
 if (@more_is) {    #html_optional_show if there are more than 3 figures
   $image_html .= html_optional_show(
-				    "Images",
+				    $additional_image_button_id,
 				    "<b>See $more more images...</b>",
 				    qq| $m_image_html |,
 				    0, #< do not show by default

--- a/mason/page/detail_page_2_col_section.mas
+++ b/mason/page/detail_page_2_col_section.mas
@@ -198,11 +198,11 @@ $sample_observation_unit_type_name => undef
 % } #End stock_related_stock_section
 % if ($info_section_id eq 'stock_images_section'){
                                 <&| /page/info_section.mas, title=>"Images of This Stock(" .  scalar(@$image_ids)  . ")", collapsible=>1, collapsed=>0 &>
-                                    <& /image/print_images.mas , images=>$image_ids , dbh=>$dbh &>
+                                    <& /image/print_images.mas , images=>$image_ids , dbh=>$dbh, additional_image_button_id=>'stock_images' &>
                                 </&>
 
                                 <&| /page/info_section.mas, title=>"Images of Related Stock(s) (" .  scalar(@$related_image_ids)  . ")", collapsible=>1, collapsed=>0 &>
-                                    <& /image/print_images.mas , images=>$related_image_ids , dbh=>$dbh &>
+                                    <& /image/print_images.mas , images=>$related_image_ids , dbh=>$dbh, additional_image_button_id=>'related_stock_images' &>
                                 </&>
 % } #End stock_images_section
 % if ($info_section_id eq 'stock_literature_annotation_section'){


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Allows for different html identifiers to be used in the "show additional images" sections on the stock detail page, in order to differentiate the direct images section from the related stock images section.

<!-- If there are relevant issues, link them here: -->
closes #2497 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
