### PR TITLE
cross wishlist with blank accessions list element

### DIFF
--- a/mason/breeders_toolbox/cross_wishlist.mas
+++ b/mason/breeders_toolbox/cross_wishlist.mas
@@ -209,6 +209,7 @@
 var lo = new CXGN.List();
 
 function draw_cross_grid(female_accessions, male_accessions){
+    console.log("draw cross grid");
     var cross_grid_html = '<h3>Set Cross Priorities: 1 is highest and 10 is lowest</h3><h4>Female Accessions Are in First Column and Male Accessions Are in Header</h4><table class="table table-bordered"><thead><tr><th>Female Accessions</th>';
     for(var i=0; i<male_accessions.length; i++){
         cross_grid_html = cross_grid_html + '<th>' + male_accessions[i] + '</th>';
@@ -261,10 +262,14 @@ jQuery(document).ready(function($) {
 
     jQuery("#create_cross_wishlist").click(function() {
         jQuery("#create_cross_wishlist_dialog").modal("show");
-        jQuery("#female_accession_list_div").html(lo.listSelect('female_accession_list_div', ["accessions"], undefined, undefined, undefined ));
-        jQuery("#male_accession_list_div").html(lo.listSelect('male_accession_list_div', ["accessions"], undefined, undefined, undefined ));
-        var female_accessions = lo.getList(jQuery('#female_accession_list_div_list_select').val());
-        var male_accessions = lo.getList(jQuery('#male_accession_list_div_list_select').val());
+        jQuery("#female_accession_list_div").html(lo.listSelect('female_accession_list_div', ["accessions"], "Please select list with < 100 accessions", undefined, undefined ));
+        jQuery("#male_accession_list_div").html(lo.listSelect('male_accession_list_div', ["accessions"], "Please select list with < 100 accessions", undefined, undefined ));
+        var female_accessions;
+        var male_accessions
+        if (jQuery('#female_accession_list_div_list_select').val() != '' && jQuery('#male_accession_list_div_list_select').val() != '' ) {
+            female_accessions = lo.getList(jQuery('#female_accession_list_div_list_select').val());
+            male_accessions = lo.getList(jQuery('#male_accession_list_div_list_select').val());
+        }
 
         jQuery.ajax ({
             url : '/ajax/odk/get_crossing_available_forms',
@@ -317,18 +322,24 @@ jQuery(document).ready(function($) {
             }
         });
 
-        draw_cross_grid(female_accessions, male_accessions);
+        if (jQuery('#female_accession_list_div_list_select').val() != '' && jQuery('#male_accession_list_div_list_select').val() != '' ) {
+            draw_cross_grid(female_accessions, male_accessions);
+        }
     });
 
     jQuery(document).on('change', '#female_accession_list_div_list_select', function(){
-        var female_accessions = lo.getList(jQuery('#female_accession_list_div_list_select').val());
-        var male_accessions = lo.getList(jQuery('#male_accession_list_div_list_select').val());
-        draw_cross_grid(female_accessions, male_accessions);
+        if (jQuery('#female_accession_list_div_list_select').val() != '' && jQuery('#male_accession_list_div_list_select').val() != '' ) {
+            var female_accessions = lo.getList(jQuery('#female_accession_list_div_list_select').val());
+            var male_accessions = lo.getList(jQuery('#male_accession_list_div_list_select').val());
+            draw_cross_grid(female_accessions, male_accessions);
+        }
     });
     jQuery(document).on('change', '#male_accession_list_div_list_select', function(){
-        var female_accessions = lo.getList(jQuery('#female_accession_list_div_list_select').val());
-        var male_accessions = lo.getList(jQuery('#male_accession_list_div_list_select').val());
-        draw_cross_grid(female_accessions, male_accessions);
+        if (jQuery('#female_accession_list_div_list_select').val() != '' && jQuery('#male_accession_list_div_list_select').val() != '' ) {
+            var female_accessions = lo.getList(jQuery('#female_accession_list_div_list_select').val());
+            var male_accessions = lo.getList(jQuery('#male_accession_list_div_list_select').val());
+            draw_cross_grid(female_accessions, male_accessions);
+        }
     });
 
     get_select_box('locations', 'cross_wishlist_location_select_list_div', { 'name' : 'cross_wishlist_location_id', 'id' : 'cross_wishlist_location_id', 'empty':1 });


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Cross wishlist dialog would select the first list in the list select in order to draw the cross wishlist grid select, and when the selected list was too large the user's browser would run out of memory and the page would crash. Now the accession lists are loaded with an empty element.

<!-- If there are relevant issues, link them here: -->
closes #2507 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
