### PR TITLE
Do fuzzy search option on accession file upload

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
@@ -371,7 +371,7 @@ jQuery(document).ready(function ($) {
             }
             if (response.success) {
                 fullParsedData = response.full_data;
-                doFuzzySearch = 1;
+                doFuzzySearch = jQuery('#fuzzy_check_upload_accessions').attr('checked');;
                 review_verification_results(doFuzzySearch, response, response.list_id);
             }
         }
@@ -646,13 +646,13 @@ function process_fuzzy_options(accession_list_id) {
                         infoToAdd.push(fullParsedData[accession_name]);
                         speciesNames.push(fullParsedData[accession_name]['species']);
                     }
-                    for (var i=0; i<accessionListFound.length; i++){
-                        var accession_name = accessionListFound[i];
-                        infoToAdd.push(fullParsedData[accession_name]);
-                        speciesNames.push(fullParsedData[accession_name]['species']);
+                    for (var accession_name in accessionListFound) {
+                        if (accessionListFound.hasOwnProperty(accession_name)) {
+                            infoToAdd.push(fullParsedData[accession_name]);
+                            speciesNames.push(fullParsedData[accession_name]['species']);
+                        }
                     }
                 }
-
                 populate_review_absent_dialog(accessionList, infoToAdd);
                 jQuery('#review_absent_dialog').modal('show');
             } else {

--- a/lib/CXGN/Stock/ParseUpload.pm
+++ b/lib/CXGN/Stock/ParseUpload.pm
@@ -26,6 +26,12 @@ has 'editable_stock_props' => (
     required => 1,
 );
 
+has 'do_fuzzy_search' => (
+    is => 'ro',
+    isa => 'Bool',
+    default => 1
+);
+
 has 'parse_errors' => (
 		       is => 'ro',
 		       isa => 'HashRef',

--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -49,22 +49,50 @@ sub verify_accession_list_GET : Args(0) {
 }
 
 sub verify_accession_list_POST : Args(0) {
-  my ($self, $c) = @_;
+    my ($self, $c) = @_;
+    my $user_id;
+    my $user_name;
+    my $user_role;
+    my $session_id = $c->req->param("sgn_session_id");
 
-  my $accession_list_json = $c->req->param('accession_list');
-  my $organism_list_json = $c->req->param('organism_list');
-  my @accession_list = @{_parse_list_from_json($accession_list_json)};
-  my @organism_list = $organism_list_json ? @{_parse_list_from_json($organism_list_json)} : [];
+    if ($session_id){
+        my $dbh = $c->dbc->dbh;
+        my @user_info = CXGN::Login->new($dbh)->query_from_cookie($session_id);
+        if (!$user_info[0]){
+            $c->stash->{rest} = {error=>'You must be logged in to upload this seedlot info!'};
+            $c->detach();
+        }
+        $user_id = $user_info[0];
+        $user_role = $user_info[1];
+        my $p = CXGN::People::Person->new($dbh, $user_id);
+        $user_name = $p->get_username;
+    } else {
+        if (!$c->user){
+            $c->stash->{rest} = {error=>'You must be logged in to upload this seedlot info!'};
+            $c->detach();
+        }
+        $user_id = $c->user()->get_object()->get_sp_person_id();
+        $user_name = $c->user()->get_object()->get_username();
+        $user_role = $c->user->get_object->get_user_type();
+    }
 
-  my $do_fuzzy_search = $c->req->param('do_fuzzy_search');
+    my $accession_list_json = $c->req->param('accession_list');
+    my $organism_list_json = $c->req->param('organism_list');
+    my @accession_list = @{_parse_list_from_json($accession_list_json)};
+    my @organism_list = $organism_list_json ? @{_parse_list_from_json($organism_list_json)} : [];
 
-  if ($do_fuzzy_search) {
-      $self->do_fuzzy_search($c, \@accession_list, \@organism_list);
-  }
-  else {
-      $self->do_exact_search($c, \@accession_list, \@organism_list);
-  }
+    my $do_fuzzy_search = $c->req->param('do_fuzzy_search');
+    if ($user_role ne 'curator' && !$do_fuzzy_search) {
+        $c->stash->{rest} = {error=>'Only a curator can add accessions without using the fuzzy search!'};
+        $c->detach();
+    }
 
+    if ($do_fuzzy_search) {
+        $self->do_fuzzy_search($c, \@accession_list, \@organism_list);
+    }
+    else {
+        $self->do_exact_search($c, \@accession_list, \@organism_list);
+    }
 }
 
 sub do_fuzzy_search {
@@ -202,6 +230,10 @@ sub verify_accessions_file_POST : Args(0) {
     my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
     my $upload = $c->req->upload('new_accessions_upload_file');
     my $do_fuzzy_search = $c->req->param('fuzzy_check_upload_accessions') ? 1 : 0;
+    if ($user_role ne 'curator' && !$do_fuzzy_search) {
+        $c->stash->{rest} = {error=>'Only a curator can add accessions without using the fuzzy search!'};
+        $c->detach();
+    }
     my $subdirectory = "accessions_spreadsheet_upload";
     my $upload_original_name = $upload->filename();
     my $upload_tempfile = $upload->tempname;

--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -201,6 +201,7 @@ sub verify_accessions_file_POST : Args(0) {
 
     my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
     my $upload = $c->req->upload('new_accessions_upload_file');
+    my $do_fuzzy_search = $c->req->param('fuzzy_check_upload_accessions') ? 1 : 0;
     my $subdirectory = "accessions_spreadsheet_upload";
     my $upload_original_name = $upload->filename();
     my $upload_tempfile = $upload->tempname;
@@ -226,7 +227,7 @@ sub verify_accessions_file_POST : Args(0) {
     unlink $upload_tempfile;
 
     my @editable_stock_props = split ',', $c->config->{editable_stock_props};
-    my $parser = CXGN::Stock::ParseUpload->new(chado_schema => $schema, filename => $archived_filename_with_path, editable_stock_props=>\@editable_stock_props);
+    my $parser = CXGN::Stock::ParseUpload->new(chado_schema => $schema, filename => $archived_filename_with_path, editable_stock_props=>\@editable_stock_props, do_fuzzy_search=>$do_fuzzy_search);
     $parser->load_plugin('AccessionsXLS');
     my $parsed_data = $parser->parse();
     #print STDERR Dumper $parsed_data;

--- a/mason/breeders_toolbox/add_accessions_dialogs.mas
+++ b/mason/breeders_toolbox/add_accessions_dialogs.mas
@@ -57,9 +57,17 @@ $editable_stock_props => {}
 
                     <form class="form-horizontal" role="form" method="post" enctype="multipart/form-data" encoding="multipart/form-data" id="upload_new_accessions_form" name="upload_new_accessions_form">
                         <div class="form-group">
-                            <label class="col-sm-3 control-label">Upload File: </label>
-                            <div class="col-sm-9" >
+                            <label class="col-sm-4 control-label">Upload File: </label>
+                            <div class="col-sm-8" >
                                 <input type="file" name="new_accessions_upload_file" id="new_accessions_upload_file" encoding="multipart/form-data" />
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Use Fuzzy Search: </label>
+                            <div class="col-sm-8">
+                                <input type="checkbox" id="fuzzy_check_upload_accessions" name="fuzzy_check_upload_accessions" checked></input>
+                                <br/>
+                                <small>Note: Use the fuzzy search to match similar names to prevent uploading of duplicate accessions. Fuzzy searching is much slower than regular search.</small>
                             </div>
                         </div>
                     </form>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fuzzy search optional during accession file upload. Only curator can skip fuzzy search

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
