### PR TITLE
fix trials call studies object

### DIFF
--- a/lib/CXGN/BrAPI/v1/Trials.pm
+++ b/lib/CXGN/BrAPI/v1/Trials.pm
@@ -97,9 +97,10 @@ sub trial_details {
 			my $children = $folder->children();
 			foreach (@$children) {
 				push @folder_studies, {
-					studyDbId=>qq|$_->folder_id|,
+					studyDbId=>$_->folder_id,
 					studyName=>$_->name,
-					locationDbId=>qq|$_->location_id|
+					locationDbId=>$_->location_id,
+                    locationName=>$_->location_name
 				};
 			}
             my $folder_id = $folder->folder_id;

--- a/lib/CXGN/Trial/Folder.pm
+++ b/lib/CXGN/Trial/Folder.pm
@@ -2,7 +2,7 @@
 package CXGN::Trial::Folder;
 
 use CXGN::Chado::Cvterm;
-
+use CXGN::Location;
 use Moose;
 use SGN::Model::Cvterm;
 use Data::Dumper;
@@ -54,6 +54,10 @@ has 'folder_for_genotyping_trials' => (isa => 'Bool',
 );
 
 has 'location_id' => (isa => 'Int',
+	is => 'rw',
+);
+
+has 'location_name' => (isa => 'Str',
 	is => 'rw',
 );
 
@@ -127,6 +131,8 @@ sub BUILD {
 				$self->folder_type("genotyping_trial");
 			} elsif ($tt->type_id == $location_cvterm_id) {
 				$self->location_id($tt->value + 0);
+                my $location = CXGN::Location->new( { bcs_schema => $self->bcs_schema, nd_geolocation_id => $self->location_id } );
+                $self->location_name($location->name());
 			}
 		}
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes error in BrAPI /trials call that retrieved study and location ids incorrectly and did not retrieve location name

<!-- If there are relevant issues, link them here: -->

Closes #2437

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
