### PR TITLE
add event relation terms to time ontology and related code

### DIFF
--- a/js/source/legacy/CXGN/ComposeTrait.js
+++ b/js/source/legacy/CXGN/ComposeTrait.js
@@ -48,6 +48,7 @@ function get_component_ids () {
   if (jQuery("#tod_select").val()) { component_ids.push(jQuery("#tod_select").val()); }
   if (jQuery("#toy_select").val()) { component_ids.push(jQuery("#toy_select").val()); }
   if (jQuery("#gen_select").val()) { component_ids.push(jQuery("#gen_select").val()); }
+  if (jQuery("#evt_select").val()) { component_ids.push(jQuery("#evt_select").val()); }
   return component_ids;
 }
 
@@ -64,6 +65,7 @@ function retrieve_matching_traits (component_ids) {
   ids["tod_ids"] = jQuery("#tod_select").val();
   ids["toy_ids"] = jQuery("#toy_select").val();
   ids["gen_ids"] = jQuery("#gen_select").val();
+  ids["evt_ids"] = jQuery("#evt_select").val();
 
 jQuery.ajax( {
   url: '/ajax/onto/get_traits_from_component_categories',
@@ -76,6 +78,7 @@ jQuery.ajax( {
           'tod_ids': ids["tod_ids"],
           'toy_ids': ids["toy_ids"],
           'gen_ids': ids["gen_ids"],
+          'evt_ids': ids["evt_ids"],
         },
   success: function(response) {
     traits = response.existing_traits || [];

--- a/lib/SGN/Controller/AJAX/Onto.pm
+++ b/lib/SGN/Controller/AJAX/Onto.pm
@@ -224,8 +224,9 @@ sub get_traits_from_component_categories: Path('/ajax/onto/get_traits_from_compo
   my @tod_ids = $c->req->param("tod_ids[]");
   my @toy_ids = $c->req->param("toy_ids[]");
   my @gen_ids = $c->req->param("gen_ids[]");
+  my @evt_ids = $c->req->param("evt_ids[]");
 
-  print STDERR "Obj ids are @object_ids\n Attr ids are @attribute_ids\n Method ids are @method_ids\n unit ids are @unit_ids\n trait ids are @trait_ids\n tod ids are @tod_ids\n toy ids are @toy_ids\n gen ids are @gen_ids\n";
+  print STDERR "Obj ids are @object_ids\n Attr ids are @attribute_ids\n Method ids are @method_ids\n unit ids are @unit_ids\n trait ids are @trait_ids\n tod ids are @tod_ids\n toy ids are @toy_ids\n gen ids are @gen_ids\n evt ids are @evt_ids\n";
   my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
 
   my $traits = SGN::Model::Cvterm->get_traits_from_component_categories($schema, \@allowed_composed_cvs, $composable_cvterm_delimiter, $composable_cvterm_format, {
@@ -237,6 +238,7 @@ sub get_traits_from_component_categories: Path('/ajax/onto/get_traits_from_compo
       tod => \@tod_ids,
       toy => \@toy_ids,
       gen => \@gen_ids,
+      evt => \@evt_ids,
   });
 
   if (!$traits) {

--- a/lib/SGN/Controller/Ontology.pm
+++ b/lib/SGN/Controller/Ontology.pm
@@ -49,7 +49,7 @@ sub compose_trait : Path('/tools/compose') :Args(0) {
     my %html_hash;
     foreach my $name (@composable_cvs) {
         $name =~ s/^\s+|\s+$//g; # remove whitespace
-        if ($name eq 'time' || $name eq 'tod' || $name eq 'toy' || $name eq 'gen' ) {
+        if ($name eq 'time' || $name eq 'tod' || $name eq 'toy' || $name eq 'gen' || $name eq 'evt' ) {
             print STDERR "Skipping time-related cv\n";
             next;
         }
@@ -105,6 +105,7 @@ sub compose_trait : Path('/tools/compose') :Args(0) {
     $c->stash->{composable_tod_root_cvterm} = $c->config->{composable_tod_root_cvterm};
     $c->stash->{composable_toy_root_cvterm} = $c->config->{composable_toy_root_cvterm};
     $c->stash->{composable_gen_root_cvterm} = $c->config->{composable_gen_root_cvterm};
+    $c->stash->{composable_evt_root_cvterm} = $c->config->{composable_evt_root_cvterm};
 
     $c->stash->{user} = $c->user();
     $c->stash->{template} = '/ontology/compose_trait.mas';

--- a/mason/ontology/compose_trait.mas
+++ b/mason/ontology/compose_trait.mas
@@ -10,6 +10,7 @@ $composable_cvs_allowed_combinations => undef
 $composable_tod_root_cvterm => undef
 $composable_toy_root_cvterm => undef
 $composable_gen_root_cvterm => undef
+$composable_evt_root_cvterm => undef
 </%args>
 
 <& /util/import_javascript.mas, classes => ['CXGN.BreederSearch', 'CXGN.ComposeTrait'] &>
@@ -107,6 +108,13 @@ $composable_gen_root_cvterm => undef
       <div id="gen_select_div"></div><br>
       <button class="btn btn-default btn-sm" id="gen_select_all" name="gen_select_all"/>Select All</button>
       <button class="btn btn-default btn-sm" id="gen_select_clear" name="gen_select_clear"/>Clear</button>
+    </div>
+    <div id="evt_div" class="col-md-6" style="display: none;">
+      <label for="evt_select_div" class="control-label">Event</label>
+      <p class="help-block"><small><i>Optional</i> Pick the breeding event to which you selected time term relates.</small></p>
+      <div id="evt_select_div"></div><br>
+      <button class="btn btn-default btn-sm" id="evt_select_all" name="evt_select_all"/>Select All</button>
+      <button class="btn btn-default btn-sm" id="evt_select_clear" name="evt_select_clear"/>Clear</button>
     </div>
     </div>
   </div>
@@ -211,7 +219,7 @@ name = name.replace('_root_select', '');
 get_select_box('trait_components', name +'_select_div', { 'id' : name +'_select', 'name': name +'_select', 'multiple': 'true', 'cv_id': cv_id, 'size':'10' });
 });
 
-jQuery(document).on('change','#object_select, #attribute_select, #method_select, #unit_select, #trait_select, #tod_select, #toy_select, #gen_select', function() { // retrieve matching traits each time component selection changes
+jQuery(document).on('change','#object_select, #attribute_select, #method_select, #unit_select, #trait_select, #tod_select, #toy_select, #gen_select, #evt_select', function() { // retrieve matching traits each time component selection changes
   if (jQuery(this).attr('name') == 'trait_select') {
     //console.log("trait select changed");
     //clearAllOptions(document.getElementById('object_select'));
@@ -226,7 +234,7 @@ jQuery(document).on('change','#object_select, #attribute_select, #method_select,
   display_matching_traits();
 });
 
-jQuery('#object_select_all, #attribute_select_all, #method_select_all, #unit_select_all, #trait_select_all, #tod_select_all, #toy_select_all, #gen_select_all').click( // select all data in a panel
+jQuery('#object_select_all, #attribute_select_all, #method_select_all, #unit_select_all, #trait_select_all, #tod_select_all, #toy_select_all, #gen_select_all, #evt_select_all').click( // select all data in a panel
   function() {
   var name = jQuery(this).attr('name');
   var select_id = name.substring(0, name.length - 4);
@@ -234,7 +242,7 @@ jQuery('#object_select_all, #attribute_select_all, #method_select_all, #unit_sel
   display_matching_traits();
 });
 
-jQuery('#object_select_clear, #attribute_select_clear, #method_select_clear, #unit_select_clear, #trait_select_clear, #gen_select_clear, #tod_select_clear, #toy_select_clear').click( // clear all selections in a panel
+jQuery('#object_select_clear, #attribute_select_clear, #method_select_clear, #unit_select_clear, #trait_select_clear, #gen_select_clear, #tod_select_clear, #toy_select_clear, #evt_select_clear').click( // clear all selections in a panel
   function() {
   var name = jQuery(this).attr('name');
   var select_id = name.substring(0, name.length - 6);
@@ -315,6 +323,7 @@ function create_multi_selects(allowed_names) {
     jQuery('#tod_div').hide();
     jQuery('#toy_div').hide();
     jQuery('#gen_div').hide();
+    jQuery('#evt_div').hide();
     jQuery('#object_div').hide();
     jQuery('#trait_div').hide();
     jQuery('#attribute_div').hide();
@@ -323,6 +332,7 @@ function create_multi_selects(allowed_names) {
     jQuery('#tod_select').val([]);
     jQuery('#toy_select').val([]);
     jQuery('#gen_select').val([]);
+    jQuery('#evt_select').val([]);
     jQuery('#object_select').val([]);
     jQuery('#trait_select').val([]);
     jQuery('#attribute_select').val([]);
@@ -350,10 +360,11 @@ function create_multi_selects(allowed_names) {
                 jQuery('#method_div').show();
                 break;
             case "time":
-                jQuery("#tod_div,#toy_div,#gen_div").show();
+                jQuery("#tod_div,#toy_div,#gen_div","evt_div").show();
                 get_select_box('ontology_children', 'tod_select_div', { 'selectbox_id' : 'tod_select', 'selectbox_name': 'tod_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_tod_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
                 get_select_box('ontology_children', 'toy_select_div', { 'selectbox_id' : 'toy_select', 'selectbox_name': 'toy_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_toy_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
                 get_select_box('ontology_children', 'gen_select_div', { 'selectbox_id' : 'gen_select', 'selectbox_name': 'gen_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_gen_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                get_select_box('ontology_children', 'evt_select_div', { 'selectbox_id' : 'evt_select', 'selectbox_name': 'evt_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_evt_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
                 break;
             case "tod":
                 jQuery("#tod_div").show();
@@ -366,6 +377,10 @@ function create_multi_selects(allowed_names) {
             case "gen":
                 jQuery("#gen_div").show();
                 get_select_box('ontology_children', 'gen_select_div', { 'selectbox_id' : 'gen_select', 'selectbox_name': 'gen_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_gen_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
+                break;
+            case "evt":
+                jQuery("#evt_div").show();
+                get_select_box('ontology_children', 'evt_select_div', { 'selectbox_id' : 'evt_select', 'selectbox_name': 'evt_select', 'multiple': 'true', 'parent_node_cvterm': '<% $composable_evt_root_cvterm %>', 'rel_cvterm': 'is_a', 'rel_cv': 'relationship' });
                 break;
             default:
                 if (window.console) console.log("Did not recognize "+name+" category");

--- a/ontology/cxgn_time.obo
+++ b/ontology/cxgn_time.obo
@@ -988,16 +988,42 @@ def: "" []
 is_a: TIME:0000005
 
 [Term]
-id: TIME:0000141
+id: TIME:0000145
 name: at pre-flowering
 synonym: "PreFLW" EXACT []
 def: "" []
 is_a: TIME:0000076
 
 [Term]
-id: TIME:0000142
+id: TIME:0000146
 name: at post-flowering
 synonym: "PostFLW" EXACT []
 def: "" []
 is_a: TIME:0000076
 
+[Term]
+id: TIME:0000147
+name: Event relations
+def: "Terms that can be linked with other time terms to specify their relation to breeding events" []
+is_a: TIME:0000000
+
+[Term]
+id: TIME:0000148
+name: after planting
+synonym: "AftPlt" EXACT []
+def: "" []
+is_a: TIME:0000147
+
+[Term]
+id: TIME:0000149
+name: before harvest
+synonym: "BfrHvt" EXACT []
+def: "" []
+is_a: TIME:0000147
+
+[Term]
+id: TIME:0000150
+name: after harvest
+synonym: "AftHvt" EXACT []
+def: "" []
+is_a: TIME:0000147

--- a/sgn.conf
+++ b/sgn.conf
@@ -22,6 +22,7 @@ composable_cvterm_format concise
 composable_tod_root_cvterm "time of day|TIME:0000001"
 composable_toy_root_cvterm "time of year|TIME:0000005"
 composable_gen_root_cvterm "generation|TIME:0000072"
+composable_evt_root_cvterm "generation|TIME:0000147"
 allow_observation_variable_submission_interface 0
 trait_cv_name cassava_trait
 trait_ontology_db_name SP


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Adds new terms to time ontology for specifying events. For example specifiying that `virus symptoms | 1 month`is `virus symptoms | 1 month | after planting`,  or `beta carotene | week 4` is `beta carotene | week 4 | after harvest`

<!-- If there are relevant issues, link them here: -->
closes #2589

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
