### PR TITLE
Bbase-8 Convert Breedbase data types to BrAPI data types in variable pulls

### DIFF
--- a/lib/CXGN/BrAPI/v1/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v1/ObservationVariables.pm
@@ -224,23 +224,8 @@ sub observation_variable_search {
 			}
 		);
 
-		# Convert our breedbase data types to BrAPI data types. If we find a type we want
-		# to convert, convert it. If there is a type, but we have no conversion for it,
-		# let it pass.
-		my $trait_format = $trait->format;
-
-		if (scalar @brapi_categories > 0) {
-			# If the trait has categories, convert to Nominal
-			$trait_format = "Nominal";
-		}
-		elsif ($trait_format eq "qualitative") {
-			# If the trait is qualitative convert to Text
-			$trait_format = "Text";
-		}
-		elsif ($trait_format eq "" || $trait_format eq "numeric" || ! defined $trait_format){
-			# If the trait is numeric or the data type is unspecified, convert to Numerical
-			$trait_format = "Numerical";
-		}
+		# Convert our breedbase data types to BrAPI data types.
+		my $trait_format = $self->convert_datatype_to_brapi($trait->format, scalar(@brapi_categories));
 
 		# Note: Breedbase does not have a concept of 'methods'.
 		# Note: Breedbase does not have a concept of 'scale'. The values populated in scale are values from cvprop.
@@ -363,5 +348,28 @@ sub observation_variable_detail {
 	return CXGN::BrAPI::JSONResponse->return_success(\%result, $pagination, \@data_files, $status, 'Observationvariable detail result constructed');
 }
 
+sub convert_datatype_to_brapi {
+	#If we find a type we want to convert, convert it.
+	# If there is a type, but we have no conversion for it, let it pass.
+	my $self = shift;
+	my $trait_format = shift;
+	my $num_brapi_categories = shift;
+
+	if ($num_brapi_categories > 0) {
+		# If the trait has categories, convert to Nominal
+		$trait_format = "Nominal";
+	}
+	elsif ($trait_format eq "qualitative") {
+		# If the trait is qualitative convert to Text
+		$trait_format = "Text";
+	}
+	elsif ($trait_format eq "" || $trait_format eq "numeric" || ! defined $trait_format){
+		# If the trait is numeric or the data type is unspecified, convert to Numerical
+		$trait_format = "Numerical";
+	}
+
+	# Return our processed trait format
+	return $trait_format;
+}
 
 1;

--- a/lib/CXGN/BrAPI/v1/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v1/ObservationVariables.pm
@@ -224,6 +224,24 @@ sub observation_variable_search {
 			}
 		);
 
+		# Convert our breedbase data types to BrAPI data types. If we find a type we want
+		# to convert, convert it. If there is a type, but we have no conversion for it,
+		# let it pass.
+		my $trait_format = $trait->format;
+
+		if (scalar @brapi_categories > 0) {
+			# If the trait has categories, convert to Nominal
+			$trait_format = "Nominal";
+		}
+		elsif ($trait_format eq "qualitative") {
+			# If the trait is qualitative convert to Text
+			$trait_format = "Text";
+		}
+		elsif ($trait_format eq "" || $trait_format eq "numeric" || ! defined $trait_format){
+			# If the trait is numeric or the data type is unspecified, convert to Numerical
+			$trait_format = "Numerical";
+		}
+
 		# Note: Breedbase does not have a concept of 'methods'.
 		# Note: Breedbase does not have a concept of 'scale'. The values populated in scale are values from cvprop.
 		# Note: Breedbase does not have a created date stored from ontology variables.
@@ -254,7 +272,7 @@ sub observation_variable_search {
 			ontologyName => $db_name,
 			ontologyReference => \%ontologyReference,
             scale => {
-                dataType=>$trait->format,
+                dataType=>$trait_format,
                 decimalPlaces=>undef,
                 name =>'',
                 ontologyReference => \%ontologyReference,

--- a/lib/CXGN/BrAPI/v1/Studies.pm
+++ b/lib/CXGN/BrAPI/v1/Studies.pm
@@ -418,6 +418,9 @@ sub studies_observation_variables {
 				}
 			);
 
+			# Convert our breedbase data types to BrAPI data types.
+			my $trait_format = CXGN::BrAPI::v1::ObservationVariables->convert_datatype_to_brapi($trait->format, scalar(@brapi_categories));
+
 			push @data, {
 				contextOfUse=>[],
 				crop => $crop,
@@ -443,7 +446,7 @@ sub studies_observation_variables {
 				ontologyName => $trait->db,
 				ontologyReference=>\%ontologyReference,
 				scale => {
-					dataType=>$trait->format,
+					dataType=>$trait_format,
 					decimalPlaces=>undef,
 					name =>'',
 					ontologyReference=>\%ontologyReference,


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Added a function to convert breedbase datatypes to BrAPI data types. So far, converting numeric to Numerical, qualitative to Text, and if the trait has categories convert to Nominal. The trait is converted to whatever condition it passes first, the order is like so:

- Nominal check
- Text check
- Numerical Check

Breedbase can have any number of data types, but numeric and qualitative are the ones Nick Morales mentioned as being the two he has seen in the past. 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ x ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
