### PR TITLE
Bug Fix: Accession search by Organization

### DIFF
--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -114,8 +114,8 @@ my $breeding_programs_select = simple_selectbox_html(
     <div class="row">
       <div class="col-sm-6">
         <div class="form-group form-group-sm">
-          <label class="col-sm-3 control-label">Organization: </label>
-          <div class="col-sm-9" >
+          <label class="col-sm-4 control-label">Organization: </label>
+          <div class="col-sm-8" >
             <input type="text" class="form-control" id="organization" placeholder="Type to Autocomplete"/>
           </div>
         </div>
@@ -333,6 +333,17 @@ jQuery(document).ready(function () {
      jQuery("#year").autocomplete({
         source: '/ajax/stock/project_year_autocomplete',
      });
+     jQuery("#organization").autocomplete({
+        source: '/ajax/stock/stockproperty_autocomplete?property=organization',
+     });
+
+    // Update changed organization
+    jQuery(document).on("change", "#organization", function() {
+      editable_stockprops_search["organization"] = {
+        "matchtype": "contains",
+        "value": jQuery(this).val()
+      }
+    });
 
     var editable_stockprops_search = {};
     var params = {};


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

The organization input in the Accession Search (Advanced -> Properties) did not autocomplete and did not filter search results

This adds the autocomplete source URL for the input
and updates the organization stock prop search term when the input field is changed



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
