### PR TITLE
Topic/remote slurm

### DIFF
--- a/lib/CXGN/List/Transform/Plugin/TraitIds2Synonyms.pm
+++ b/lib/CXGN/List/Transform/Plugin/TraitIds2Synonyms.pm
@@ -2,6 +2,8 @@ package CXGN::List::Transform::Plugin::TraitIds2Synonyms;
 
 use Moose;
 
+use CXGN::Cvterm;
+
 sub name {
     return "trait_ids_2_synonyms";
 }

--- a/lib/SGN/Controller/AJAX/Blast.pm
+++ b/lib/SGN/Controller/AJAX/Blast.pm
@@ -322,7 +322,12 @@ sub check : Path('/tools/blast/check') Args(1) {
     #my $jobid =~ s/\.\.//g; # prevent hacks
     my $job_file = File::Spec->catfile($cluster_tmp_dir, $jobid, "job");
 
-    my $job = CXGN::Tools::Run->new( { job_file => $job_file} );
+    my $job = CXGN::Tools::Run->new( 
+	{ 
+	    job_file => $job_file, 
+	    submit_host => $c->config->{cluster_host},
+	    backend => $c->config->{backend},
+	});
 
     if ( $job->alive()) {
       # my $t1 = [gettimeofday]; #-------------------------- TIME CHECK

--- a/lib/SGN/Controller/AJAX/Blast.pm
+++ b/lib/SGN/Controller/AJAX/Blast.pm
@@ -267,6 +267,7 @@ sub run : Path('/tools/blast/run') Args(0) {
     eval {
 	my $config = { 
 	    backend => $c->config->{backend},
+	    submit_host => $c->config->{cluster_host},
 	    temp_base => $blast_tmp_output,
 	    queue => $c->config->{'web_cluster_queue'},
 	    do_cleanup => 0,

--- a/lib/SGN/Controller/InSilicoPcr.pm
+++ b/lib/SGN/Controller/InSilicoPcr.pm
@@ -315,7 +315,7 @@ sub _blast_to_pcr {
   
   ##############################################################################################################################
   
-  my $fs = Bio::BLAST::Database->open(full_file_basename => "$basename",);
+  my $fs = Bio::BLAST2::Database->open(full_file_basename => "$basename",);
   
   my $find_seq;
   my $find_subseq;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This pull request enables RemoteSlurm operation for the SGN BLAST tool.

The sgn_local.conf needs to be configured with the new parameter cluster_host to identify the remote host that the job will be run on.

The backend parameter needs to be set to RemoteSlurm.

Host keys need to be installed in the www-data account and the cluster host. (VMs can share the same private key).

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
