### PR TITLE
Bug Fix: Location Map does not display if no locations

### DIFF
--- a/mason/breeders_toolbox/location_map.mas
+++ b/mason/breeders_toolbox/location_map.mas
@@ -449,7 +449,13 @@ function initialize_map (id, locationJSON, table) {
 
     mymap.addControl(new locateUser({ position: 'topleft' }));
 
-    mymap.fitBounds(location_layer.getBounds());
+    // Set Map Bounds if provided, otherwise fit the map to the world
+    if ( Object.entries(location_layer.getBounds()).length !== 0 ) {
+        mymap.fitBounds(location_layer.getBounds());
+    }
+    else {
+        mymap.fitWorld();
+    }
     var layerControl = L.control.layers(baseMaps, overlayMaps, {position: 'bottomright'}).addTo(mymap);
     var scale = L.control.scale().addTo(mymap);
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

When there are no stored locations in the DB, there are no map bounds to calculate and the map
does not display on /breeders/locations

This fix sets the map bounds to the entire world if the calculated map bounds are not provided


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
