### PR TITLE
fix link to create genotyping plate

### DIFF
--- a/mason/breeders_toolbox/manage_upload.mas
+++ b/mason/breeders_toolbox/manage_upload.mas
@@ -75,7 +75,7 @@ $editable_stock_props => {}
 <tbody>
 <tr>
 <td>
-<a id="create_igd_genotyping_trial_link"><p>Create An IGD Genotyping Plate</p></a>
+<a name="create_genotyping_trial_link"><p>Create An IGD Genotyping Plate</p></a>
 </td>
 <td>
 <a href="/breeders/genotyping"><p>Go To Manage Genotyping Plates</p></a>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Changed name associated with link to create the plate such that it pulls up the workflow to Add Genotyping Plate.

<!-- If there are relevant issues, link them here: -->

Issue #2697 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [X] Bug fix
  - [X] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
