### PR TITLE
fixed derived trait to allow ontology database names with more than 2 caracters

### DIFF
--- a/lib/CXGN/BreedersToolbox/StocksFuzzySearch.pm
+++ b/lib/CXGN/BreedersToolbox/StocksFuzzySearch.pm
@@ -94,7 +94,7 @@ sub get_matches {
             } elsif (scalar(@{$synonym_uniquename_lookup{$stock_name}}) == 1){
                 $match_info{matched_string} = $stock_name." (SYNONYM OF ".$synonym_uniquename_lookup{$stock_name}->[0].")";
                 $match_info{is_synonym} = 1;
-                $match_info{uniquename} = $synonym_uniquename_lookup{$stock_name}->[0];
+                $match_info{unique_name} = $synonym_uniquename_lookup{$stock_name}->[0];
             }
             push @found_stocks, \%match_info;
             next;

--- a/lib/CXGN/List/Validate/Plugin/Accessions.pm
+++ b/lib/CXGN/List/Validate/Plugin/Accessions.pm
@@ -22,7 +22,7 @@ sub validate {
     my $h = $schema->storage->dbh()->prepare($q);
     $h->execute();
     while (my ($uniquename, $synonym, $type_id) = $h->fetchrow_array()) {
-        $all_names{$uniquename}++;
+        $all_names{lc($uniquename)}++;
         if ($type_id) {
             if ($type_id == $synonym_type_id) {
                 $all_names{$synonym}++;

--- a/lib/CXGN/List/Validate/Plugin/Accessions.pm
+++ b/lib/CXGN/List/Validate/Plugin/Accessions.pm
@@ -22,7 +22,7 @@ sub validate {
     my $h = $schema->storage->dbh()->prepare($q);
     $h->execute();
     while (my ($uniquename, $synonym, $type_id) = $h->fetchrow_array()) {
-        $all_names{lc($uniquename)}++;
+        $all_names{$uniquename}++;
         if ($type_id) {
             if ($type_id == $synonym_type_id) {
                 $all_names{$synonym}++;

--- a/lib/SGN/Controller/AJAX/DeriveTrait.pm
+++ b/lib/SGN/Controller/AJAX/DeriveTrait.pm
@@ -155,7 +155,13 @@ sub compute_derive_traits : Path('/ajax/phenotype/create_derived_trait') Args(0)
 	my (%hash1, %hash2, %hash3, @trait_values1, @trait_values2, @trait_values3);
 	while ($msg_formula =~ /(\w*\:\d+)/g){
 		push @dependent_trait_ids, [$1];
-		($db_id,$accession) = split (/:/, $1);
+		($db_id,$accession) = split (/:/, $1);	
+			
+		$accession =~ s/\s+$//;
+		$accession =~ s/^\s+//;
+		$db_id =~ s/\s+$//;
+		$db_id =~ s/^\s+//;
+			
 		push @accessions, $accession;
 	}
 	print "DB ID: $db_id\n";

--- a/lib/SGN/Controller/AJAX/DeriveTrait.pm
+++ b/lib/SGN/Controller/AJAX/DeriveTrait.pm
@@ -153,7 +153,7 @@ sub compute_derive_traits : Path('/ajax/phenotype/create_derived_trait') Args(0)
 	my @dependent_trait_ids;
 	my ($db_id, $accession, @traits_cvterm_ids, $cvterm_id, @found_trait_cvterm_ids, @accessions, @trait_values);
 	my (%hash1, %hash2, %hash3, @trait_values1, @trait_values2, @trait_values3);
-	while ($msg_formula =~ /(\w{2}\:\d+)/g){
+	while ($msg_formula =~ /(\w*\:\d+)/g){
 		push @dependent_trait_ids, [$1];
 		($db_id,$accession) = split (/:/, $1);
 		push @accessions, $accession;
@@ -177,7 +177,7 @@ sub compute_derive_traits : Path('/ajax/phenotype/create_derived_trait') Args(0)
 		}
 	}
 
-	while ($msg_formula =~ /([\w\s-]+\|\w{2}\:\d+)/g){
+	while ($msg_formula =~ /([\w\s-]+\|\w*\:\d+)/g){
 		my $full_name = $1;
 		if ($full_name =~ m/\s-\s/g){
 			$full_name =~ s/-\s//g;
@@ -244,7 +244,7 @@ project.project_id=? ) );");
 			#print STDERR Dumper \%map_hash;
 			my $msg_formula_sub = $msg_formula;
 			foreach my $full_trait (keys %map_hash) {
-				$full_trait =~ /([\w\s-]+)\|(\w{2}\:\d+)/g;
+				$full_trait =~ /([\w\s-]+)\|(\w*\:\d+)/g;
 				#print STDERR Dumper $full_trait;
 				$msg_formula_sub =~ s/($1\|$2)/$map_hash{$full_trait}/g;
 			}


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Derived trait module can now handle ontology database names with more than 2 characters. 
Also fixed accession validation in lists to be case insensitive and fixed a typo in a variable in StocksFuzzySearch.pm.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
