### PR TITLE
Topic/upload accessions error

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
@@ -365,14 +365,18 @@ jQuery(document).ready(function ($) {
             console.log(response);
             jQuery('#working_modal').modal("hide");
 
-            if (response.error_string) {
+            if (response.error) {
                 fullParsedData = undefined;
-                alert(response.error_string);
+                alert(response.error);
             }
-            if (response.success) {
+            else if (response.success) {
                 fullParsedData = response.full_data;
                 doFuzzySearch = jQuery('#fuzzy_check_upload_accessions').attr('checked');;
                 review_verification_results(doFuzzySearch, response, response.list_id);
+            }
+            else {
+                fullParsedData = undefined;
+                alert("An unknown error occurred.  Please try again later or contact us for help.");
             }
         }
     });

--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -234,6 +234,13 @@ sub verify_accessions_file_POST : Args(0) {
         $c->stash->{rest} = {error=>'Only a curator can add accessions without using the fuzzy search!'};
         $c->detach();
     }
+
+    # These roles are required by CXGN::UploadFile
+    if ($user_role ne 'curator' && $user_role ne 'submitter' && $user_role ne 'sequencer' ) {
+        $c->stash->{rest} = {error=>'Only a curator, submitter or sequencer can upload a file'};
+        $c->detach();
+    }
+
     my $subdirectory = "accessions_spreadsheet_upload";
     my $upload_original_name = $upload->filename();
     my $upload_tempfile = $upload->tempname;

--- a/lib/SGN/Controller/BreedersToolbox.pm
+++ b/lib/SGN/Controller/BreedersToolbox.pm
@@ -126,6 +126,7 @@ sub manage_accessions : Path("/breeders/accessions") Args(0) {
     #$c->stash->{population_groups} = $populations;
     $c->stash->{preferred_species} = $c->config->{preferred_species};
     $c->stash->{editable_stock_props} = \%editable_stock_props;
+    $c->stash->{user} = $c->user();
     $c->stash->{template} = '/breeders_toolbox/manage_accessions.mas';
 }
 

--- a/mason/breeders_toolbox/add_accessions_dialogs.mas
+++ b/mason/breeders_toolbox/add_accessions_dialogs.mas
@@ -1,7 +1,12 @@
 <%args>
 $preferred_species => ""
 $editable_stock_props => {}
+$user => undef
 </%args>
+
+<%perl>
+    my $user_role = $user->get_object()->get_user_type();
+</%perl>
 
 <div class="modal fade" id="add_accessions_dialog" name="add_accessions_dialog" tabindex="-1" role="dialog" aria-labelledby="addAccessionsDialog" data-backdrop="static" data-keyboard="false">
   <div class="modal-dialog modal-lg" role="document">
@@ -37,9 +42,13 @@ $editable_stock_props => {}
                         <div class="form-group">
                             <label class="col-sm-4 control-label">Use Fuzzy Search: </label>
                             <div class="col-sm-8">
+% if ( $user_role eq 'curator' ) {
                                 <input type="checkbox" id="fuzzy_check" name="fuzzy_check" checked></input>
+% } else { 
+                                <input type="checkbox" id="fuzzy_check" name="fuzzy_check" checked disabled></input>
+% }
                                 <br/>
-                                <small>Note: Use the fuzzy search to match similar names to prevent uploading of duplicate accessions. Fuzzy searching is much slower than regular search.</small>
+                                <small>Note: Use the fuzzy search to match similar names to prevent uploading of duplicate accessions. Fuzzy searching is much slower than regular search. Only a curator can disable the fuzzy search.</small>
                             </div>
                         </div>
                     </form>
@@ -65,9 +74,13 @@ $editable_stock_props => {}
                         <div class="form-group">
                             <label class="col-sm-4 control-label">Use Fuzzy Search: </label>
                             <div class="col-sm-8">
+% if ( $user_role eq 'curator' ) {
                                 <input type="checkbox" id="fuzzy_check_upload_accessions" name="fuzzy_check_upload_accessions" checked></input>
+% } else {
+                                <input type="checkbox" id="fuzzy_check_upload_accessions" name="fuzzy_check_upload_accessions" checked disabled></input>
+% }
                                 <br/>
-                                <small>Note: Use the fuzzy search to match similar names to prevent uploading of duplicate accessions. Fuzzy searching is much slower than regular search.</small>
+                                <small>Note: Use the fuzzy search to match similar names to prevent uploading of duplicate accessions. Fuzzy searching is much slower than regular search. Only a curator can disable the fuzzy search.</small>
                             </div>
                         </div>
                     </form>

--- a/mason/breeders_toolbox/manage_accessions.mas
+++ b/mason/breeders_toolbox/manage_accessions.mas
@@ -4,6 +4,7 @@ $accessions
 $preferred_species => ""
 $list_id => undef
 $editable_stock_props => {}
+$user => undef
 </%args>
 
 <& /util/import_javascript.mas, classes => [ 'bootstrap_min.js', 'jquery.iframe-post-form','CXGN.List','CXGN.BreedersToolbox.Accessions', 'CXGN.BreedersToolbox.UploadPedigrees' ] &>
@@ -17,7 +18,7 @@ $editable_stock_props => {}
 <&| /page/info_section.mas, title=>'Accessions', collapsible=>1, collapsed=>0, subtitle=>'[<a name="add_accessions_link">Add Accessions Or Upload Accession Info</a>] [<a id="upload_pedigrees_link">Upload Pedigree File</a>]' &>
 
 <& /breeders_toolbox/accessions.mas, accessions=>$accessions &>
-<& /breeders_toolbox/add_accessions_dialogs.mas, preferred_species=>$preferred_species, editable_stock_props=>$editable_stock_props &>
+<& /breeders_toolbox/add_accessions_dialogs.mas, preferred_species=>$preferred_species, editable_stock_props=>$editable_stock_props, user=>$user &>
 <& /breeders_toolbox/upload_pedigrees_dialogs.mas &>
 <& /breeders_toolbox/manage_populations_dialogs.mas &>
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

If there was an error when uploading / adding new accessions from the Manage Accessions page, no error message was displayed and the working dialog would silently close with no feedback.

This fix displays an alert with the error message returned from the AJAX request

It also checks if the user has a role of curator, submitter or sequencer when uploading a file since those roles are required by the CXGN::UploadFile archive function.

It also disables the checkbox for the fuzzy search unless the user is a curator.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
