### PR TITLE
Addendum to PR/2748 for genotype download fixes

### DIFF
--- a/lib/CXGN/Genotype/Download/DosageMatrix.pm
+++ b/lib/CXGN/Genotype/Download/DosageMatrix.pm
@@ -88,6 +88,21 @@ has 'genotype_data_project_list' => (
     is => 'ro',
 );
 
+has 'chromosome_list' => (
+    isa => 'ArrayRef[Int]|ArrayRef[Str]|Undef',
+    is => 'ro',
+);
+
+has 'start_position' => (
+    isa => 'Int|Undef',
+    is => 'ro',
+);
+
+has 'end_position' => (
+    isa => 'Int|Undef',
+    is => 'ro',
+);
+
 has 'marker_name_list' => (
     isa => 'ArrayRef[Str]|Undef',
     is => 'ro',
@@ -144,6 +159,9 @@ sub download {
     my $return_only_first_genotypeprop_for_stock = $self->return_only_first_genotypeprop_for_stock;
     my $limit = $self->limit;
     my $offset = $self->offset;
+    my $chromosome_list = $self->chromosome_list;
+    my $start_position = $self->start_position;
+    my $end_position = $self->end_position;
 
     my $genotypes_search = CXGN::Genotype::Search->new({
         bcs_schema=>$schema,
@@ -159,6 +177,9 @@ sub download {
         protocolprop_top_key_select=>$protocolprop_top_key_select,
         protocolprop_marker_hash_select=>$protocolprop_marker_hash_select,
         return_only_first_genotypeprop_for_stock=>$return_only_first_genotypeprop_for_stock,
+        chromosome_list=>$chromosome_list,
+        start_position=>$start_position,
+        end_position=>$end_position,
         limit=>$limit,
         offset=>$offset
     });

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -1001,8 +1001,8 @@ sub key {
     my $protocolprophash = $json->encode( $self->protocolprop_top_key_select() || [] );
     my $protocolpropmarkerhash = $json->encode( $self->protocolprop_marker_hash_select() || [] );
     my $chromosomes = $json->encode( $self->chromosome_list() || [] );
-    my $start = $json->encode( $self->start_position() || [] );
-    my $end = $json->encode( $self->end_position() || [] );
+    my $start = $self->start_position() || '' ;
+    my $end = $self->end_position() || '';
     my $key = md5_hex($accessions.$tissues.$trials.$protocols.$markerprofiles.$genotypedataprojects.$markernames.$genotypeprophash.$protocolprophash.$protocolpropmarkerhash.$chromosomes.$start.$end.$self->return_only_first_genotypeprop_for_stock().$self->limit().$self->offset()."_$datatype");
     return $key;
 }
@@ -1049,7 +1049,13 @@ sub get_cached_file_dosage_matrix {
 
         my @all_marker_objects;
         foreach (@protocol_ids) {
-            my $protocol = CXGN::Genotype::Protocol->new({bcs_schema => $self->bcs_schema, nd_protocol_id => $_});
+            my $protocol = CXGN::Genotype::Protocol->new({
+                bcs_schema => $self->bcs_schema,
+                nd_protocol_id => $_,
+                chromosome_list=>$self->chromosome_list,
+                start_position=>$self->start_position,
+                end_position=>$self->end_position
+            });
             my $markers = $protocol->markers;
             push @all_marker_objects, values %$markers;
         }

--- a/lib/SGN/Controller/Stock.pm
+++ b/lib/SGN/Controller/Stock.pm
@@ -343,13 +343,9 @@ sub download_genotypes : Chained('get_stock') PathPart('genotypes') Args(0) {
     my $stock_type = $stock->type();
 
     if ($stock_id) {
-        my $dir = $c->tempfiles_subdir('genotype_download');
-        my ($tempfile, $uri) = $c->tempfile(TEMPLATE => "genotype_download/gt_download_XXXXX", UNLINK=> 0);
-        $tempfile = $tempfile.".vcf";
-
         my %genotype_download_factory = (
             bcs_schema=>$schema,
-            filename=>$tempfile,  #file path to write to
+            cache_root_dir=>$c->config->{cache_file_path},
             markerprofile_id_list=>$genotypeprop_id,
             #genotype_data_project_list=>$genotype_data_project_list,
             #marker_name_list=>['S80_265728', 'S80_265723'],
@@ -368,7 +364,7 @@ sub download_genotypes : Chained('get_stock') PathPart('genotypes') Args(0) {
             'VCF',    #can be either 'VCF' or 'GenotypeMatrix'
             \%genotype_download_factory
         );
-        my $status = $geno->download();
+        my $file_handle = $geno->download();
 
         $c->res->content_type("application/text");
         $c->res->cookies->{$dl_cookie} = {
@@ -376,8 +372,7 @@ sub download_genotypes : Chained('get_stock') PathPart('genotypes') Args(0) {
             expires => '+1m',
         };
         $c->res->header('Content-Disposition', qq[attachment; filename="BreedBaseGenotypesDownload.vcf"]);
-        my $output = read_file($tempfile);
-        $c->res->body($output);
+        $c->res->body($file_handle);
     }
 }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes genotype download cache in dosage matrix format to account for chromosome list, start, and end position

<!-- If there are relevant issues, link them here: -->
addendum to PR #2748 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
