### PR TITLE
add ibrc japan genotyping facility

### DIFF
--- a/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
+++ b/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
@@ -70,6 +70,7 @@
                                                     <option value="intertek">Intertek</option>
                                                     <option value="dart">Dart</option>
                                                     <option value="bgi">BGI</option>
+                                                    <option value="IBRC_Japan">IBRC Japan</option>
                                                 </select>
                                             </div>
                                         </div>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Adds IBRC Japan as a genotyping facility when uploading VCF

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
