### PR TITLE
Add 'multiple' attribute to trials list

### DIFF
--- a/mason/breeders_toolbox/folder/folder_set.mas
+++ b/mason/breeders_toolbox/folder/folder_set.mas
@@ -162,7 +162,7 @@ function breeding_program_change_folders() {
 
 function breeding_program_change_trials() {
   var breeding_program_id = jQuery("#folder_set_breeding_program_id").val();
-  get_select_box('projects', 'select_trial_for_folder', { 'name' : 'html_select_trial_for_folder', 'id' : 'html_select_trial_for_folder', 'breeding_program_id' : breeding_program_id, 'size':'20', 'get_field_trials':<% $get_field_trials %>, 'get_crossing_trials':<% $get_crossing_trials %>, 'get_genotyping_trials':<% $get_genotyping_trials %> });
+  get_select_box('projects', 'select_trial_for_folder', { 'name' : 'html_select_trial_for_folder', 'id' : 'html_select_trial_for_folder', 'breeding_program_id' : breeding_program_id, 'size':'20', 'get_field_trials':<% $get_field_trials %>, 'get_crossing_trials':<% $get_crossing_trials %>, 'get_genotyping_trials':<% $get_genotyping_trials %>, 'multiple': true });
 }
 
 function set_trial_folder() {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds the `multiple` attribute to the trials select box so multiple trials can be moved into a folder at once.

Fixes #2760 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
