### PR TITLE
Topic/trait addition interface

### DIFF
--- a/lib/CXGN/BrAPI/v1/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v1/ObservationVariables.pm
@@ -87,6 +87,7 @@ sub observation_variable_ontologies {
         $composable_cv_prop_sql = " cvprop.type_id IN ($composable_cv_prop_sql)";
     }
 
+    # Add db name spaces for databases tagged as trait_ontology, method_ontology, etc for the cvprop_type_names being queried. This added name spaces onto those taken from onto_root_namespaces conf key. When using the "add ontology web interface", ontologies are tagged with a cvprop type; however, when loading obo file ontologies, the cvprop must be added afterward.
     my $q1 = "SELECT distinct(db.name) FROM db JOIN dbxref ON(db.db_id = dbxref.db_id) JOIN cvterm ON(cvterm.dbxref_id = dbxref.dbxref_id) JOIN cv ON(cvterm.cv_id = cv.cv_id) JOIN cvprop ON(cvprop.cv_id=cv.cv_id) WHERE $composable_cv_prop_sql;";
     my $sth1 = $self->bcs_schema->storage->dbh->prepare($q1);
     $sth1->execute();

--- a/lib/CXGN/BrAPI/v1/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v1/ObservationVariables.pm
@@ -69,8 +69,8 @@ sub observation_variable_data_types {
 sub observation_variable_ontologies {
     my $self = shift;
 	my $inputs = shift;
-	my $name_spaces = $inputs->{name_spaces};
-	my $cvprop_types = $inputs->{cvprop_type_names} || [];
+	my $name_spaces = $inputs->{name_spaces} || [];
+	my $cvprop_types = $inputs->{cvprop_type_names} || ['trait_ontology','method_ontology','unit_ontology','composed_trait_ontology','object_ontology','attribute_ontology','time_ontology'];
 	my $page_size = $self->page_size;
 	my $page = $self->page;
 	my $status = $self->status;
@@ -84,11 +84,18 @@ sub observation_variable_ontologies {
     my $composable_cv_prop_sql;
     if (scalar(@composable_cv_prop_types)>0) {
         $composable_cv_prop_sql = join ("," , @composable_cv_prop_types);
-        $composable_cv_prop_sql = " AND cvprop.type_id IN ($composable_cv_prop_sql)";
+        $composable_cv_prop_sql = " cvprop.type_id IN ($composable_cv_prop_sql)";
+    }
+
+    my $q1 = "SELECT distinct(db.name) FROM db JOIN dbxref ON(db.db_id = dbxref.db_id) JOIN cvterm ON(cvterm.dbxref_id = dbxref.dbxref_id) JOIN cv ON(cvterm.cv_id = cv.cv_id) JOIN cvprop ON(cvprop.cv_id=cv.cv_id) WHERE $composable_cv_prop_sql;";
+    my $sth1 = $self->bcs_schema->storage->dbh->prepare($q1);
+    $sth1->execute();
+    while (my ($db_name) = $sth1->fetchrow_array()) {
+        push @$name_spaces, $db_name;
     }
 
 	#Using code pattern from SGN::Controller::AJAX::Onto->roots_GET
-	my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, dbxref.accession, dbxref.version, dbxref.description, cv.cv_id, cv.name, cv.definition FROM cvterm JOIN dbxref USING(dbxref_id) JOIN db USING(db_id) JOIN cv USING(cv_id) JOIN cvprop USING(cv_id) LEFT JOIN cvterm_relationship ON (cvterm.cvterm_id=cvterm_relationship.subject_id) WHERE cvterm_relationship.subject_id IS NULL AND is_obsolete= 0 AND is_relationshiptype = 0 and db.name=? $composable_cv_prop_sql;";
+	my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, dbxref.accession, dbxref.version, dbxref.description, cv.cv_id, cv.name, cv.definition FROM cvterm JOIN dbxref USING(dbxref_id) JOIN db USING(db_id) JOIN cv USING(cv_id) JOIN cvprop USING(cv_id) LEFT JOIN cvterm_relationship ON (cvterm.cvterm_id=cvterm_relationship.subject_id) WHERE cvterm_relationship.subject_id IS NULL AND is_obsolete= 0 AND is_relationshiptype = 0 and db.name=? AND $composable_cv_prop_sql;";
 	my $sth = $self->bcs_schema->storage->dbh->prepare($q);
 	foreach (@$name_spaces){
 		$sth->execute($_);

--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -163,6 +163,69 @@ sub store_composed_term {
     return \@new_terms;
 }
 
+sub store_ontology_identifier {
+    my $self = shift;
+    my $ontology_name = shift;
+    my $ontology_description = shift;
+    my $ontology_identifier = shift;
+    my $ontology_type = shift;
+    my $schema = $self->schema();
+    my $dbh = $schema->storage->dbh;
+
+    my $cv_check = $schema->resultset("Cv::Cv")->find({name=>$ontology_name});
+    if ($cv_check) {
+        return {
+            error => "The ontology name $ontology_name has already been used!";
+        }
+    }
+
+    my $db_check = $schema->resultset("General::Db")->find({name=>$ontology_name});
+    if ($db_check) {
+        return {
+            error => "The ontology identifier $ontology_identifier has already been used!";
+        }
+    }
+
+    my $coderef = sub {
+        my $cv_rs = $schema->resultset("Cv::Cv")->create({
+            name => $ontology_name,
+            definition => $ontology_description
+        });
+        my $new_cv_id = $cv_rs->cv_id();
+
+        my $db_rs = $schema->resultset("General::Db")->create({
+            name => $ontology_identifier
+        });
+        my $new_db_id = $db_rs->db_id();
+
+        my $dbxref_rs = $schema->resultset("General::Dbxref")->create({
+            db_id => $new_db_id,
+            accession => "0000000"
+        });
+        my $new_dbxref_id = $dbxref_rs->dbxref_id();
+
+        my $cvterm_rs = $schema->resultset("Cv::Cvterm")->create({
+            name => $ontology_name,
+            definition => $ontology_description,
+            dbxref_id => $new_dbxref_id,
+            cv_id => $new_cv_id
+        });
+
+        return {
+            success => 1,
+            new_term => [$cvterm_rs->cvterm_id(), $cvterm_rs->name()]
+        };
+    };
+    
+    try {
+        $schema->txn_do($coderef);
+    } catch {
+        return {
+            error => $@
+        };
+    };
+}
+
 sub store_observation_variable_trait_method_scale {
     my $self = shift;
     my $selected_observation_variable_db_id = shift;

--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -175,16 +175,18 @@ sub store_ontology_identifier {
     my $cv_check = $schema->resultset("Cv::Cv")->find({name=>$ontology_name});
     if ($cv_check) {
         return {
-            error => "The ontology name $ontology_name has already been used!";
-        }
+            error => "The ontology name $ontology_name has already been used!"
+        };
     }
 
     my $db_check = $schema->resultset("General::Db")->find({name=>$ontology_name});
     if ($db_check) {
         return {
-            error => "The ontology identifier $ontology_identifier has already been used!";
-        }
+            error => "The ontology identifier $ontology_identifier has already been used!"
+        };
     }
+
+    my $cv_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, $ontology_type, 'composable_cvtypes')->cvterm_id();
 
     my $coderef = sub {
         my $cv_rs = $schema->resultset("Cv::Cv")->create({
@@ -192,6 +194,11 @@ sub store_ontology_identifier {
             definition => $ontology_description
         });
         my $new_cv_id = $cv_rs->cv_id();
+
+        my $new_ontology_cvprop = $schema->resultset("Cv::Cvprop")->create({
+            cv_id   => $new_cv_id,
+            type_id => $cv_type_id
+        });
 
         my $db_rs = $schema->resultset("General::Db")->create({
             name => $ontology_identifier

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -653,10 +653,11 @@ sub get_ontologies : Path('/ajax/html/select/trait_variable_ontologies') Args(0)
     my $use_full_trait_name = $c->req->param("use_full_trait_name") || 0;
 
     my $observation_variables = CXGN::BrAPI::v1::ObservationVariables->new({
+        context => $c,
         bcs_schema => $c->dbic_schema("Bio::Chado::Schema"),
-	metadata_schema => $c->dbic_schema("CXGN::Metadata::Schema"),
-	phenome_schema=>$c->dbic_schema("CXGN::Phenome::Schema"),
-	people_schema => $c->dbic_schema("CXGN::People::Schema"),
+        metadata_schema => $c->dbic_schema("CXGN::Metadata::Schema"),
+        phenome_schema=>$c->dbic_schema("CXGN::Phenome::Schema"),
+        people_schema => $c->dbic_schema("CXGN::People::Schema"),
         page_size => 1000000,
         page => 0,
         status => []

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -649,7 +649,7 @@ sub get_seedlots_select : Path('/ajax/html/select/seedlots') Args(0) {
 sub get_ontologies : Path('/ajax/html/select/trait_variable_ontologies') Args(0) {
     my $self = shift;
     my $c = shift;
-    my $cvprop_type_names = $c->req->param("cvprop_type_name") ? decode_json $c->req->param("cvprop_type_name") : ['trait_ontology'];
+    my $cvprop_type_names = $c->req->param("cvprop_type_name") ? decode_json $c->req->param("cvprop_type_name") : ['trait_ontology', 'method_ontology', 'unit_ontology'];
     my $use_full_trait_name = $c->req->param("use_full_trait_name") || 0;
 
     my $observation_variables = CXGN::BrAPI::v1::ObservationVariables->new({
@@ -663,14 +663,7 @@ sub get_ontologies : Path('/ajax/html/select/trait_variable_ontologies') Args(0)
         status => []
     });
 
-    #Using code pattern found in SGN::Controller::Ontology->onto_browser
-    my $onto_root_namespaces = $c->config->{trait_variable_onto_root_namespaces};
-    my @namespaces = split ", ", $onto_root_namespaces;
-    foreach my $n (@namespaces) {
-        $n =~ s/\s*(\w+)\s*\(.*\)/$1/g;
-    }
-
-    my $result = $observation_variables->observation_variable_ontologies({name_spaces => \@namespaces, cvprop_type_names => $cvprop_type_names});
+    my $result = $observation_variables->observation_variable_ontologies({cvprop_type_names => $cvprop_type_names});
     #print STDERR Dumper $result;
 
     my @ontos;
@@ -984,11 +977,17 @@ sub all_ontology_terms_select : Path('/ajax/html/select/all_ontology_terms') Arg
 
     my $empty = $c->request->param("empty") || '';
     my $multiple =  $c->req->param("multiple") || 0;
+    my $exclude_top_term =  $c->req->param("exclude_top_term") || 1;
 
     my $bcs_schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
 
+    my $exclude_top_sql = '';
+    if ($exclude_top_term) {
+        $exclude_top_sql = " AND dbxref.accession != '0000000' ";
+    }
+
     my @ontology_terms;
-    my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, dbxref.accession, count(cvterm.cvterm_id) OVER() AS full_count FROM cvterm JOIN dbxref USING(dbxref_id) JOIN db using(db_id) WHERE db_id=$db_id ORDER BY cvterm.name;";
+    my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, dbxref.accession, count(cvterm.cvterm_id) OVER() AS full_count FROM cvterm JOIN dbxref USING(dbxref_id) JOIN db using(db_id) WHERE db_id=$db_id $exclude_top_sql ORDER BY cvterm.name;";
     my $sth = $bcs_schema->storage->dbh->prepare($q);
     $sth->execute();
     while (my ($cvterm_id, $cvterm_name, $cvterm_definition, $db_name, $db_id, $accession, $count) = $sth->fetchrow_array()) {

--- a/lib/SGN/Controller/AJAX/Search/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Search/Trait.pm
@@ -22,10 +22,8 @@ sub search : Path('/ajax/search/traits') Args(0) {
     my $params = $c->req->params() || {};
     #print STDERR Dumper $params;
 
-    my $trait_cv_name = $params->{trait_cv_name} || $c->config->{trait_cv_name};
     my $ontology_db_ids;
     if ($params->{'ontology_db_id[]'}){
-        $trait_cv_name = undef;
         $ontology_db_ids = ref($params->{'ontology_db_id[]'}) eq 'ARRAY' ? $params->{'ontology_db_id[]'} : [$params->{'ontology_db_id[]'}];
     }
 
@@ -57,7 +55,6 @@ sub search : Path('/ajax/search/traits') Args(0) {
 
     my $trait_search = CXGN::Trait::Search->new({
         bcs_schema=>$schema,
-        trait_cv_name => $trait_cv_name,
         ontology_db_id_list => $ontology_db_ids,
         limit => $limit,
         offset => $offset,

--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -1833,8 +1833,8 @@ sub get_stock_datatables_genotype_data : Chained('/stock/get_stock') :PathPart('
 sub get_stock_datatables_genotype_data_GET  {
     my $self = shift;
     my $c = shift;
-    my $limit = $c->req->param('length');
-    my $offset = $c->req->param('start');
+    my $limit = $c->req->param('length') || 1000;
+    my $offset = $c->req->param('start') || 0;
     my $stock_id = $c->stash->{stock_row}->stock_id();
 
     my $schema = $c->dbic_schema("Bio::Chado::Schema", 'sgn_chado');

--- a/lib/SGN/Controller/Search/Trait.pm
+++ b/lib/SGN/Controller/Search/Trait.pm
@@ -8,9 +8,6 @@ BEGIN { extends 'Catalyst::Controller'; }
 sub trait_search_page : Path('/search/traits/') Args(0) {
     my $self = shift;
     my $c = shift;
-    my $trait_cv_name = $c->get_conf("trait_cv_name");
-
-    $c->stash->{trait_cv_name} = $trait_cv_name  || 'not_provided';
     $c->stash->{template} = '/search/traits.mas';
 }
 

--- a/mason/breeders_toolbox/add_new_trait_dialogs.mas
+++ b/mason/breeders_toolbox/add_new_trait_dialogs.mas
@@ -311,9 +311,9 @@
                                     <label class="col-sm-3 control-label">Ontology Type: </label>
                                     <div class="col-sm-9">
                                         <select class="form-control" id="add_new_observation_variable_ontology_type" name="add_new_observation_variable_ontology_type"/>
-                                            <option value="trait">Trait or Observation Variable</option>
-                                            <option value="method">Method</option>
-                                            <option value="unit">Scale</option>
+                                            <option value="trait_ontology">Trait or Observation Variable</option>
+                                            <option value="method_ontology">Method</option>
+                                            <option value="unit_ontology">Scale</option>
                                         </select>
                                     </div>
                                 </div>

--- a/mason/breeders_toolbox/add_new_trait_dialogs.mas
+++ b/mason/breeders_toolbox/add_new_trait_dialogs.mas
@@ -23,6 +23,11 @@
 
                             <br/><br/>
                             <center>
+                                <button class="btn btn-primary" id="add_new_observation_variable_ontology_add_button">Need a new ontology? Click here first.</button>
+                            </center>
+
+                            <br/><br/>
+                            <center>
                                 <button class="btn btn-primary" onclick="Workflow.complete(this);">Go to Next Step</button>
                             </center>
                         </&>
@@ -256,8 +261,92 @@
     </div>
 </div>
 
+<div class="modal fade" id="add_new_observation_variable_ontology_dialog" name="add_new_observation_variable_ontology_dialog" tabindex="-1" role="dialog" aria-labelledby="addNewObservationVariableOntologyDialog">
+    <div class="modal-dialog modal-xl" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="addNewObservationVariableOntologyDialog">Add New Ontology</h4>
+            </div>
+            <div class="modal-body">
+                <div class="container-fluid">
+
+                    <&| /util/workflow.mas, id=> "add_new_ontology_workflow" &>
+                        <&| /util/workflow.mas:step, title=> "Intro" &>
+                            <& /page/page_title.mas, title=>"Start a new ontology" &>
+                            <ul>
+                                <li>In this workflow you can add a new ontology to the database. Once an ontology is added, you can add terms into it from the add observation variables workflow.</li>
+                                <li>Ontologies are tagged as being either for traits, methods, or scales</li>
+                            </ul>
+
+                            <br/><br/>
+                            <center>
+                                <button class="btn btn-primary" onclick="Workflow.complete(this);">Go to Next Step</button>
+                            </center>
+                        </&>
+
+                        <&| /util/workflow.mas:step, title=> "Ontology" &>
+                            <& /page/page_title.mas, title=>"Define your ontology" &>
+
+                            <form class="form-horizontal">
+                                <div class="form-group">
+                                    <label class="col-sm-3 control-label">New Ontology Name: </label>
+                                    <div class="col-sm-9">
+                                        <input class="form-control" id="add_new_observation_variable_ontology_name" name="add_new_observation_variable_ontology_name" type="text" placeholder="e.g. MyBreedingProgram Grape Ontology"/>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label class="col-sm-3 control-label">New Ontology Definition: </label>
+                                    <div class="col-sm-9">
+                                        <input class="form-control" id="add_new_observation_variable_ontology_definition" name="add_new_observation_variable_ontology_definition" type="text" placeholder="e.g. description of the ontology"/>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label class="col-sm-3 control-label">New Ontology Database Identifier: </label>
+                                    <div class="col-sm-9">
+                                        <input class="form-control" id="add_new_observation_variable_ontology_db_name" name="add_new_observation_variable_ontology_db_name" type="text" placeholder="a unique identifier for the terms in the ontology e.g. CO322"/>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label class="col-sm-3 control-label">Ontology Type: </label>
+                                    <div class="col-sm-9">
+                                        <select class="form-control" id="add_new_observation_variable_ontology_type" name="add_new_observation_variable_ontology_type"/>
+                                            <option value="trait">Trait or Observation Variable</option>
+                                            <option value="method">Method</option>
+                                            <option value="unit">Scale</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </form>
+                            <br/>
+
+                            <center>
+                                <button class="btn btn-primary" id="add_new_trait_observation_variable_ontology_step">Go to Next Step</button>
+                            </center>
+
+                        </&>
+                        <&| /util/workflow.mas:complete, title=> "Complete" &>
+                            <& /page/page_title.mas, title=>"Finished! Your ontology is now in the database. Add new terms into it from the add observation variable workflow." &>
+                        </&>
+
+                    </&><!-- End of workflow -->
+
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script>
 jQuery(document).ready(function() {
+
+    jQuery('#add_new_observation_variable_ontology_add_button').click(function(){
+        jQuery('#add_new_observation_variable_ontology_dialog').modal('show');
+    });
+
     jQuery('button[name="add_new_observation_variable_button"]').click(function(){
         jQuery('#add_new_observation_variable_dialog').modal('show');
 

--- a/mason/breeders_toolbox/add_new_trait_dialogs.mas
+++ b/mason/breeders_toolbox/add_new_trait_dialogs.mas
@@ -321,7 +321,7 @@
                             <br/>
 
                             <center>
-                                <button class="btn btn-primary" id="add_new_trait_observation_variable_ontology_step">Go to Next Step</button>
+                                <button class="btn btn-primary" id="add_new_trait_observation_variable_ontology_step">Store Ontology</button>
                             </center>
 
                         </&>
@@ -637,6 +637,41 @@ jQuery(document).ready(function() {
             error: function(response){
                 jQuery("#working_modal").modal("hide");
                 alert("Error saving observation variable.");
+            }
+        });
+    });
+
+    jQuery('#add_new_trait_observation_variable_ontology_step').click(function(){
+        jQuery.ajax ({
+            url: '/ajax/onto/store_ontology_identifier',
+            type: 'POST',
+            data: {
+                'ontology_name':jQuery('#add_new_observation_variable_ontology_name').val(),
+                'ontology_description':jQuery('#add_new_observation_variable_ontology_definition').val(),
+                'ontology_identifier':jQuery('#add_new_observation_variable_ontology_db_name').val(),
+                'ontology_type':jQuery('#add_new_observation_variable_ontology_type').val()
+            },
+            beforeSend: function() {
+                jQuery("#working_modal").modal("show");
+            },
+            success: function(response){
+                console.log(response);
+                jQuery("#working_modal").modal("hide");
+                //if (response.message){
+                //    Workflow.complete('#add_new_trait_observation_variable_ontology_step');
+                //    Workflow.focus("#add_new_ontology_workflow", -1); //go to success page
+                //}
+                if (response.success) {
+                    alert(response.success);
+                }
+                if (response.error) {
+                    alert(response.error);
+                }
+                location.reload();
+            },
+            error: function(response){
+                jQuery("#working_modal").modal("hide");
+                alert("Error saving ontology.");
             }
         });
     });

--- a/mason/breeders_toolbox/add_new_trait_dialogs.mas
+++ b/mason/breeders_toolbox/add_new_trait_dialogs.mas
@@ -23,7 +23,7 @@
 
                             <br/><br/>
                             <center>
-                                <button class="btn btn-primary" id="add_new_observation_variable_ontology_add_button">Need a new ontology? Click here first.</button>
+                                <button class="btn btn-primary" name="add_new_observation_variable_ontology_add_button">Need a new ontology? Click here first.</button>
                             </center>
 
                             <br/><br/>
@@ -37,6 +37,11 @@
 
                             <p>An observation variable is composed of a trait for the attribute being observed, a method describing how the attribute was measured, and a scale indicating the units of the observation.</p>
                             <hr>
+
+                            <center>
+                                <button class="btn btn-primary" name="add_new_observation_variable_ontology_add_button">Need a new ontology? Click here first.</button>
+                            </center>
+                            <br/><br/>
 
                             <form class="form-horizontal">
                                 <div class="form-group">
@@ -74,6 +79,11 @@
                                 <li>Here you can select a trait that already exists in an ontology in the database or you can add a new trait into an ontology.</li>
                             </ul>
                             <hr>
+
+                            <center>
+                                <button class="btn btn-primary" name="add_new_observation_variable_ontology_add_button">Need a new ontology? Click here first.</button>
+                            </center>
+                            <br/><br/>
 
                             <form class="form-horizontal">
                                 <div class="form-group">
@@ -119,6 +129,11 @@
                             <p>A method defines the how it was measured measured. It is one component of an observation variable; the others are a trait and a scale.</p>
                             <hr>
 
+                            <center>
+                                <button class="btn btn-primary" name="add_new_observation_variable_ontology_add_button">Need a new ontology? Click here first.</button>
+                            </center>
+                            <br/><br/>
+
                             <form class="form-horizontal">
                                 <div class="form-group">
                                     <label class="col-sm-3 control-label">Method Ontology Name: </label>
@@ -161,6 +176,11 @@
                         </&>
                         <&| /util/workflow.mas:step, title=> "Scale" &>
                             <& /page/page_title.mas, title=>"Define your scale" &>
+
+                            <center>
+                                <button class="btn btn-primary" name="add_new_observation_variable_ontology_add_button">Need a new ontology? Click here first.</button>
+                            </center>
+                            <br/><br/>
 
                             <form class="form-horizontal">
                                 <div class="form-group">
@@ -343,7 +363,7 @@
 <script>
 jQuery(document).ready(function() {
 
-    jQuery('#add_new_observation_variable_ontology_add_button').click(function(){
+    jQuery('button[name="add_new_observation_variable_ontology_add_button"]').click(function(){
         jQuery('#add_new_observation_variable_ontology_dialog').modal('show');
     });
 
@@ -397,7 +417,7 @@ jQuery(document).ready(function() {
             alert('Only select one trait ontology!');
         } else {
             add_new_trait_new_trait_db_id = selected[0];
-            get_select_box('all_ontology_terms', 'add_new_trait_existing_trait_select_div', { 'selectbox_name':'add_new_trait_existing_trait_select',    'selectbox_id':'add_new_trait_existing_trait_select', 'empty':1, 'db_id':selected[0] });
+            get_select_box('all_ontology_terms', 'add_new_trait_existing_trait_select_div', { 'selectbox_name':'add_new_trait_existing_trait_select',    'selectbox_id':'add_new_trait_existing_trait_select', 'empty':1, 'db_id':selected[0], 'exclude_top_term':1 });
         }
     });
 
@@ -411,7 +431,7 @@ jQuery(document).ready(function() {
             alert('Only select one method ontology!');
         } else {
             add_new_trait_new_method_db_id = selected[0];
-            get_select_box('all_ontology_terms', 'add_new_trait_existing_method_select_div', { 'selectbox_name':'add_new_trait_existing_method_select',    'selectbox_id':'add_new_trait_existing_method_select', 'empty':1, 'db_id':selected[0] });
+            get_select_box('all_ontology_terms', 'add_new_trait_existing_method_select_div', { 'selectbox_name':'add_new_trait_existing_method_select',    'selectbox_id':'add_new_trait_existing_method_select', 'empty':1, 'db_id':selected[0], 'exclude_top_term':1 });
         }
     });
 
@@ -425,7 +445,7 @@ jQuery(document).ready(function() {
             alert('Only select one scale ontology!');
         } else {
             add_new_trait_new_scale_db_id = selected[0];
-            get_select_box('all_ontology_terms', 'add_new_trait_existing_scale_select_div', { 'selectbox_name':'add_new_trait_existing_scale_select',    'selectbox_id':'add_new_trait_existing_scale_select', 'empty':1, 'db_id':selected[0] });
+            get_select_box('all_ontology_terms', 'add_new_trait_existing_scale_select_div', { 'selectbox_name':'add_new_trait_existing_scale_select',    'selectbox_id':'add_new_trait_existing_scale_select', 'empty':1, 'db_id':selected[0], 'exclude_top_term':1 });
         }
     });
 

--- a/mason/search/traits.mas
+++ b/mason/search/traits.mas
@@ -1,6 +1,5 @@
 
 <%args>
-$trait_cv_name
 </%args>
 
 <& /util/import_javascript.mas, classes => [ 'jquery', 'jquery.dataTables', 'jquery.dataTables-select-min' ] &>
@@ -107,7 +106,7 @@ $trait_cv_name
 
 jQuery(document).ready(function () {
 
-    get_select_box('trait_variable_ontologies', 'trait_search_ontology_select', { 'name' : 'trait_search_ontology_select_id', 'cvprop_type_name':JSON.stringify(['trait_ontology','composed_trait_ontology','attribute_ontology']) });
+    get_select_box('trait_variable_ontologies', 'trait_search_ontology_select', { 'name' : 'trait_search_ontology_select_id', 'cvprop_type_name':JSON.stringify(['trait_ontology','method_ontology','unit_ontology','composed_trait_ontology','object_ontology','attribute_ontology','time_ontology']) });
 
     var lo = new CXGN.List();
     jQuery('#trait_search_list_select').html(lo.listSelect('trait_search_list_select', [ 'traits' ], 'Leave blank to see all traits', undefined, undefined));
@@ -152,7 +151,7 @@ jQuery(document).ready(function () {
                 'style':    'multi'
             },
             'ajax': {
-                'url': '/ajax/search/traits?trait_cv_name=<% $trait_cv_name %>',
+                'url': '/ajax/search/traits',
                 'data': function(d) {
                     d.trait_search_list_id  = jQuery('#trait_search_list_select_list_select').val();
                     d.trait_any_name  = jQuery('#trait_search_name').val();

--- a/sgn.conf
+++ b/sgn.conf
@@ -24,12 +24,9 @@ composable_toy_root_cvterm "time of year|TIME:0000005"
 composable_gen_root_cvterm "generation|TIME:0000072"
 composable_evt_root_cvterm "event|TIME:0000477"
 allow_observation_variable_submission_interface 0
-trait_cv_name cassava_trait
 trait_ontology_db_name SP
 # For displaying ontologies in Ontology Browser
 onto_root_namespaces  GO (Gene Ontology), PO (Plant Ontology), SO (Sequence Ontology), PATO (Phenotype and Trait Ontology), SP (Solanaceae Ontology), UO (Units), CASSTISS (Cass tissues)
-# For Trait Search page
-trait_variable_onto_root_namespaces CO_322 (Cassava Ontology), UO (Units), CASSTISS (Cass tissues), COMP (Composed Variables)
 
 project_name SGN
 

--- a/system_cvterms.txt
+++ b/system_cvterms.txt
@@ -268,13 +268,13 @@ protocol_property	protocol comment	From BrAPI	03/27/2017	nm529	00076
 protocol_property	vcf_map_details	Information about protocol, such as marker names, header info lines, and reference_genome_name	6/20/2018	nm529	00098
 protocol_property	vcf_map_details_markers	Genotyping protocol marker info in an object format	9/17/2019	nm529	00115
 protocol_property	vcf_map_details_markers_array	Genotyping protocol marker info in an array format	9/17/2019	nm529	00115
-composable_cvs	trait_ontology		05/01/2017		00073
-composable_cvs	composed_trait_ontology		05/01/2017		00073
-composable_cvs	object_ontology		05/01/2017		00073
-composable_cvs	attribute_ontology		05/01/2017		00073
-composable_cvs	method_ontology		05/01/2017		00073
-composable_cvs	unit_ontology		05/01/2017		00073
-composable_cvs	time_ontology		05/01/2017		00073
+composable_cvtypes	trait_ontology		05/01/2017		00073
+composable_cvtypes	composed_trait_ontology		05/01/2017		00073
+composable_cvtypes	object_ontology		05/01/2017		00073
+composable_cvtypes	attribute_ontology		05/01/2017		00073
+composable_cvtypes	method_ontology		05/01/2017		00073
+composable_cvtypes	unit_ontology		05/01/2017		00073
+composable_cvtypes	time_ontology		05/01/2017		00073
 project_design? 						suggested to move the trial design names from projectprop.value to projectprop.type_id
 phenotype_property  phenotype_outlier   suppressed phenotype measurement    01/04/2018  aco46   00089
 project_md_image	raw_drone_imagery	Raw images uploaded as drone imagery	9/6/2018	nm529	00103

--- a/t/unit_fixture/CXGN/Onto.t
+++ b/t/unit_fixture/CXGN/Onto.t
@@ -430,4 +430,17 @@ $response = decode_json $mech->content;
 print STDERR Dumper $response;
 ok($response->{success});
 
+$mech->post_ok('http://localhost:3010/ajax/onto/store_ontology_identifier',
+    [
+        "sgn_session_id"=>$sgn_session_id,
+        "ontology_name"=> "NewOntology1",
+        "ontology_description"=> "new ontology",
+        "ontology_identifier"=> "NOO1",
+        "ontology_type"=> "method_ontology",
+    ]
+);
+$response = decode_json $mech->content;
+print STDERR Dumper $response;
+ok($response->{success});
+
 done_testing();

--- a/t/unit_mech/AJAX/Search/Trait.t
+++ b/t/unit_mech/AJAX/Search/Trait.t
@@ -16,7 +16,7 @@ my $schema = $f->bcs_schema;
 my $mech = Test::WWW::Mechanize->new;
 my $response;
 
-$mech->post_ok('http://localhost:3010/ajax/search/traits?trait_cv_name=cassava_trait&length=5&start=1' );
+$mech->post_ok('http://localhost:3010/ajax/search/traits?length=5&start=1' );
 $response = decode_json $mech->content;
 print STDERR Dumper $response;
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Adds a simple interface to add new ontology into the database. An ontology is defined with: a name, a description, an identifier (e.g. CO322), and an ontology type (trait, method, scale).

There already exists an interface to add observation variables with traits, methods, and scales into the database https://solgenomics.github.io/sgn/03_managing_breeding_data/03_16.html
However, to activate this interface you must set the allow_observation_variable_submission_interface to 1 in the sgn configuration file.


<!-- If there are relevant issues, link them here: -->
closes #2798 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
