### PR TITLE
Upload Accessions: fuzzy search and error message

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
@@ -365,9 +365,9 @@ jQuery(document).ready(function ($) {
             console.log(response);
             jQuery('#working_modal').modal("hide");
 
-            if (response.error) {
+            if (response.error || response.error_string) {
                 fullParsedData = undefined;
-                alert(response.error);
+                alert(response.error || response.error_string);
             }
             else if (response.success) {
                 fullParsedData = response.full_data;

--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -229,7 +229,8 @@ sub verify_accessions_file_POST : Args(0) {
 
     my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
     my $upload = $c->req->upload('new_accessions_upload_file');
-    my $do_fuzzy_search = $c->req->param('fuzzy_check_upload_accessions') ? 1 : 0;
+    my $do_fuzzy_search = $user_role eq 'curator' && !$c->req->param('fuzzy_check_upload_accessions') ? 0 : 1;
+
     if ($user_role ne 'curator' && !$do_fuzzy_search) {
         $c->stash->{rest} = {error=>'Only a curator can add accessions without using the fuzzy search!'};
         $c->detach();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

When a non-curator was uploading an accession template:

In some cases the disabled (but checked) fuzzy search checkbox was not being sent as checked to the `verify_accessions_file` endpoint and the user was receiving an error stating only a curator can disable the fuzzy search.

This fix will only disable the fuzzy search in the `verify_accessions_file` endpoint if the user is a curator when the checkbox is off.

It also displays error messages sent in the `error_string` property of some responses (others use the `error` property).


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
