### PR TITLE
Topic/duplication on sequenced accessions page

### DIFF
--- a/lib/SGN/Controller/AJAX/SequencedAccessions.pm
+++ b/lib/SGN/Controller/AJAX/SequencedAccessions.pm
@@ -5,6 +5,7 @@ use Moose;
 
 use Data::Dumper;
 use DateTime;
+use List::MoreUtils qw(uniq);
 use CXGN::Stock::SequencingInfo;
 
 __PACKAGE__->config(
@@ -53,7 +54,7 @@ sub retrieve_sequencing_infos {
 
     my @data = ();
 
-    foreach my $stock_id (@stock_ids) {
+    foreach my $stock_id (uniq @stock_ids) {
 	print STDERR "retrieving data for stock stock_id...\n";
 	my $infos = CXGN::Stock::SequencingInfo->get_sequencing_project_infos($schema, $stock_id);
 

--- a/mason/genomes/sequenced_accessions.mas
+++ b/mason/genomes/sequenced_accessions.mas
@@ -3,24 +3,89 @@
 </%args>
 
 <& /util/import_css.mas, paths => ['/documents/inc/datatables/jquery.dataTables.css'] &>
-  
+
 <& /util/import_javascript.mas,
   entries => ["sequenced_accessions"]
 &>
 
 
 <& /page/page_title.mas, title=> "Sequenced Accessions" &>
-  
-  <div id="sequenced_stocks_div">[loading...]</div>
-  
+
+<div>
+<table class="table table-condensed" cellspacing="20px" id="sequenced_stocks_table" >
+<thead>
+   <tr>
+   <th>Accession</th>
+   <th>Year</th>
+<th>Organization</th>
+   <th>Website</th>
+<th>Analyze</th>
+<th>Manage</th>
+   </tr>
+</thead>
+</table>
+</div>
+<!-- Dialog for adding sequencing info -->
+
+ <div class="modal fade" id="edit_sequencing_info_dialog" role="dialog">
+<div class="modal-dialog" role="modal">
+ <div class="modal-content">
+
+   <div class="modal-header">
+     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <div aria-hidden="true">&times;</div>
+     </button>
+
+         <h5 class="modal-title">Enter sequencing info for accession:</h5>
+   </div> <!-- modal-header -->
+<form id="sequencing_info_form">
+   <div class="modal-body">
+         <div class="form-search">
+           <input type="text" class="form-control" alt="Organization" placeholder="Sequencing organization" name="organization" id="organization" size="30"/>
+<br />
+       <input type="text" class="form-control mb-4" placeholder="Sequencing year" name="sequencing_year" id="sequencing_year" size="6"></input><br />
+       <div class="input-group">
+             <span class="input-group-addon" id="https-prefix">https:&sol;&sol;</span>
+         <input type="text" class="form-control" placeholder="Website" aria-label="https-prefix" aria-describedby="https-prefix" name="website"  id="website" size="10" />
+</div> <!-- input-group -->
+<br />
+   <input type="text" class="form-control" placeholder="Contact email" name="contact_email"  id="contact_email" size="10" />
+<br />
+<input type="text" class="form-control" placeholder="Genbank Accession" name="genbank_accession"  id="genbank_accession" size="10" />
+<br />
+<input type="text" class="form-control" placeholder="Funding organization" name="funded_by"  id="funded_by" size="10" />
+<br />
+<input type="text" class="form-control" placeholder="Funding organization project ID"  name="funder_project_id" id="funder_project_id" size="10" />
+   <br />
+          <div class="input-group mb-3">
+        <input type="text" class="form-control" placeholder="Jbrowse link" name="jbrowse_link" id="jbrowse_link" size="20"></input><br />
+      </div> <!-- input group -->
+          <br />
+      <div class="input-group mb-3">
+        <input type="text" class="form-control" placeholder="BLAST link" name="blast_link" id="blast_link" size="20"></input><br />
+</div> <!-- input group -->
+
+<input id="stock_id"  name="stock_id" value="`+stock_id+`" />
+<input type="hidden" id="stockprop_id"  name="stockprop_id" value="`+stockprop_id+`" />
+   </div> <!-- form-search -->
+  </div> <!-- modal-body -->
+  <div class="modal-footer">
+        <button id="save_sequencing_info_button" type="submit" class="btn btn-primary">Save changes</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+  </div> <!-- modal-footer -->
+</form> <!-- sequencing_info form -->
+</div> <!-- modal-content -->
+</div> <!-- modal-dialog -->
+</div> <!-- modal -->
+
+
+<div id="sequenced_stocks_div">
+</div>
+
   <script>
-    $(window).ready( function() {
+    jQuery(document).ready( function() {
     //alert("HELLO");
     var sequenced_stocks = window.jsMod['sequenced_accessions'].init("sequenced_stocks_div");
     //alert("HELLO AGAIN!");
     });
   </script>
-
-  
-
- 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes the multiple appearances of sequencing info entries on the sequenced accessions page. Also, fixes bug where table doesn't appear by incorporating mason structure in sequenced_accessions mason.

<!-- If there are relevant issues, link them here: -->
Fixes issue #2788 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.