### PR TITLE
enable UTF-8 in Mason.

### DIFF
--- a/lib/SGN/View/Mason.pm
+++ b/lib/SGN/View/Mason.pm
@@ -24,6 +24,7 @@ __PACKAGE__->config(
         comp_root => [
             [ main => SGN->path_to('mason') ],
         ],
+        preamble => "use utf8; ",
     },
 );
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This pull request will enable UTF-8 in mason files, thereby allowing foreign language fonts to be displayed correctly on the site.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [x] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
