### PR TITLE
remove debugging alert box after account into change.

### DIFF
--- a/mason/user/change_account.mas
+++ b/mason/user/change_account.mas
@@ -91,7 +91,7 @@ Please verify your current password to make changes. Select changes desired by c
     jQuery('#change_account_form').submit( function(event) { 
        event.preventDefault();
        var form_data = jQuery('#change_account_form').serialize();
-       alert(JSON.stringify(form_data));
+       // alert(JSON.stringify(form_data));
        jQuery.ajax( { 
          url: '/ajax/user/update',
          data: form_data,
@@ -99,7 +99,7 @@ Please verify your current password to make changes. Select changes desired by c
          success: function(r) {
            if (r.error) { alert(r.error); }
            else { 
-             alert(r.message);
+             alert("Done! " +r.message);
            }
          }
        });


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

fixes #2871 - system displayed a debugging alert box. It has been removed.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
