### PR TITLE
Fixes to trait search to check for VARIABLE_OF relationship

### DIFF
--- a/lib/CXGN/Trait/Search.pm
+++ b/lib/CXGN/Trait/Search.pm
@@ -146,8 +146,8 @@ sub search {
             join => [{'cvterm_relationship_subjects' => 'type'}, {'dbxref' => 'db'} ],
             where => \%where_join,
             order_by => { '-asc' => $order_by },
-            '+select' => ['db.name', 'dbxref.accession'],
-            '+as' => ['db_name', 'db_accession'],
+            '+select' => ['db.name', 'dbxref.accession', 'type.name'],
+            '+as' => ['db_name', 'db_accession', 'cvterm_relationship_name'],
             distinct => 1
         }
     );
@@ -169,6 +169,7 @@ sub search {
             trait_definition => $t->definition,
             db_name => $t->get_column('db_name'),
             accession=> $t->get_column('db_accession'),
+            cvterm_relationship_name=> $t->get_column('cvterm_relationship_name')
         };
     }
 

--- a/lib/SGN/Controller/AJAX/Search/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Search/Trait.pm
@@ -74,6 +74,9 @@ sub search : Path('/ajax/search/traits') Args(0) {
                 "<a href=\"/cvterm/$_->{trait_id}/view\">$trait_accession</a>",
                 "<a href=\"/cvterm/$_->{trait_id}/view\">$_->{trait_name}</a>",
                 $_->{trait_definition},
+                $_->{cvterm_relationship_name},
+                $_->{trait_name},
+                $trait_accession
             ];
     }
     #print STDERR Dumper \@result;

--- a/mason/search/traits.mas
+++ b/mason/search/traits.mas
@@ -52,10 +52,11 @@
                     <table id="trait_search_results" width="100%" class="table table-hover table-striped">
                     <thead>
                       <tr>
-                        <th></th>
+                        <th>Select <a href="#" data-toggle="tooltip" data-placement="top" title="Only observation variables can be used for collecting phenotypes. For this reason, only observation variables can be selected below. More technically, these terms have VARIABLE_OF relationships in the database."><span class="glyphicon glyphicon-info-sign"></span></a></th>
                         <th>Trait ID</th>
                         <th>Trait Name</th>
                         <th>Definition</th>
+                        <th>Type</th>
                     </tr>
                     </thead>
                     </table>
@@ -107,6 +108,8 @@
 jQuery(document).ready(function () {
 
     get_select_box('trait_variable_ontologies', 'trait_search_ontology_select', { 'name' : 'trait_search_ontology_select_id', 'cvprop_type_name':JSON.stringify(['trait_ontology','method_ontology','unit_ontology','composed_trait_ontology','object_ontology','attribute_ontology','time_ontology']) });
+
+    jQuery('[data-toggle="tooltip"]').tooltip();
 
     var lo = new CXGN.List();
     jQuery('#trait_search_list_select').html(lo.listSelect('trait_search_list_select', [ 'traits' ], 'Leave blank to see all traits', undefined, undefined));
@@ -174,13 +177,21 @@ jQuery(document).ready(function () {
    var selection_changed = function () {
      var selected_rows = trait_table.rows({'selected':true});
      jQuery("#trait_result_count").text(selected_rows.count());
+     //console.log(selected_rows.data());
+
      var name_links = selected_rows.data().map(function(row){
-       return [row[2], row[1]];
+        if (row[4] == 'VARIABLE_OF') {
+            return [row[5], row[6]];
+        }
+        else {
+            alert(row[5]+' is not an observation variable! Do no try to collect phenotypes for terms which are not observation variables! More technically, your term needs to have a VARIABLE_OF relationship!');
+            trait_table.rows().deselect();
+        }
      });
 
      var names = [];
      for (var i = 0; i < name_links.length; i++) { //extract and combine trait name and id from anchor tags
-       names.push(name_links[i][0].match(/<a [^>]+>([^<]+)<\/a>/)[1] + '|' + name_links[i][1].match(/<a [^>]+>([^<]+)<\/a>/)[1] + '\n');
+       names.push(name_links[i][0] + '|' + name_links[i][1] + '\n');
      }
 
      jQuery('#trait_result_names').html(names);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The trait search table checks for VARIABLE_OF before adding to list. also shows the relationship term in the table.
Gives the user information that only observation variables can have phenotypes collected, meaning the term must have a VARIABLE_OF relationship.

<!-- If there are relevant issues, link them here: -->
closes #2831 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
