### PR TITLE
Parse Multi-Trial Upload Bug: accession name column

### DIFF
--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
@@ -584,8 +584,8 @@ sub _parse_with_plugin {
   my %seen_accession_names;
   for my $row ( 1 .. $row_max ) {
       my $accession_name;
-      if ($worksheet->get_cell($row,14)) {
-          $accession_name = $worksheet->get_cell($row,14)->value();
+      if ($worksheet->get_cell($row,13)) {
+          $accession_name = $worksheet->get_cell($row,13)->value();
           $accession_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
           $seen_accession_names{$accession_name}++;
       }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes an incorrect column id for getting the accession_name from the upload template
This was causing the synonym lookup to fail

Fixes #2885 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
