### PR TITLE
Phenotype Download: Allow multiple traits to be selected

### DIFF
--- a/mason/breeders_toolbox/trial/download_phenotypes_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_phenotypes_dialog.mas
@@ -146,7 +146,7 @@ jQuery(document).ready(function() {
 });
 
 function data_level_change_traits() {
-    get_select_box('traits', 'download_trial_phenotypes_traits', { 'name' : 'download_trial_phenotypes_traits_select', 'id' : 'download_trial_phenotypes_traits_select', 'trial_ids':'<% $trial_ids %>', 'data_level':jQuery('#download_trial_phenotypes_level_option').val() });
+    get_select_box('traits', 'download_trial_phenotypes_traits', { 'name' : 'download_trial_phenotypes_traits_select', 'id' : 'download_trial_phenotypes_traits_select', 'trial_ids':'<% $trial_ids %>', 'data_level':jQuery('#download_trial_phenotypes_level_option').val(), 'multiple': true });
     get_select_box('phenotyped_trait_components', 'download_trial_phenotypes_trait_components', { 'name' : 'download_trial_phenotypes_trait_components_select', 'id' : 'download_trial_phenotypes_trait_components_select', 'trial_ids':'<% $trial_ids %>', 'data_level':jQuery('#download_trial_phenotypes_level_option').val() });
 }
 </script>


### PR DESCRIPTION
The download phenotypes dialog (from the trial and folder detail pages) was only allowing a single trait to be selected.  This changes the single select box to a multi-select box.