### PR TITLE
revert login form ids

### DIFF
--- a/lib/SGN/Controller/AJAX/User.pm
+++ b/lib/SGN/Controller/AJAX/User.pm
@@ -19,8 +19,8 @@ sub login : Path('/ajax/user/login') Args(0) {
     my $self = shift;
     my $c = shift;
 
-    my $username = $c->req->param("login_username");
-    my $password = $c->req->param("login_password");
+    my $username = $c->req->param("username");
+    my $password = $c->req->param("password");
     my $goto_url = $c->req->param("goto_url");
 
     print STDERR "Goto URL = $goto_url\n";

--- a/mason/site/login_dialog.mas
+++ b/mason/site/login_dialog.mas
@@ -19,13 +19,13 @@ $goto_url => ''
                     <div class="container-fluid">
 
 % if ($c->config->{default_login_janedoe}) {
-                        <input class="form-control" style="width:240px" id="login_username" name="login_username" placeholder="Username" type="text" value="janedoe"/>
+                        <input class="form-control" style="width:240px" id="username" name="username" placeholder="Username" type="text" value="janedoe"/>
                         <br />
-                        <input class="form-control" style="width:240px" id="login_password" name="login_password" placeholder="Password" type="password" value="secretpw"/>
+                        <input class="form-control" style="width:240px" id="password" name="password" placeholder="Password" type="password" value="secretpw"/>
 % } else {
-                        <input class="form-control" style="width:240px" id="login_username" name="login_username" placeholder="Username" type="text" />
+                        <input class="form-control" style="width:240px" id="username" name="username" placeholder="Username" type="text" />
                         <br />
-                        <input class="form-control" style="width:240px" id="login_password" name="login_password" placeholder="Password" type="password" />
+                        <input class="form-control" style="width:240px" id="password" name="password" placeholder="Password" type="password" />
 % }
                         <br />
                         <div style="margin-bottom:40px">
@@ -224,7 +224,7 @@ jQuery(document).ready( function() {
 
     jQuery('#login_form').submit( function(event) { 
         var form_data = jQuery('#login_form').serialize();
-        if (!jQuery('#login_username').val() || !jQuery('#login_password').val()) { 
+        if (!jQuery('#username').val() || !jQuery('#password').val()) { 
             alert('Please enter a username and password');
             return;
         }

--- a/t/unit_mech/AJAX/Login.t
+++ b/t/unit_mech/AJAX/Login.t
@@ -16,7 +16,7 @@ my $f = SGN::Test::Fixture->new();
 my $mech = Test::WWW::Mechanize->new;
 my $response;
 
-$mech->get_ok('http://localhost:3010/ajax/user/login?login_username=janedoe&login_password=secretpw');
+$mech->get_ok('http://localhost:3010/ajax/user/login?username=janedoe&password=secretpw');
 $response = decode_json $mech->content;
 print STDERR Dumper $response;
 is($response->{message}, 'Login successful');
@@ -57,7 +57,7 @@ $response = decode_json $mech->content;
 print STDERR Dumper $response;
 is($response->{message}, 'The password was successfully updated.');
 
-$mech->get_ok('http://localhost:3010/ajax/user/login?login_username=testusername&login_password=testpasschange');
+$mech->get_ok('http://localhost:3010/ajax/user/login?username=testusername&password=testpasschange');
 $response = decode_json $mech->content;
 print STDERR Dumper $response;
 is($response->{message}, 'Login successful');


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Revert login form ids to how they were previously because of selenium tests using these html ids.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
