### PR TITLE
fix defaults for word_size in blastp, blastx, tblastx and tblastn

### DIFF
--- a/mason/tools/blast/index.mas
+++ b/mason/tools/blast/index.mas
@@ -258,6 +258,13 @@ jQuery(document).ready(function() {
 	  swap_menu(selectedId);
 	});
 
+	jQuery('#program_select').change( function() {
+	  var selected_program = jQuery('#program_select').find(':selected').attr('value');
+	  if (selected_program === 'blastp' or selected_program === 'blastx') {
+	     jQuery('#word_size').html("3");
+	  }
+	});
+
 	var input_examples = eval(<% $input_example_json %>);
 	var database_types = eval (<% $database_type_json %>);
 	var input_option_types = eval(<% $input_option_json %>);

--- a/mason/tools/blast/index.mas
+++ b/mason/tools/blast/index.mas
@@ -99,6 +99,8 @@
 
 <& /page/page_title.mas, title=>"BLAST" &>
 
+<div style="border-style:dotted;border-width:1px;margin-bottom:20px;"><div style="margin-top:10px;margin-right:10px;margin-bottom:10px;margin-left:10px;" >Note: you can now also set the word_size for the blast algorithm. Shorter word sizes are better when analyzing short sequences. The default for blastn is 11 and for protein-based blast programs it is 3. The correct default will be set automatically when changing the program.</div></div>
+
 <&| /page/info_section.mas, id=>"input_parameter_section", title=>"Input parameters", collapsible=>1, collapsed=>0, subtitle=>'<a class="btn btn-link pull-right" href="/help/tools/blast" target="_blank">Help <span class="glyphicon glyphicon-question-sign"></span></a>' &>
   <input type="hidden" name="outformat" value="0" />
 

--- a/mason/tools/blast/index.mas
+++ b/mason/tools/blast/index.mas
@@ -261,9 +261,10 @@ jQuery(document).ready(function() {
 
 	jQuery('#program_select').change( function() {
 	  var selected_program = jQuery('#program_select').find(':selected').attr('value');
-	  if (selected_program === 'blastp' or selected_program === 'blastx') {
-	     jQuery('#word_size').html("3");
+	  if (selected_program === 'blastp' || selected_program === 'blastx' || selected_program === 'tblastn' || selected_program === 'tblastx') {
+	     jQuery('#word_size').val("3");
 	  }
+	  if (selected_program === 'blastn') { jQuery('#word_size').val("11"); }
 	});
 
 	var input_examples = eval(<% $input_example_json %>);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
A javascript event was added that changes the default for word_size when a new program is selected with the program pull down menu. 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
