### PR TITLE
Search Wizard: get public lists

### DIFF
--- a/js/source/entries/wizard.js
+++ b/js/source/entries/wizard.js
@@ -139,7 +139,7 @@ export function WizardSetup(main_id){
     
     var load_lists = ()=>(new Promise((resolve,reject)=>{
       var private_lists = list.availableLists(initialtypes);
-      var public_lists = list.availableLists(initialtypes);
+      var public_lists = list.publicLists(initialtypes);
       if(public_lists.error) public_lists = [];
       if(private_lists.error) private_lists = [];
       resolve(private_lists.concat(public_lists))


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR fixes a bug that enables public lists (created by a different user) to be accessible in the "Select Column Type" selectbox in the Search Wizard.

Fixes solgenomics/sgn#3027

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
