### PR TITLE
User: dedicated URL for new user registration

### DIFF
--- a/lib/SGN/Controller/User.pm
+++ b/lib/SGN/Controller/User.pm
@@ -15,6 +15,15 @@ sub login :Path('/user/login') Args(0) {
     $c->stash->{template} = '/user/login.mas';
 }
 
+sub new_user :Path('/user/new') Args(0) {
+    my $self = shift;
+    my $c = shift;
+
+    # Redirect to the login page and display the new user form
+    $c->res->redirect('/user/login?goto_url=/&new_user=1');
+    $c->detach();
+}
+
 sub update_account :Path('/user/update') Args(0) { 
     my $self = shift;
     my $c = shift;

--- a/mason/site/login_dialog.mas
+++ b/mason/site/login_dialog.mas
@@ -247,6 +247,12 @@ jQuery(document).ready( function() {
             }
         });
     });
+
+    // Display New User Dialog if `new_user` query param set
+    url = new URL(window.location.href);
+    if ( url.searchParams.get('new_user') ) {
+        jQuery('#site_login_new_user_dialog').modal('show');
+    }
 });
 </script>
 


### PR DESCRIPTION
This PR reinstates the `/user/new` URL for directly bringing up the new user registration page.

We've found that some people have a hard time finding the new user registration page when its link is only found on the login dialog.  Having a direct link we can add to the homepage and send in an email has been helpful.

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
