### PR TITLE
When phenotypes are uploaded, the "overwrite" option sometimes deletes phenotypic values that shouldn't be deleted

### DIFF
--- a/lib/CXGN/Project.pm
+++ b/lib/CXGN/Project.pm
@@ -1808,51 +1808,49 @@ sub delete_phenotype_values_and_nd_experiment_md_values {
         my $h2 = $schema->storage->dbh()->prepare($q_pheno_delete);
         $h2->execute();
 
+        print STDERR "DELETED ".scalar(@{$phenotype_ids_and_nd_experiment_ids_to_delete->{phenotype_ids}})." Phenotype Values\n";
 
         my $nd_experiment_id_sql = join (",", @{$phenotype_ids_and_nd_experiment_ids_to_delete->{nd_experiment_ids}});
 
-	# check if the nd_experiment has no other associated phenotypes
-	#
-	my $checkq = "SELECT nd_experiment_id from nd_experiment left join nd_experiment_phenotype using(nd_experiment_id)  where nd_experiment_id in ($nd_experiment_id_sql) and phenotype_id IS NULL";
+        # check if the nd_experiment has no other associated phenotypes, since phenotypstore actually attaches many phenotypes to one nd_experiment
+        #
+        my $checkq = "SELECT nd_experiment_id FROM nd_experiment left join nd_experiment_phenotype using(nd_experiment_id) where nd_experiment_id in ($nd_experiment_id_sql) and phenotype_id IS NULL";
+        my $check_h = $schema->storage->dbh()->prepare($checkq);
+        $check_h ->execute();
 
-	my $check_h = $schema->storage->dbh()->prepare($checkq);
+        my @nd_experiment_ids;
+        while (my ($nd_experiment_id) = $check_h->fetchrow_array()) {
+            push @nd_experiment_ids, $nd_experiment_id;
+        }
 
-	$check_h ->execute();
+        if (scalar(@nd_experiment_ids)>0) { 
+            $nd_experiment_id_sql = join(",", @nd_experiment_ids);
 
-	my @nd_experiment_ids;
-	while (my ($nd_experiment_id) = $check_h->fetchrow_array()) {
-	    push @nd_experiment_ids, $nd_experiment_id;
-	}
+            my $q_nd_exp_files_delete = "DELETE FROM phenome.nd_experiment_md_files WHERE nd_experiment_id IN ($nd_experiment_id_sql);";
+            my $h3 = $schema->storage->dbh()->prepare($q_nd_exp_files_delete);
+            $h3->execute();
 
-	$nd_experiment_id_sql = join(",", @nd_experiment_ids);
+            my $q_nd_json = "DELETE FROM phenome.nd_experiment_md_json WHERE nd_experiment_id IN ($nd_experiment_id_sql)";
+            my $h_nd_json = $schema->storage->dbh()->prepare($q_nd_json);
+            $h_nd_json->execute();
 
-	if ($nd_experiment_id_sql) { 
+            my $q_nd_exp_files_images_delete = "DELETE FROM phenome.nd_experiment_md_images WHERE nd_experiment_id IN ($nd_experiment_id_sql);";
+            my $h4 = $schema->storage->dbh()->prepare($q_nd_exp_files_images_delete);
+            $h4->execute();
 
-	    my $q_nd_exp_files_delete = "DELETE FROM phenome.nd_experiment_md_files WHERE nd_experiment_id IN ($nd_experiment_id_sql);";
-	    my $h3 = $schema->storage->dbh()->prepare($q_nd_exp_files_delete);
-	    $h3->execute();
+            open (my $fh, ">", $temp_file_nd_experiment_id ) || die ("\nERROR: the file $temp_file_nd_experiment_id could not be found\n" );
+                foreach (@nd_experiment_ids) {
+                    print $fh "$_\n";
+                }
+            close($fh);
 
-	    my $q_nd_json = "DELETE FROM phenome.nd_experiment_md_json where nd_experiment_id in ($nd_experiment_id_sql)";
-	    my $h_nd_json = $schema->storage->dbh()->prepare($q_nd_json);
-	    $h_nd_json->execute();
+            my $async_delete = CXGN::Tools::Run->new();
+            $async_delete->run_async("perl $basepath/bin/delete_nd_experiment_entries.pl -H $dbhost -D $dbname -U $dbuser -P $dbpass -i $temp_file_nd_experiment_id");
 
-	    my $q_nd_exp_files_images_delete = "DELETE FROM phenome.nd_experiment_md_images WHERE nd_experiment_id IN ($nd_experiment_id_sql);";
-	    my $h4 = $schema->storage->dbh()->prepare($q_nd_exp_files_images_delete);
-	    $h4->execute();
-
-	    open (my $fh, ">", $temp_file_nd_experiment_id ) || die ("\nERROR: the file $temp_file_nd_experiment_id could not be found\n" );
-            foreach (@{$phenotype_ids_and_nd_experiment_ids_to_delete->{nd_experiment_ids}}) {
-                print $fh "$_\n";
-            }
-	    close($fh);
-
-	    my $async_delete = CXGN::Tools::Run->new();
-	    $async_delete->run_async("perl $basepath/bin/delete_nd_experiment_entries.pl -H $dbhost -D $dbname -U $dbuser -P $dbpass -i $temp_file_nd_experiment_id");
-
-	    print STDERR "DELETED ".scalar(@{$phenotype_ids_and_nd_experiment_ids_to_delete->{phenotype_ids}})." Phenotype Values and nd_experiment_md_file_links (nd_experiment entries may still be in deletion in asynchronous process.)\n";
-	}
+            print STDERR "DELETED ".scalar(@{$phenotype_ids_and_nd_experiment_ids_to_delete->{phenotype_ids}})." Phenotype Values and nd_experiment_md_file_links (and ".scalar(@nd_experiment_ids)." nd_experiment entries may still be in deletion in asynchronous process.)\n";
+        }
     };
-    
+
     my $error;
     try {
         $schema->txn_do($coderef);

--- a/lib/CXGN/Project.pm
+++ b/lib/CXGN/Project.pm
@@ -1807,26 +1807,52 @@ sub delete_phenotype_values_and_nd_experiment_md_values {
         my $q_pheno_delete = "DELETE FROM phenotype WHERE phenotype_id IN ($phenotype_id_sql);";
         my $h2 = $schema->storage->dbh()->prepare($q_pheno_delete);
         $h2->execute();
-        my $nd_experiment_id_sql = join (",", @{$phenotype_ids_and_nd_experiment_ids_to_delete->{nd_experiment_ids}});
-        my $q_nd_exp_files_delete = "DELETE FROM phenome.nd_experiment_md_files WHERE nd_experiment_id IN ($nd_experiment_id_sql);";
-        my $h3 = $schema->storage->dbh()->prepare($q_nd_exp_files_delete);
-        $h3->execute();
-        my $q_nd_exp_files_images_delete = "DELETE FROM phenome.nd_experiment_md_images WHERE nd_experiment_id IN ($nd_experiment_id_sql);";
-        my $h4 = $schema->storage->dbh()->prepare($q_nd_exp_files_images_delete);
-        $h4->execute();
 
-        open (my $fh, ">", $temp_file_nd_experiment_id ) || die ("\nERROR: the file $temp_file_nd_experiment_id could not be found\n" );
+
+        my $nd_experiment_id_sql = join (",", @{$phenotype_ids_and_nd_experiment_ids_to_delete->{nd_experiment_ids}});
+
+	# check if the nd_experiment has no other associated phenotypes
+	#
+	my $checkq = "SELECT nd_experiment_id from nd_experiment left join nd_experiment_phenotype using(nd_experiment_id)  where nd_experiment_id in ($nd_experiment_id_sql) and phenotype_id IS NULL";
+
+	my $check_h = $schema->storage->dbh()->prepare($checkq);
+
+	$check_h ->execute();
+
+	my @nd_experiment_ids;
+	while (my ($nd_experiment_id) = $check_h->fetchrow_array()) {
+	    push @nd_experiment_ids, $nd_experiment_id;
+	}
+
+	$nd_experiment_id_sql = join(",", @nd_experiment_ids);
+
+	if ($nd_experiment_id_sql) { 
+
+	    my $q_nd_exp_files_delete = "DELETE FROM phenome.nd_experiment_md_files WHERE nd_experiment_id IN ($nd_experiment_id_sql);";
+	    my $h3 = $schema->storage->dbh()->prepare($q_nd_exp_files_delete);
+	    $h3->execute();
+
+	    my $q_nd_json = "DELETE FROM phenome.nd_experiment_md_json where nd_experiment_id in ($nd_experiment_id_sql)";
+	    my $h_nd_json = $schema->storage->dbh()->prepare($q_nd_json);
+	    $h_nd_json->execute();
+
+	    my $q_nd_exp_files_images_delete = "DELETE FROM phenome.nd_experiment_md_images WHERE nd_experiment_id IN ($nd_experiment_id_sql);";
+	    my $h4 = $schema->storage->dbh()->prepare($q_nd_exp_files_images_delete);
+	    $h4->execute();
+
+	    open (my $fh, ">", $temp_file_nd_experiment_id ) || die ("\nERROR: the file $temp_file_nd_experiment_id could not be found\n" );
             foreach (@{$phenotype_ids_and_nd_experiment_ids_to_delete->{nd_experiment_ids}}) {
                 print $fh "$_\n";
             }
-        close($fh);
+	    close($fh);
 
-        my $async_delete = CXGN::Tools::Run->new();
-        $async_delete->run_async("perl $basepath/bin/delete_nd_experiment_entries.pl -H $dbhost -D $dbname -U $dbuser -P $dbpass -i $temp_file_nd_experiment_id");
+	    my $async_delete = CXGN::Tools::Run->new();
+	    $async_delete->run_async("perl $basepath/bin/delete_nd_experiment_entries.pl -H $dbhost -D $dbname -U $dbuser -P $dbpass -i $temp_file_nd_experiment_id");
 
-        print STDERR "DELETED ".scalar(@{$phenotype_ids_and_nd_experiment_ids_to_delete->{phenotype_ids}})." Phenotype Values and nd_experiment_md_file_links (nd_experiment entries may still be in deletion in asynchronous process.)\n";
+	    print STDERR "DELETED ".scalar(@{$phenotype_ids_and_nd_experiment_ids_to_delete->{phenotype_ids}})." Phenotype Values and nd_experiment_md_file_links (nd_experiment entries may still be in deletion in asynchronous process.)\n";
+	}
     };
-
+    
     my $error;
     try {
         $schema->txn_do($coderef);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Phenotypic values that shouldn't be deleted are sometimes deleted when "overwrite values" is selected in the phenotype upload dialog. The extra deletes occurred because all of the nd_experiments associated with the phenotypes in question were deleted, but sometimes nd_experiments have more phenotypes associated with them, which were then left dangling in the database. The fix checks if there are any phenotypes still associated with the nd_experiment and deletes only  nd_experiments with no associated phenotypes.

Closes issue #3159 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
