### PR TITLE
add trial pheno summary options for page length

### DIFF
--- a/mason/breeders_toolbox/trial/phenotype_summary.mas
+++ b/mason/breeders_toolbox/trial/phenotype_summary.mas
@@ -196,6 +196,7 @@ jQuery(document).ready(function () {
 
 function datatables_display_phenosummary(type) {
     jQuery('#phenotype_summary_data').DataTable( {
+        "lengthMenu": [ 5, 10, 25, 50, 75, 100 ],
         "retrieve": true,
         "ajax": '/ajax/breeders/trial/'+ <% $trial_id %> + '/phenotypes?display='+jQuery('#display_trial_phenosummary').val() + '&trial_stock_type='+type,
     });


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Option to select 5 as the page length on trial phenotype summary table.

<!-- If there are relevant issues, link them here: -->
closes #3151 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
