### PR TITLE
Bug Fix: creating list of traits from the trait search page

### DIFF
--- a/lib/SGN/Controller/AJAX/Search/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Search/Trait.pm
@@ -119,7 +119,9 @@ sub search : Path('/ajax/search/traits') Args(0) {
                 "<a href=\"/cvterm/$_->{trait_id}/view\">$trait_accession</a>",
                 "<a href=\"/cvterm/$_->{trait_id}/view\">$_->{trait_name}</a>",
                 $_->{trait_definition},
-                $trait_usage
+                $trait_usage,
+                $_->{trait_name},
+                $trait_accession
             ];
     }
     #print STDERR Dumper \@result;

--- a/mason/search/traits.mas
+++ b/mason/search/traits.mas
@@ -180,7 +180,7 @@ jQuery(document).ready(function () {
      //console.log(selected_rows.data());
 
      var name_links = selected_rows.data().map(function(row){
-         return [row[4], row[5]];
+         return [row[5], row[6]];
          trait_table.rows().deselect();
      });
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes a bug where the trait list item names were using the wrong values

Add back the plain text trait name and trait accession values to the AJAX response
Update the indices of the values used to create the trait list item names


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
