### PR TITLE
make country_name an optional parameter.

### DIFF
--- a/mason/breeders_toolbox/trial.mas
+++ b/mason/breeders_toolbox/trial.mas
@@ -20,7 +20,7 @@ $breeding_program_id
 $breeding_program_name
 $location_id
 $location_name
-$country_name
+$country_name => ""
 $main_production_site_url => undef
 $year => undef
 $trial_type => undef


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Trial page crashes if database does not have country information in location tables. This makes the parameter to the trial page optional.


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
