### PR TITLE
fix typo in cvterm_id function on line 610 (cvterm should be cvterm_id)

### DIFF
--- a/lib/CXGN/Trial/TrialLayout/AbstractLayout.pm
+++ b/lib/CXGN/Trial/TrialLayout/AbstractLayout.pm
@@ -607,7 +607,7 @@ sub retrieve_plot_info {
 	my %plants_tissue_hash;
 	while (my $p = $plants->next()) {
 	    if ($self->get_verify_layout){
-		my $plant_accession_check = $p->search_related('stock_relationship_subjects', {'me.type_id'=>$self->cvterm('plant_of')})->search_related('object', {'object.stock_id'=>$accession_id, 'object.type_id'=>$self->cvterm_id('accession')});
+		my $plant_accession_check = $p->search_related('stock_relationship_subjects', {'me.type_id'=>$self->cvterm_id('plant_of')})->search_related('object', {'object.stock_id'=>$accession_id, 'object.type_id'=>$self->cvterm_id('accession')});
 		if (!$plant_accession_check->first){
 		    push @{$verify_errors{errors}->{layout_errors}}, "Plant: ".$p->uniquename." does not have the same accession: $accession_name as the plot: $plot_name.";
 		}


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Bug caused the cache rebuild for a trial to fail.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
