### PR TITLE
Search Wizard: fix Select All button

### DIFF
--- a/js/source/modules/wizard-search.js
+++ b/js/source/modules/wizard-search.js
@@ -268,10 +268,11 @@ export function Wizard(main_id,col_number){
     reflow(d.index, true);
   });
   allCols.select(".wizard-select-all").on("click",function(d){
-      var search_txt = d3.select(".wizard-search").property("value").replace(/\s+/g, "").toLowerCase();
+      var s = d3.selectAll(".wizard-search").filter(function(e, i) { return i === d.index });
+      var search_txt = s ? s.property("value").replace(/\s+/g, "").toLowerCase() : undefined;
       d.items.forEach(i=>{
           var val = i.name.replace(/\s+/g, "").toLowerCase();
-          val.indexOf(search_txt)!=-1 ? i.selected=true : i.selected=false
+          i.selected = search_txt ? val.indexOf(search_txt) != -1 : true;
       });
       reflow(d.index,true);
   })


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes a bug with the Search Wizard's "Select All" buttons.  It was using the filter/search text from the first column for all of the columns.  This gets the text from the appropriate column.



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
