### PR TITLE
Gwas clay fixes

### DIFF
--- a/R/solgwas/solgwas_script.R
+++ b/R/solgwas/solgwas_script.R
@@ -10,7 +10,7 @@ library("dplyr")
 ########################################
 args = commandArgs(trailingOnly = TRUE)
 
-pheno <- read.table(args[1], sep = "\t", header = TRUE)
+pheno <- read.table(args[1], sep = "\t", header = TRUE, stringsAsFactors = FALSE, check.names = FALSE)
 colnames(pheno)
 
 #### Current script accepts genotype data with markers as rows and accessions as columns
@@ -31,10 +31,11 @@ pc_check
 print("kinship_check:")
 kinship_check
 
-
 # pheno[1:5,1:21]
 # Note: still need to test how well this pmatch deals with other trickier cases
-pheno_vector <- pheno[,pmatch(study_trait, names(pheno))]
+pheno_names <- names(pheno)
+pheno_names <- gsub(" ", ".", pheno_names)
+pheno_vector <- pheno[,pmatch(study_trait, pheno_names)]
 pheno_vector[1:5]
 # Make a new phenotype table, including only the phenotype selected:
 pheno_mod <- cbind(pheno, pheno_vector)

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -1325,7 +1325,7 @@ sub get_cached_file_dosage_matrix {
 
         #VCF should be sorted by chromosome and position
         no warnings 'uninitialized';
-        @all_marker_objects = sort { $a->{chrom} <=> $b->{chrom} || $a->{pos} <=> $b->{pos} || $a->{name} cmp $b->{name} } @all_marker_objects;
+        @all_marker_objects = sort { $a->{chrom} cmp $b->{chrom} || $a->{pos} <=> $b->{pos} || $a->{name} cmp $b->{name} } @all_marker_objects;
         @all_marker_objects = $self->_check_filtered_markers(\@all_marker_objects);
 
         my $counter = 0;
@@ -1915,7 +1915,7 @@ sub get_cached_file_VCF_compute_from_parents {
         }
 
         no warnings 'uninitialized';
-        @all_marker_objects = sort { $a->{chrom} <=> $b->{chrom} || $a->{pos} <=> $b->{pos} || $a->{name} cmp $b->{name} } @all_marker_objects;
+        @all_marker_objects = sort { $a->{chrom} cmp $b->{chrom} || $a->{pos} <=> $b->{pos} || $a->{name} cmp $b->{name} } @all_marker_objects;
         @all_marker_objects = $self->_check_filtered_markers(\@all_marker_objects);
 
         my $counter = 0;

--- a/lib/CXGN/Phenotypes/PhenotypeMatrix.pm
+++ b/lib/CXGN/Phenotypes/PhenotypeMatrix.pm
@@ -215,6 +215,7 @@ sub get_phenotype_matrix {
 
             $trial_name =~ s/\s+$//g;
             $trial_desc =~ s/\s+$//g;
+	    $trial_desc = "\"" . $trial_desc . "\"";
 
             my @line = ($obs_unit->{year}, $obs_unit->{breeding_program_id}, $obs_unit->{breeding_program_name}, $obs_unit->{breeding_program_description}, $obs_unit->{trial_id}, $trial_name, $trial_desc, $obs_unit->{design}, $obs_unit->{plot_width}, $obs_unit->{plot_length}, $obs_unit->{field_size}, $obs_unit->{field_trial_is_planned_to_be_genotyped}, $obs_unit->{field_trial_is_planned_to_cross}, $obs_unit->{planting_date}, $obs_unit->{harvest_date}, $obs_unit->{trial_location_id}, $obs_unit->{trial_location_name}, $obs_unit->{germplasm_stock_id}, $obs_unit->{germplasm_uniquename}, $synonym_string, $obs_unit->{observationunit_type_name}, $obs_unit->{observationunit_stock_id}, $obs_unit->{observationunit_uniquename}, $obs_unit->{obsunit_rep}, $obs_unit->{obsunit_block}, $obs_unit->{obsunit_plot_number}, $obs_unit->{obsunit_row_number}, $obs_unit->{obsunit_col_number}, $entry_type, $obs_unit->{obsunit_plant_number}, $obs_unit->{seedlot_stock_id}, $obs_unit->{seedlot_uniquename}, $obs_unit->{seedlot_current_count}, $obs_unit->{seedlot_current_weight_gram}, $obs_unit->{seedlot_box_name}, $obs_unit->{seedlot_transaction_amount}, $obs_unit->{seedlot_transaction_weight_gram}, $obs_unit->{seedlot_transaction_description}, $available_germplasm_seedlots_uniquenames);
 


### PR DESCRIPTION
Description - Fix errors when running solgwas tool. 
1. long trial descriptions would give wrong number of columns when reading in file by R scripts
2. R script could not match trait provided in arguement with trait in phenotype file because of the trait name was being changed using the default check.names = TRUE
-----------------------------------------------------


https://github.com/solgenomics/sgn/issues/3212
#3212 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [X] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
