### PR TITLE
It keeps the button 'add tissue sample' working even if there is alre…

### DIFF
--- a/mason/breeders_toolbox/trial/design_section.mas
+++ b/mason/breeders_toolbox/trial/design_section.mas
@@ -65,7 +65,9 @@ $trial_stock_type => undef
            <button class="btn btn-default" id="create_tissue_sample_entries_button">Add tissue sample entries</button>
            <& /breeders_toolbox/trial/add_tissue_sample_per_plant.mas, trial_id => $trial_id, trial_name => $trial_name, trial_has_plants => $has_plant_entries &>
 % } else {
-            <& /breeders_toolbox/trial/trial_tissue_samples.mas, trial_id => $trial_id &>
+		   <button class="btn btn-default" id="create_tissue_sample_entries_button">Add tissue sample entries</button>
+           <& /breeders_toolbox/trial/add_tissue_sample_per_plant.mas, trial_id => $trial_id, trial_name => $trial_name, trial_has_plants => $has_plant_entries &>
+           <& /breeders_toolbox/trial/trial_tissue_samples.mas, trial_id => $trial_id &>
 % }
 
         </div><!--closes tissue_sample_entries_section -->


### PR DESCRIPTION
…ady tissue sample in the trial


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

In trial details page>Experimental design>Tissue Sample Entries

The button to add tissue samples shows up even if the trial already has tissue sample.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
