### PR TITLE
Topic/fix boxplotter labels

### DIFF
--- a/js/build.webpack.config.js
+++ b/js/build.webpack.config.js
@@ -59,10 +59,15 @@ module.exports = {
     optimization: {
         minimize: true,
         namedChunks: true,
-        minimizer: [new UglifyWebpackPlugin({ 
+        minimizer: [new UglifyWebpackPlugin({
+            uglifyOptions: {
+                output: {
+                    ascii_only: true
+                },
+            },
             'sourceMap': true,
             'parallel': 4,
-            
+
         })],
         runtimeChunk: {
             name: 'runtime'

--- a/js/build.webpack.config.js
+++ b/js/build.webpack.config.js
@@ -67,7 +67,6 @@ module.exports = {
             },
             'sourceMap': true,
             'parallel': 4,
-
         })],
         runtimeChunk: {
             name: 'runtime'


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Adds `ascii_only: true` output option to the webpack minimizer configuration to prevent the minimizer from prematurely converting `&nbsp;` unicode string literals to UTF-8.

In other words, it gets rid of those random `Â` characters cluttering the boxplotter labels. It's a small world, looks like Integrated Breeding Platform had a [similar problem and solution](https://github.com/IntegratedBreedingPlatform/Workbench/commit/bedcc2eba70ca4ffa157a5984ecc8cb124c94a5b)

Closes #3278

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
