### PR TITLE
Allow test sites to send emails (contact and registration verification emails)

### DIFF
--- a/lib/CXGN/Contact.pm
+++ b/lib/CXGN/Contact.pm
@@ -75,7 +75,7 @@ sub send_email {
 
     $body .= $request_info;
     print STDERR "$subject\n\n$body";
-    if ( $vhost_conf->get_conf('production_server') ) {
+    #if ( $vhost_conf->get_conf('production_server') ) {
         if ( $vhost_conf->get_conf('disable_emails') ) {
             print STDERR "CXGN::Contact: Configured as production server, but not configured to send emails; no email sent from $mailfrom to $mailto.\n";
         }
@@ -129,11 +129,11 @@ sub send_email {
               }
 
             }
-        }
-    }
-    else {
-        print STDERR "CXGN::Contact: Not configured as production server; no email sent from $mailfrom to $mailto.\n";
-    }
+       # }
+   # }
+    #else {
+     #   print STDERR "CXGN::Contact: Not configured as production server; no email sent from $mailfrom to $mailto.\n";
+    #}
 }
 
 

--- a/lib/CXGN/Contact.pm
+++ b/lib/CXGN/Contact.pm
@@ -129,7 +129,7 @@ sub send_email {
               }
 
             }
-       # }
+        }
    # }
     #else {
      #   print STDERR "CXGN::Contact: Not configured as production server; no email sent from $mailfrom to $mailto.\n";

--- a/lib/CXGN/Login.pm
+++ b/lib/CXGN/Login.pm
@@ -301,6 +301,7 @@ sub login_allowed {
         return 1;
     }
     else {
+	print STDERR "Login is disabled if dbname contains 'sandbox' and production_server is set to 1\n";
         return 0;
     }
 }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
This allows the test sites to also send emails, by removing the constraint that suppressed emails when production_server = 0.

Note that you still may have to 
* configure the correct github_access_token in sgn_local.conf (it can be copied from a production server), and that 
* the main_production_site_url, also in sgn_local.conf, needs to be set to the correct domain such that the confirmation link in the verification email goes to the correct site.
* set disable_emails = 0 in sgn_local.conf (this should be the default)
* postfix needs to be installed on the vm/server
* there might be additional firewall issues in sending mail

Closes issue #3302.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [x] minor change
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
