### PR TITLE
add a check that the headers are correct in the pedigree upload

### DIFF
--- a/lib/SGN/Controller/AJAX/Pedigrees.pm
+++ b/lib/SGN/Controller/AJAX/Pedigrees.pm
@@ -95,6 +95,33 @@ sub upload_pedigrees_verify : Path('/ajax/pedigrees/upload_verify') Args(0)  {
     my %stocks;
 
     my $header = <$F>;
+
+    my ($progeny_name, $female_parent_accession, $male_parent_accession, $type) =split /\t/, $header;
+
+    my %header_errors;
+    
+    if ($progeny_name ne 'progeny name') {
+	$header_errors{'progeny name'} = "First column must have header 'progeny name' (not '$progeny_name'); ";
+    }
+
+    if ($female_parent_accession ne 'female parent accession') {
+	$header_errors{'female parent accession'} = "Second column must have header 'female parent accession' (not '$female_parent_accession'); ";
+    }
+
+    if ($male_parent_accession ne 'male parent accession') {
+	$header_errors{'male parent accession'} = "Third column must have header 'male parent accession' (not '$male_parent_accession'); ";
+    }
+
+    if ($type ne 'type') {
+	$header_errors{'type'} = "Fourth column must have header 'type' (not '$type');";
+    }
+
+    if (%header_errors) {
+	my $error = join "\n", values %header_errors;
+	$c->stash->{rest} = { error => $error, archived_filename_with_path => $archived_filename_with_path };
+	return;
+    }
+    
     my %legal_cross_types = ( biparental => 1, open => 1, self => 1, sib => 1, polycross => 1, backcross => 1);
     my %errors;
 

--- a/lib/SGN/Controller/AJAX/Pedigrees.pm
+++ b/lib/SGN/Controller/AJAX/Pedigrees.pm
@@ -95,7 +95,7 @@ sub upload_pedigrees_verify : Path('/ajax/pedigrees/upload_verify') Args(0)  {
     my %stocks;
 
     my $header = <$F>;
-
+    chomp($header);
     my ($progeny_name, $female_parent_accession, $male_parent_accession, $type) =split /\t/, $header;
 
     my %header_errors;
@@ -117,12 +117,12 @@ sub upload_pedigrees_verify : Path('/ajax/pedigrees/upload_verify') Args(0)  {
     }
 
     if (%header_errors) {
-	my $error = join "\n", values %header_errors;
+	my $error = join "<br />", values %header_errors;
 	$c->stash->{rest} = { error => $error, archived_filename_with_path => $archived_filename_with_path };
 	return;
     }
     
-    my %legal_cross_types = ( biparental => 1, open => 1, self => 1, sib => 1, polycross => 1, backcross => 1);
+    my %legal_cross_types = ( biparental => 1, open => 1, self => 1, sib => 1, polycross => 1, backcross => 1 );
     my %errors;
 
     while (<$F>) {
@@ -146,7 +146,9 @@ sub upload_pedigrees_verify : Path('/ajax/pedigrees/upload_verify') Args(0)  {
                 }
             }
         }
+	
         # check if the cross types are recognized...
+	#
         if ($acc[3] && !exists($legal_cross_types{lc($acc[3])})) {
             $errors{"not legal cross type: $acc[3] (should be biparental, self, open, sib or polycross)"}=1;
         }


### PR DESCRIPTION
Add a check that the headers are correct in the pedigree upload, as the upload crashes silently when the headers are not correct.

Addresses issue #3294.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
