### PR TITLE
move quoting of phenotype data from PhenotypeMatrix.pm to Dataset/Fil…

### DIFF
--- a/lib/CXGN/Dataset/File.pm
+++ b/lib/CXGN/Dataset/File.pm
@@ -3,7 +3,6 @@ package CXGN::Dataset::File;
 
 use Moose;
 use File::Slurp qw | write_file |;
-#use File::Sp qw(append_file write_file);
 use JSON::Any;
 use Data::Dumper;
 use CXGN::Genotype::Search;
@@ -118,11 +117,24 @@ override('retrieve_phenotypes',
 	     my $file = shift || $self->file_name()."_phenotype.txt";
 	     my $phenotypes = $self->SUPER::retrieve_phenotypes();
 	     my $phenotype_string = "";
+	     my $s;
 	     foreach my $line (@$phenotypes) {
-			 my $s = join "\t", map { $_ ? $_ : "" } @$line;
-			 $s =~ s/\n//g;
-			 $s =~ s/\r//g;
-			 $phenotype_string .= $s."\n";
+		 $s = "";
+	         my $num_col = scalar(@{$line});
+		 for (my $j = 0; $j < $num_col; $j++) {
+                     if (@$line[$j]) {
+		         if ($s eq "") {
+	                    $s .= "\"@$line[$j]\"";
+		         } else {
+		            $s .= "\t\"@$line[$j]\"";
+			 }
+                     } else {
+                         $s .= "\t";
+                     }
+                 }			 
+		 $s =~ s/\n//g;
+		 $s =~ s/\r//g;
+		 $phenotype_string .= $s."\n";
 	     }
 	     write_file($file, $phenotype_string);
 	     return $phenotypes;

--- a/lib/CXGN/Phenotypes/PhenotypeMatrix.pm
+++ b/lib/CXGN/Phenotypes/PhenotypeMatrix.pm
@@ -215,7 +215,6 @@ sub get_phenotype_matrix {
 
             $trial_name =~ s/\s+$//g;
             $trial_desc =~ s/\s+$//g;
-	    $trial_desc = "\"" . $trial_desc . "\"";
 
             my @line = ($obs_unit->{year}, $obs_unit->{breeding_program_id}, $obs_unit->{breeding_program_name}, $obs_unit->{breeding_program_description}, $obs_unit->{trial_id}, $trial_name, $trial_desc, $obs_unit->{design}, $obs_unit->{plot_width}, $obs_unit->{plot_length}, $obs_unit->{field_size}, $obs_unit->{field_trial_is_planned_to_be_genotyped}, $obs_unit->{field_trial_is_planned_to_cross}, $obs_unit->{planting_date}, $obs_unit->{harvest_date}, $obs_unit->{trial_location_id}, $obs_unit->{trial_location_name}, $obs_unit->{germplasm_stock_id}, $obs_unit->{germplasm_uniquename}, $synonym_string, $obs_unit->{observationunit_type_name}, $obs_unit->{observationunit_stock_id}, $obs_unit->{observationunit_uniquename}, $obs_unit->{obsunit_rep}, $obs_unit->{obsunit_block}, $obs_unit->{obsunit_plot_number}, $obs_unit->{obsunit_row_number}, $obs_unit->{obsunit_col_number}, $entry_type, $obs_unit->{obsunit_plant_number}, $obs_unit->{seedlot_stock_id}, $obs_unit->{seedlot_uniquename}, $obs_unit->{seedlot_current_count}, $obs_unit->{seedlot_current_weight_gram}, $obs_unit->{seedlot_box_name}, $obs_unit->{seedlot_transaction_amount}, $obs_unit->{seedlot_transaction_weight_gram}, $obs_unit->{seedlot_transaction_description}, $available_germplasm_seedlots_uniquenames);
 


### PR DESCRIPTION
move quoting of phenotype data from PhenotypeMatrix.pm to Dataset/File.pm


There was an error because quoting in PhenotypeMatrix.pm caused double quoting
-----------------------------------------------------


#3331 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
