### PR TITLE
remove DOS style line feed characters in the header line.

### DIFF
--- a/lib/SGN/Controller/AJAX/Pedigrees.pm
+++ b/lib/SGN/Controller/AJAX/Pedigrees.pm
@@ -95,6 +95,7 @@ sub upload_pedigrees_verify : Path('/ajax/pedigrees/upload_verify') Args(0)  {
     my %stocks;
 
     my $header = <$F>;
+    $header =~ s/\r//g; 
     chomp($header);
     my ($progeny_name, $female_parent_accession, $male_parent_accession, $type) =split /\t/, $header;
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
added a line that removes the line feeds from the header. The rest of the lines in the files were already processed correctly.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
