### PR TITLE
Phenotype download in CSV format does not report values of zero

### DIFF
--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetCSV.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetCSV.pm
@@ -38,7 +38,7 @@ sub validate {
 
     my $csv = Text::CSV->new({ sep_char => ',' });
 
-    open(my $fh, '<', $filename)
+    open(my $fh, '< :encoding(UTF-8)', $filename)
         or die "Could not open file '$filename' $!";
 
     if (!$fh) {
@@ -143,7 +143,7 @@ sub parse {
     my @traits;
     my %data;
 
-    open(my $fh, '<', $filename)
+    open(my $fh, '< :encoding(UTF-8)', $filename)
         or die "Could not open file '$filename' $!";
 
     if (!$fh) {

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -573,7 +573,7 @@ sub download_action : Path('/breeders/download_action') Args(0) {
                     my @columns = @{$data[$line]};
                     my $step = 1;
                     for(my $i=0; $i<$num_col; $i++) {
-                        if ($columns[$i]) {
+                        if (defined($columns[$i])) {
                             print CSV "\"$columns[$i]\"";
                         } else {
                             print CSV "\"\"";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The phenotype download does not list values of zero when the CSV format is chosen. The values need to be checked for definedness, not true or false, as 0 is a false value in Perl.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
