### PR TITLE
tweak trial metadata editing permissions

### DIFF
--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -227,8 +227,14 @@ sub trial_details_POST  {
 
     print STDERR "my user roles = @user_roles and trial breeding program = $breeding_program_name \n";
 
-    if (!exists($has_roles{$breeding_program_name})) {
-      $c->stash->{rest} = { error => "You need to be associated with breeding program $breeding_program_name to change the details of this trial." };
+    # policy: curators can change without breeding program association
+    # submitters can change if they are associated with the breeding program
+    # users cannot change
+
+    if (! ( (exists($has_roles{$breeding_program_name}) && exists($has_roles{submitter})) || exists($has_roles{curator}))) { 
+    
+#    if (!exists($has_roles{$breeding_program_name})) {
+      $c->stash->{rest} = { error => "You need to be either a curator, or a submitter associated with breeding program $breeding_program_name to change the details of this trial." };
       return;
     }
 

--- a/lib/SGN/Controller/BreedersToolbox/Trial.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Trial.pm
@@ -63,8 +63,6 @@ sub trial_info : Chained('trial_init') PathPart('') Args(0) {
 	return;
     }
 
-    $c->stash->{user_can_modify} = ($user->check_roles("submitter") || $user->check_roles("curator")) ;
-
     my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
     my $trial = $c->stash->{trial};
     my $program_object = CXGN::BreedersToolbox::Projects->new( { schema => $schema });
@@ -103,6 +101,10 @@ sub trial_info : Chained('trial_init') PathPart('') Args(0) {
     $c->stash->{breeding_program_id} = $breeding_program_data->[0]->[0];
     $c->stash->{breeding_program_name} = $breeding_program_data->[0]->[1];
 
+    $c->stash->{user_can_modify} = ($user->check_roles("submitter") && $user->check_roles($c->stash->{breeding_program_name})) || $user->check_roles("curator") ;
+
+
+    
     $c->stash->{year} = $trial->get_year();
 
     $c->stash->{trial_id} = $c->stash->{trial_id};

--- a/mason/breeders_toolbox/trial.mas
+++ b/mason/breeders_toolbox/trial.mas
@@ -243,8 +243,8 @@ $management_factor_types => ()
 jQuery(document).ready(function () {
 
     var can_modify = '<% $user_can_modify %>';
-    alert('can modify: '+can_modify);
-    if (can_modify === '0') { 
+    // alert('can modify: '+can_modify);
+    if (can_modify === '0') {
       jQuery('#edit_trial_details').prop('disabled', true);
     }
 

--- a/mason/breeders_toolbox/trial.mas
+++ b/mason/breeders_toolbox/trial.mas
@@ -242,6 +242,12 @@ $management_factor_types => ()
 
 jQuery(document).ready(function () {
 
+    var can_modify = '<% $user_can_modify %>';
+    alert('can modify: '+can_modify);
+    if (can_modify === '0') { 
+      jQuery('#edit_trial_details').prop('disabled', true);
+    }
+
     jQuery('#edit_trial_details').click(function(){
 
         jQuery('#trial_details_edit_dialog').modal("show");


### PR DESCRIPTION
Implement policy: Curators can edit, submitters when associated with respective breeding program, users cannot edit.
Also, edit button is only active when these conditions are met.

closes #3347

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
