### PR TITLE
stockprops.mas: add missing closing div tags

### DIFF
--- a/mason/stock/stockprops.mas
+++ b/mason/stock/stockprops.mas
@@ -83,6 +83,9 @@ my $prop_select = simple_selectbox_html(
                 <input name="<% $div_name %>_prop" id="<% $div_name %>_prop" class="form-control" type="text" />
               </div>
             </div>
+
+          </div>
+        </div>
       
       <div class="modal-footer">
         <button id="close_add_<% $div_name %>_stockprop_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR adds missing end div tags to the add stock props modal dialog, which was causing display issues on the stock detail page.

Before fix:

![Web capture_8-3-2021_11561_localhost](https://user-images.githubusercontent.com/7526014/110360808-33632d80-800d-11eb-9632-9c629a820ea6.jpeg)

After fix:

![Web capture_8-3-2021_115920_localhost](https://user-images.githubusercontent.com/7526014/110360820-39590e80-800d-11eb-992f-5a35eb233aad.jpeg)


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
