### PR TITLE
remove Digest::SHA1 and replace with Digest::SHA.

### DIFF
--- a/lib/SGN/Controller/Bulk.pm
+++ b/lib/SGN/Controller/Bulk.pm
@@ -3,7 +3,7 @@ use 5.010;
 use Moose;
 use namespace::autoclean;
 use Cache::File;
-use Digest::SHA1 qw/sha1_hex/;
+use Digest::SHA qw/sha1_hex/;
 use File::Path qw/make_path/;
 use CXGN::Page::FormattingHelpers qw/modesel simple_selectbox_html /;
 use CXGN::Tools::Text qw/trim/;

--- a/t/legacy/integration/bulk_feature.t
+++ b/t/legacy/integration/bulk_feature.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More tests => 34;
 
-use Digest::SHA1 qw/sha1_hex/;
+use Digest::SHA qw/sha1_hex/;
 use Data::Dumper;
 
 use lib 't/lib';

--- a/t/legacy/integration/bulk_gene.t
+++ b/t/legacy/integration/bulk_gene.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 use SGN::Test::WWW::Mechanize skip_cgi => 1;
 use SGN::Test::Data qw/ create_test /;
 use Catalyst::Test 'SGN';
-use Digest::SHA1 qw/sha1_hex/;
+use Digest::SHA qw/sha1_hex/;
 use Data::Dumper;
 
 my $mech = SGN::Test::WWW::Mechanize->new;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
fixes issue #3378 

Digest::SHA is already installed in the local-lib.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
