### PR TITLE
displays markers from nd_protocolprop table

### DIFF
--- a/cgi-bin/search/markers/markerinfo.pl
+++ b/cgi-bin/search/markers/markerinfo.pl
@@ -3,9 +3,15 @@ use CGI ();
 
 my $q = CGI->new;
 my $marker_id = $q->param('marker_id');
-$marker_id =~ s/\D//g;
+my $marker_name = $q->param('marker_name');
 
-print $q->redirect(
+if (defined $marker_id) {
+    $marker_id =~ s/\D//g;
+    print $q->redirect(
     -status => 301,
-    -uri => "/marker/SGN-M$marker_id/details",
-);
+    -uri => "/marker/SGN-M$marker_id/details",);
+} else {
+    print $q->redirect(
+    -status => 301,
+    -uri => "/markerGeno/$marker_name/details",);
+};

--- a/lib/CXGN/Marker/SearchJson.pm
+++ b/lib/CXGN/Marker/SearchJson.pm
@@ -1,0 +1,176 @@
+use strict;
+use warnings;
+
+package CXGN::Marker::SearchJson;
+
+use CXGN::Marker;
+use CXGN::Marker::LocMarker;
+use CXGN::Marker::Tools qw(clean_marker_name);
+
+=head1 NAME
+
+CXGN::Marker::SearchJson - object to return lists of markers based on your criteria
+
+=head1 SYNOPSIS
+
+  use CXGN::Marker::SearchJson;
+  my $search = CXGN::Marker::SearchJson->new();
+
+
+=head1 DESCRIPTION
+
+Running a search consists of two steps:
+
+0. Create marker search object
+
+1. Call search_marker_json() to execute the SQL
+
+=cut
+  
+=head2 Constructor
+
+=over 12
+
+=item new($dbh)
+
+  my $msearch = CXGN::Marker::SearchJson->new($dbh);
+
+Returns a search object, ready for searching. Required before any of the other methods are called.
+
+=back
+
+=cut
+
+sub new {
+
+  my ($class, $dbh) = @_;
+
+  die "must provide a dbh as first argument: CXGN::Marker->new($dbh)\n"
+      unless $dbh && ref($dbh) && $dbh->can('selectall_arrayref');
+
+  my $self = bless {dbh => $dbh},$class;
+
+  return $self;
+
+}
+
+sub name_like {
+
+  my ($self, $name) = @_;
+
+  return unless $name;
+
+  # convert * to % (but leave underscores alone)
+  $name =~ s/\*/\%/g;
+
+  # strip un-normal characters?
+  $name =~ s|[^-_\w./%]||g;
+
+  # clean the name to see what WE would call it. 
+  # We'll search for both the input name and the cleaned name.
+  my $clean_name = clean_marker_name($name);
+
+  my $subquery = " s.value->>'name' like '$name'";
+  $self->{query_parts} .= $subquery;
+}
+
+sub on_chr {
+
+  my ($self, @chrs) = @_;
+
+  my $chrom_str = "'" . join('\',\'', @chrs) . "'";
+  my $subquery = " AND (s.value->>'chrom' IN ($chrom_str))";
+  $self->{query_parts} .= $subquery;
+}
+
+=item position_between($start, $end)
+
+Limits the results to markers appearing between the given endpoints.
+
+  $msearch->position_between(90,100);
+  $msearch->on_chr(5);
+  # returns only markers between 90-100 on chr 5
+
+  $msearch->position_between(50, undef);
+  # returns markers after 50 cM on any chromosome
+
+=cut
+
+sub position_between {
+
+  my ($self, $start, $end) = @_;
+
+  # making sure our inputs are numbers
+  # (pg barfs if you feed it a string; 
+  # we want to fail gracefully)
+  $start += 0;
+  $end += 0;
+  return unless ($start || $end);
+
+  my $subquery = " AND (s.value->>'pos')::int > $start AND (s.value->>'pos')::int < $end";
+  $self->{query_parts} .= $subquery;
+}
+
+sub return_subquery {
+    my ($self) = @_;
+    my $subq = '';
+    return $self->{query_parts};
+}    
+
+sub search_marker_json {
+    my ($self, $marker) = @_;
+    my @row;
+    my $protocol_name;
+    my $species_name;
+    my @protocol_set;
+    my %protocol_list;
+    my %species_list;
+    my $protocol_str;
+    my @marker_set;
+    my $results;
+
+    my $query = "select cvterm_id from cvterm where name = 'vcf_map_details'";
+    $self->{sth} = $self->{dbh}->prepare($query);
+    $self->{sth}->execute();
+    my ($protocol_map_cvterm) = $self->{sth}->fetchrow_array();
+
+    $query = "select cvterm_id from cvterm where name = 'vcf_map_details_markers'";
+    $self->{sth} = $self->{dbh}->prepare($query);
+    $self->{sth}->execute();
+    my ($protocol_markers_cvterm) = $self->{sth}->fetchrow_array(); 
+
+    $query = "select nd_protocol_id from nd_protocolprop WHERE '$marker' IN (SELECT jsonb_array_elements_text(nd_protocolprop.value->'marker_names') where type_id = $protocol_map_cvterm)";
+    $self->{sth} = $self->{dbh}->prepare($query);
+    $self->{sth}->execute();
+    while (@row = $self->{sth}->fetchrow_array()) {
+	push @protocol_set, $row[0];
+    }
+    my $count = scalar @protocol_set;
+    if ($count > 0) {
+        $protocol_str = join(',', @protocol_set);
+
+        $query = "select nd_protocol_id , s.value->>'name' as alias ,s.value->>'chrom' as lg_name ,s.value->>'pos' as position, s.value->>'ref' as ref, s.value->>'alt' as alt";
+        $query .= " FROM nd_protocolprop, jsonb_each(nd_protocolprop.value) as s";
+        $query .= " WHERE nd_protocol_id IN ($protocol_str) AND type_id = $protocol_map_cvterm AND s.value->>'name' = '$marker'";
+        $self->{sth} = $self->{dbh}->prepare($query);
+        $self->{sth}->execute();
+	$results = $self->{sth}->fetchall_arrayref({});
+    } else {
+	print STDERR "$query\nnot fount\n";
+    }
+    if (defined($results)) {
+        return $results;
+    } else {
+	return;
+    }
+}
+
+sub perform_search {
+
+  my ($self, $start, $end) = @_;
+
+}
+
+
+# all good modules return true
+1;

--- a/mason/markers/indexGenotype.mas
+++ b/mason/markers/indexGenotype.mas
@@ -1,0 +1,74 @@
+
+<%doc>
+
+=head1 NAME
+
+/markers/indexGenotype.mas - a Mason component displaying a marker detail page.
+
+=head1 DESCRIPTION
+
+The following parameters are required: 
+
+=over 5
+
+=item *
+
+$dbh - a database handle
+
+=item *
+
+$marker_name - the name of a marker in the SGN database
+$protocol_id - the id of the protocol in the SGN database
+
+=back
+
+This component is based on Perl code developed by John Binns.
+
+=head1 AUTHOR
+
+Clay Birkett <clb343@cornell.edu>
+
+=cut
+
+</%doc>
+
+<%args>
+$dbh
+$marker_name => undef
+$protocol_id => undef
+</%args>
+
+<%perl>
+
+use CXGN::Marker;
+use SGN::Exception;
+
+my $e = undef;
+
+if (!$marker_name) { 
+  $c->throw(
+     public_message => 'marker_name must be provided as an argument for this page',
+     is_client_error => 1,
+  );
+}
+
+my $marker = $marker_name;
+
+my $src_feature = "SL2.50";
+
+if (!$marker) { 
+  $e = SGN::Exception->new(title=>"Marker detail page error: Marker with name $marker_name does not exist in the database");
+ $m->comp('/site/error/exception.mas', exception=>$e);
+  return;
+}
+
+</%perl>
+
+<& /page/page_title.mas, title=> "Marker $marker_name" &>
+
+<& /markers/locationsGenotype.mas, marker=>$marker, dbh=>$dbh &>
+
+<&| /page/info_section.mas, title => "Genomic location of $marker_name", collapsible=>1 &>
+<& /feature/jbrowse_exact_match.mas, feature=> $marker_name, src_feature=> $src_feature &>
+</&>
+

--- a/mason/markers/locationsGenotype.mas
+++ b/mason/markers/locationsGenotype.mas
@@ -1,0 +1,109 @@
+<%doc>
+
+=head1 NAME
+
+/markers/locationsGenotype.mas - a Mason component displaying information about map locations of markers
+
+=head1 DESCRIPTION
+
+parameters 
+
+=over 5
+
+=item *
+
+$marker - a CXGN::Marker object.
+
+=back
+
+=head1 AUTHOR
+
+Lukas Mueller <clb343@cornell.edu>
+
+=cut
+
+</%doc>
+
+<%args>
+$marker
+$dbh
+</%args>
+
+<%perl>
+
+use strict;
+
+my @row;
+my $url;
+my $protocol_name;
+my $species_name;
+my $reference;
+my %protocol_list;
+my %species_list;
+my %reference_list;
+my @protocol_set;
+my $protocol_str;
+my $locations_html = '';
+
+my $sth = $dbh->prepare("select nd_protocol_id, name from nd_protocol");
+$sth->execute();
+while (@row = $sth->fetchrow_array()) {
+  $protocol_list{$row[0]} = $row[1];
+}
+
+my $query = "select cvterm_id from cvterm where name = 'vcf_map_details'";
+$sth = $dbh->prepare($query);
+$sth->execute();
+my ($protocol_map_cvterm) = $sth->fetchrow_array();
+
+$query = "select cvterm_id from cvterm where name = 'vcf_map_details_markers'";
+$sth = $dbh->prepare($query);
+$sth->execute();
+my ($protocol_markers_cvterm) = $sth->fetchrow_array();
+
+$query = "select nd_protocol_id from nd_protocolprop WHERE '$marker' IN (SELECT jsonb_array_elements_text(nd_protocolprop.value->'marker_names') where type_id = $protocol_map_cvterm)";
+$sth = $dbh->prepare($query);
+$sth->execute();
+while (@row = $sth->fetchrow_array()) {
+    push @protocol_set, $row[0];
+}
+my $count = scalar @protocol_set;
+if ($count > 0) {
+    $protocol_str = join(',', @protocol_set);
+    $query = "select nd_protocol_id, nd_protocolprop.value->>'species_name', nd_protocolprop.value->>'reference_genome_name' from nd_protocolprop";
+    $query .= " WHERE nd_protocol_id IN ($protocol_str) and type_id = $protocol_map_cvterm";
+    $sth = $dbh->prepare($query);
+    $sth->execute();
+    while (@row = $sth->fetchrow_array()) {
+        $species_list{$row[0]} = $row[1];
+        $reference_list{$row[0]} = $row[2];
+    }
+    $query = "select nd_protocol_id , s.value->>'name' as alias ,s.value->>'chrom' as lg_name ,s.value->>'pos' as position, s.value->>'ref' as ref, s.value->>'alt' as alt";
+    $query .= " FROM nd_protocolprop, jsonb_each(nd_protocolprop.value) as s";
+    $query .= " WHERE nd_protocol_id IN ($protocol_str) AND type_id = $protocol_markers_cvterm AND s.value->>'name' = '$marker'";
+    $sth = $dbh->prepare($query);
+    $sth->execute();
+    $locations_html = "<br><table style=\"border-spacing: 10px; border-collapse: separate;\">";
+    $locations_html .= "<tr><th>marker<th>protocol<th>Reference<th>species<th>chromosome<th>position<th>ref<th>alt\n";
+    while (@row = $sth->fetchrow_array()) {
+        $protocol_name = $protocol_list{$row[0]};
+        $species_name = $species_list{$row[0]};
+        $reference = $reference_list{$row[0]};
+        $url = "<a href=\"/breeders_toolbox/protocol/$row[0]\">$protocol_name</a>";;
+        $locations_html .= "<tr><td>$row[1]<td>$url<td>$reference<td>$species_name<td>$row[2]<td>$row[3]<td>$row[4]<td>$row[5]";
+    }
+    $locations_html .=  "</table>";
+
+} else {
+   $locations_html = "No results found";
+}
+
+my $marker_name    = $marker;
+my @displayed_locs;
+my @displayed_pcr;
+
+</%perl>
+
+<&| /page/info_section.mas, title=>'Genotype locations', collapsible=>1, collapsed=>0 &>
+  <% $locations_html %>
+</&>


### PR DESCRIPTION
adds a section to marker details page that will display markers from nd_protocolprop table
this pull request does not change the marker search page because that has been heavily modified for Triticeae Toolbox
the query for nd_protocolprop can be slow depending on the size of the table and how many protocols contain the marker
-----------------------------------------------------

#3351 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ x] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
