### PR TITLE
provide an option to download phenotype file with or without quotes; fix mixed model tool

### DIFF
--- a/lib/CXGN/Analysis/AnalysisCreate.pm
+++ b/lib/CXGN/Analysis/AnalysisCreate.pm
@@ -401,65 +401,75 @@ sub store {
             my $trait_cvterm_id = SGN::Model::Cvterm->get_cvterm_row_from_trait_name($bcs_schema, $trait_name)->cvterm_id();
             $trait_id_map{$trait_name} = $trait_cvterm_id;
         }
-        # print STDERR Dumper \%trait_id_map;
-        my @trait_ids = values %trait_id_map;
+        # # print STDERR Dumper \%trait_id_map;
+        # my @trait_ids = values %trait_id_map;
 
         my $stat_cvterm_id = SGN::Model::Cvterm->get_cvterm_row_from_trait_name($bcs_schema, $analysis_statistical_ontology_term)->cvterm_id();
 
-        my $categories = {
-            object => [],
-            attribute => [$stat_cvterm_id],
-            method => [],
-            unit => [],
-            trait => \@trait_ids,
-            tod => [],
-            toy => [],
-            gen => [],
-        };
-
-        # print STDERR Dumper $analysis_result_trait_compose_info_time;
-        my %time_term_map;
-        if ($analysis_result_trait_compose_info_time) {
-            my %unique_toy;
-            foreach my $v (values %$analysis_result_trait_compose_info_time) {
-                foreach (@$v) {
-                    my $trait_id = SGN::Model::Cvterm->get_cvterm_row_from_trait_name($bcs_schema, $_)->cvterm_id();
-                    $unique_toy{$trait_id}++;
-                    $time_term_map{$_} = $trait_id;
-                }
-            }
-            my @toy = keys %unique_toy;
-            $categories->{toy} = \@toy;
-        }
-        # print STDERR Dumper $categories;
-        # print STDERR Dumper \%time_term_map;
-
-        my $traits = SGN::Model::Cvterm->get_traits_from_component_categories($bcs_schema, $allowed_composed_cvs, $composable_cvterm_delimiter, $composable_cvterm_format, $categories);
-        my $existing_traits = $traits->{existing_traits};
-        my $new_traits = $traits->{new_traits};
-        # print STDERR Dumper $new_traits;
-        # print STDERR Dumper $existing_traits;
-        my %new_trait_names;
-        foreach (@$new_traits) {
-            my $components = $_->[0];
-            $new_trait_names{$_->[1]} = join ',', @$components;
-        }
-
+        # my $categories = {
+        #     object => [],
+        #     attribute => [$stat_cvterm_id],
+        #     method => [],
+        #     unit => [],
+        #     trait => \@trait_ids,
+        #     tod => [],
+        #     toy => [],
+        #     gen => [],
+        # };
+        #
+        # # print STDERR Dumper $analysis_result_trait_compose_info_time;
+        # my %time_term_map;
+        # if ($analysis_result_trait_compose_info_time) {
+        #     my %unique_toy;
+        #     foreach my $v (values %$analysis_result_trait_compose_info_time) {
+        #         foreach (@$v) {
+        #             my $trait_id = SGN::Model::Cvterm->get_cvterm_row_from_trait_name($bcs_schema, $_)->cvterm_id();
+        #             $unique_toy{$trait_id}++;
+        #             $time_term_map{$_} = $trait_id;
+        #         }
+        #     }
+        #     my @toy = keys %unique_toy;
+        #     $categories->{toy} = \@toy;
+        # }
+        # # print STDERR Dumper $categories;
+        # # print STDERR Dumper \%time_term_map;
+        #
+        # my $traits = SGN::Model::Cvterm->get_traits_from_component_categories($bcs_schema, $allowed_composed_cvs, $composable_cvterm_delimiter, $composable_cvterm_format, $categories);
+        # my $existing_traits = $traits->{existing_traits};
+        # my $new_traits = $traits->{new_traits};
+        # # print STDERR Dumper $new_traits;
+        # # print STDERR Dumper $existing_traits;
+        # my %new_trait_names;
+        # foreach (@$new_traits) {
+        #     my $components = $_->[0];
+        #     $new_trait_names{$_->[1]} = join ',', @$components;
+        # }
+        #
         my $onto = CXGN::Onto->new( { schema => $bcs_schema } );
-        my $new_terms = $onto->store_composed_term(\%new_trait_names);
+        # my $new_terms = $onto->store_composed_term(\%new_trait_names);
 
         my %composed_trait_map;
         while (my($trait_name, $trait_id) = each %trait_id_map) {
             my $components = [$trait_id, $stat_cvterm_id];
-            if (exists($analysis_result_trait_compose_info_time->{$trait_name})) {
-                foreach (@{$analysis_result_trait_compose_info_time->{$trait_name}}) {
-                    my $time_cvterm_id = $time_term_map{$_};
-                    push @$components, $time_cvterm_id;
-                }
-            }
+            # if (exists($analysis_result_trait_compose_info_time->{$trait_name})) {
+            #     foreach (@{$analysis_result_trait_compose_info_time->{$trait_name}}) {
+            #         my $time_cvterm_id = $time_term_map{$_};
+            #         push @$components, $time_cvterm_id;
+            #     }
+            # }
             my $composed_cvterm_id = SGN::Model::Cvterm->get_trait_from_exact_components($bcs_schema, $components);
-            my $composed_trait_name = SGN::Model::Cvterm::get_trait_from_cvterm_id($bcs_schema, $composed_cvterm_id, 'extended');
-            $composed_trait_map{$trait_name} = $composed_trait_name;
+            if ($composed_cvterm_id) {
+                my $composed_trait_name = SGN::Model::Cvterm::get_trait_from_cvterm_id($bcs_schema, $composed_cvterm_id, 'extended');
+                $composed_trait_map{$trait_name} = $composed_trait_name;
+            } else {
+                my ($name, $id) = split (/\|/ , $trait_name);
+                my ($analysis_name, $analysis_id) = split (/\|/ , $analysis_statistical_ontology_term);
+                my $composed_trait_name = $name . "|" . $analysis_name;
+                my %term_to_store;
+                $term_to_store{$composed_trait_name} = join ',', @$components;
+                my $new_term = $onto->store_composed_term(\%term_to_store);
+                $composed_trait_map{$trait_name} = @$new_term[0]->[1];
+            }
         }
         my @composed_trait_names = values %composed_trait_map;
 

--- a/lib/CXGN/Dataset/File.pm
+++ b/lib/CXGN/Dataset/File.pm
@@ -14,6 +14,11 @@ has 'file_name' => ( isa => 'Str',
 		     default => '/tmp/dataset_file',
     );
 
+has 'quotes' => ( isa => 'Bool',
+		  is => 'rw',
+		  default => 1,
+    );
+
 override('retrieve_genotypes',
 	sub {
 	    my $self = shift;
@@ -119,19 +124,26 @@ override('retrieve_phenotypes',
 	     my $phenotype_string = "";
 	     my $s;
 	     foreach my $line (@$phenotypes) {
-		 $s = "";
-	         my $num_col = scalar(@{$line});
-		 for (my $j = 0; $j < $num_col; $j++) {
-                     if (@$line[$j]) {
-		         if ($s eq "") {
-	                    $s .= "\"@$line[$j]\"";
-		         } else {
-		            $s .= "\t\"@$line[$j]\"";
-			 }
-                     } else {
-                         $s .= "\t";
-                     }
-                 }			 
+		 if ($self->quotes()) {
+		     $s = join("\t", map { "\"$_\"" } @$line);
+		 }
+		 else {
+		     $s = join("\t", @$line);
+		 }
+		 # $s = "";
+	         # my $num_col = scalar(@{$line});
+		 # for (my $j = 0; $j < $num_col; $j++) {
+                 #     if (@$line[$j]) {
+		 #         if ($s eq "") {
+	         #            $s .= "\"@$line[$j]\"";
+		 #         } else {
+		 #            $s .= "\t\"@$line[$j]\"";
+		 # 	 }
+                 #     } else {
+                 #         $s .= "\t";
+                 #     }
+                 # }		
+		 
 		 $s =~ s/\n//g;
 		 $s =~ s/\r//g;
 		 $phenotype_string .= $s."\n";

--- a/lib/CXGN/Phenotypes/File.pm
+++ b/lib/CXGN/Phenotypes/File.pm
@@ -25,6 +25,8 @@ has 'traits' => ( is => 'rw', isa => 'ArrayRef' );
 
 has 'levels' => ( is => 'rw', isa => 'HashRef' );
 
+has 'remove_quotes' => (is => 'rw', isa => 'Bool', default => sub { return 1; } );
+
 our $FACTOR_COUNT = 38; # number of columns in the file before traits columns start
 
 sub BUILD {
@@ -35,6 +37,15 @@ sub BUILD {
     chomp($header);
     
     my @keys = split("\t", $header);
+
+    if ($self->remove_quotes()) {
+	foreach my $k (@keys) { 
+	    print STDERR "Removing quotes from $k...";
+	    $k=~ s/^\"(.*)\"$/$1/;
+	    print STDERR "Now $k...\n";
+	}
+    }
+    
     
     my @data = ();
     my %line = ();
@@ -42,7 +53,13 @@ sub BUILD {
     
     for (my $i=1; $i<@lines; $i++) { 
 	my @fields = split /\t/, $lines[$i];
-	for(my $n=0; $n <@keys; $n++) { 
+	for(my $n=0; $n <@keys; $n++) {
+	    if ($self->remove_quotes()) {
+		print STDERR "Removing quotes from $fields[$n]...";
+		$fields[$n]=~ s/^\"(.*)\"$/$1/;
+		print STDERR "Now $fields[$n]...\n"; 
+	    }
+	    
 	    if (exists($fields[$n]) && defined($fields[$n])) {
 		$line{$keys[$n]}=$fields[$n];
 		if ($n<39) { 

--- a/lib/CXGN/Phenotypes/Search/MaterializedViewTable.pm
+++ b/lib/CXGN/Phenotypes/Search/MaterializedViewTable.pm
@@ -49,7 +49,7 @@ use SGN::Model::Cvterm;
 use CXGN::Stock::StockLookup;
 use CXGN::Trial::TrialLayout;
 use CXGN::Calendar;
-use JSON;
+use JSON::XS;
 
 has 'bcs_schema' => ( isa => 'Bio::Chado::Schema',
     is => 'rw',
@@ -298,10 +298,10 @@ sub search {
         my $planting_date_value = $calendar_funcs->display_start_date($planting_date);
         my $synonyms = $synonym_hash_lookup{$germplasm_uniquename};
         my $location_name = $location_id ? $location_id_lookup{$location_id} : '';
-        my $observations = decode_json $observations;
-        my $treatments = decode_json $treatments;
-        my $available_germplasm_seedlots = decode_json $available_germplasm_seedlots;
-        my $seedlot_transaction = $seedlot_transaction ? decode_json $seedlot_transaction : {};
+        my $observations = JSON::XS->new->decode($observations);
+        my $treatments = JSON::XS->new->decode($treatments);
+        my $available_germplasm_seedlots = JSON::XS->new->decode($available_germplasm_seedlots);
+        my $seedlot_transaction = $seedlot_transaction ? JSON::XS->new->decode($seedlot_transaction) : {};
 
         my %ordered_observations;
         foreach (@$observations){

--- a/lib/SGN/Controller/AJAX/MixedModels.pm
+++ b/lib/SGN/Controller/AJAX/MixedModels.pm
@@ -84,8 +84,10 @@ sub prepare: Path('/ajax/mixedmodels/prepare') Args(0) {
     my $schema = $c->dbic_schema("Bio::Chado::Schema", "sgn_chado");
     my $temppath = $c->config->{basepath}."/".$tempfile;
 
-    my $ds = CXGN::Dataset::File->new(people_schema => $people_schema, schema => $schema, sp_dataset_id => $dataset_id, file_name => $temppath);
+    my $ds = CXGN::Dataset::File->new(people_schema => $people_schema, schema => $schema, sp_dataset_id => $dataset_id, file_name => $temppath, quotes => 0);
     $ds->retrieve_phenotypes();
+
+    
 
     my $pf = CXGN::Phenotypes::File->new( { file => $temppath."_phenotype.txt" });
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The phenotype download in CXGN::Dataset::File was changed to contain quotes, which breaks the mixed model tool and possibly other tools. In this pull request, the CXGN::Dataset::File now has an additional method, quotes, which is by default true. Setting it to false (0) will generate files without quotes.

Check your tools to see if the quotes affect them... In general, I think the quotes are cleaner, and we should stay with the quotes for the general case.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
