### PR TITLE
add option to search nd_protocolprop in marker search page

### DIFF
--- a/cgi-bin/search/markers/markersearch.pl
+++ b/cgi-bin/search/markers/markersearch.pl
@@ -1,20 +1,19 @@
 
 package main;
 
-
 use strict;
+use warnings;
 use CXGN::Page;
 use CXGN::Search::CannedForms;
 use CXGN::Page::FormattingHelpers qw/blue_section_html  page_title_html columnar_table_html/;
 use CXGN::DB::Connection;
 use CXGN::Marker::Search;
+use CXGN::Marker::SearchJson;
 use HTML::Entities;
 
 our $page = CXGN::Page->new( "Marker Search", "Beth Skwarecki");
 
 my %params=$page->cgi_params();
-#use Data::Dumper
-#warn Dumper \%params;
 my $dbh=CXGN::DB::Connection->new();
 
 
@@ -22,41 +21,47 @@ my $form = CXGN::Search::CannedForms::MarkerSearch->new($dbh);
 $form->set_data(%params);
 $form->from_request(\%params);
 
-#warn "name param is $params{w822_marker_name}\n";
-#warn "name param is ". $form->data('marker_name');
-
 $page->header('SGN: Marker search') unless $form->data('text');
 
-
 if($form->data('submit') && ($form->data('submit') eq 'Search') || ($form->data('random') && $form->data('random') eq 'yes')) {
-
 
   #use Data::Dumper;
   #print '<pre>' .(Dumper \%params). '</pre>';
 
-
   # do the search!
-
+  my $query;
+  my @protos;
+  my $protocol;
+  my $marker_name;
   my $msearch = CXGN::Marker::Search->new($dbh);
+  my $msearchJ = CXGN::Marker::SearchJson->new($dbh);
 
-  if(my $marker_name = $form->data('marker_name')){
+  if($marker_name = $form->data('marker_name')){
 
     if($form->data('nametype') eq 'exactly'){
       # using name_exactly would be more efficient, 
       # but we probably want to be case-insensitive.
       $msearch->name_like($marker_name);
+      $msearchJ->name_like($marker_name);
     } elsif ($form->data('nametype') eq 'contains'){
       $msearch->name_like('%'.$marker_name.'%');
+      $msearchJ->name_like('%'.$marker_name.'%');
     } elsif ($form->data('nametype') eq 'starts with'){
       $msearch->name_like($marker_name.'%');
+      $msearchJ->name_like($marker_name.'%');
     }
 
   }
   
-
   if($form->data('mapped') && $form->data('mapped') eq 'on'){
-    #warn "MUST BE MAPPED\n";
-    $msearch->must_be_mapped();
+      #warn "MUST BE MAPPED\n";
+      $msearch->must_be_mapped();
+  } elsif ($marker_name =~ /\w/) {
+      print STDERR "marker_name = $marker_name\n";
+  } else {
+      print blue_section_html('Error',"You must enter a marker name.\n" );
+      print '<br /><br />', blue_section_html('Search Again', form_html($form));
+      return;
   }
 
   if($form->data('bac_assoc')){
@@ -79,12 +84,13 @@ if($form->data('submit') && ($form->data('submit') eq 'Search') || ($form->data(
     $msearch->in_species(@species) unless grep /^Any$/, @species;
   }
 
-  if(my @protos = $form->data_multiple('protos')){
-    $msearch->protocol(@protos) unless grep /^Any$/, @protos;
+  if(my @species = $form->data_multiple('species')){
+    $msearch->in_species(@species) unless grep /^Any$/, @species;
   }
 
   if(my @chromos = $form->data_multiple('chromos')){
     $msearch->on_chr(@chromos) unless grep /^Any$/, @chromos;
+    $msearchJ->on_chr(@chromos) unless grep /^Any$/, @chromos;
   }
 
   my $pos_start = $form->data('pos_start') || '';
@@ -92,6 +98,7 @@ if($form->data('submit') && ($form->data('submit') eq 'Search') || ($form->data(
 
   if ($pos_start or $pos_end){
     $msearch->position_between($pos_start, $pos_end);
+    $msearchJ->position_between($pos_start, $pos_end);
   }
 
   if(my @conf = $form->data_multiple('confs')){
@@ -117,12 +124,23 @@ if($form->data('submit') && ($form->data('submit') eq 'Search') || ($form->data(
   #print '<pre>'.(Dumper \@marker_ids).'</pre>';
 
   #print '<!-- '. $msearch->query_text() . ' -->';
-  
+ 
   my ($subq, $places) = $msearch->return_subquery_and_placeholders();
-  #warn $msearch->query_text();
+  my ($subq2) = $msearchJ->return_subquery();
 
-  my $resultstart = abs($form->data('resultstart')) || 0;
-  my $resultsize = abs($form->data('resultsize')) || 30;
+
+  my $resultstart;
+  my $resultsize;
+  if (defined $form->data('resultstart')) {
+      $resultstart = abs($form->data('resultstart'));
+  } else {
+      $resultstart = 0;
+  }
+  if (defined $form->data('resultsize')) {
+      $resultsize = abs($form->data('resultsize'));
+  } else {
+      $resultsize = 30;
+  }
 
   my $limitclause = " LIMIT $resultsize OFFSET $resultstart";
    $limitclause = "" if $form->data('text') && $form->data('text') eq 'yes';
@@ -132,11 +150,74 @@ if($form->data('submit') && ($form->data('submit') eq 'Search') || ($form->data(
   my $timestart = Time::HiRes::time;
 
   # This is our query.
-  my $query = "select distinct subq.lg_order, subq.confidence_id, subq.marker_id, alias, protocol, short_name, subq.lg_name, subq.position, confidence_name FROM ($subq) as subq inner join marker_alias using(marker_id) left join marker_location as ml on (ml.location_id=subq.location_id) left join marker_experiment as me on(me.location_id = subq.location_id) left join map_version as mv on (mv.map_version_id=ml.map_version_id) left join map on (map.map_id = mv.map_id) left join linkage_group as lg on(lg.lg_id = ml.lg_id) left join marker_confidence on(marker_confidence.confidence_id=ml.confidence_id) WHERE preferred = 't' ORDER BY subq.lg_order, position, subq.confidence_id desc, short_name";
+  my $resultcount;
+  my $countquery;
+  my %protocol_list;
+  my @protocol_set;
+  my $protocol_str;
+  my $protocol_name;
+  my @row;
 
-  # See how many rows we should get back.
-  my $countquery = "select count(*) from ($query) as countq";
-  my ($resultcount) = $dbh->selectrow_array($countquery, undef, @$places);
+  $query = "select cvterm_id from cvterm where name = 'vcf_map_details_markers'";
+  my $sth = $dbh->prepare($query);
+  $sth->execute();
+  my ($protocol_markers_cvterm) = $sth->fetchrow_array();
+
+  if($form->data('mapped') && $form->data('mapped') eq 'on'){
+    $query = "select distinct subq.lg_order, subq.confidence_id, subq.marker_id, alias, protocol, short_name, subq.lg_name, subq.position, confidence_name FROM ($subq) as subq inner join marker_alias using(marker_id) left join marker_location as ml on (ml.location_id=subq.location_id) left join marker_experiment as me on(me.location_id = subq.location_id) left join map_version as mv on (mv.map_version_id=ml.map_version_id) left join map on (map.map_id = mv.map_id) left join linkage_group as lg on(lg.lg_id = ml.lg_id) left join marker_confidence on(marker_confidence.confidence_id=ml.confidence_id) WHERE preferred = 't' ORDER BY subq.lg_order, position, subq.confidence_id desc, short_name";
+
+    # See how many rows we should get back.
+    $countquery = "select count(*) from ($query) as countq";
+    ($resultcount) = $dbh->selectrow_array($countquery, undef, @$places);
+  } else {
+    if ((defined $protocol) && ($protocol =~ /\d/)) {
+        push @protocol_set, $protocol;
+    } else {
+	$sth = $dbh->prepare("select nd_protocol_id, name from nd_protocol");
+        $sth->execute();
+        while (@row = $sth->fetchrow_array()) {
+            $protocol_list{$row[0]} = $row[1];
+        }
+	$query = "select cvterm_id from cvterm where name = 'vcf_map_details'";
+        $sth = $dbh->prepare($query);
+        $sth->execute();
+        my ($protocol_map_cvterm) = $sth->fetchrow_array();
+	$query = "select nd_protocol_id from nd_protocolprop WHERE '$marker_name' IN (SELECT jsonb_array_elements_text(nd_protocolprop.value->'marker_names') where type_id = $protocol_map_cvterm)";
+        $sth = $dbh->prepare($query);
+        $sth->execute();
+        while (@row = $sth->fetchrow_array()) {
+            push @protocol_set, $row[0];
+        }
+    }
+    my $protocolprop_marker_hash_select = ['name', 'chrom', 'pos', 'alt', 'ref']; #THESE ARE THE KEYS IN THE MARKERS OBJECT IN THE PROTOCOLPROP OBJECT
+    my @protocolprop_marker_hash_select_arr;
+    foreach (@$protocolprop_marker_hash_select){
+      push @protocolprop_marker_hash_select_arr, "s.value->>'$_'";
+    }
+    my $protocolprop_hash_select_sql = scalar(@protocolprop_marker_hash_select_arr) > 0 ? ', '.join ',', @protocolprop_marker_hash_select_arr : '';
+    $query = "select nd_protocol_id, s.value->>'name' as alias ,s.value->>'chrom' as lg_name ,s.value->>'pos' as position, s.value->>'ref' as ref, s.value->>'alt' as alt from nd_protocolprop, jsonb_each(nd_protocolprop.value) as s";
+    $countquery = "select count(*) as countq from nd_protocolprop, jsonb_each(nd_protocolprop.value) as s";
+    if (scalar(@protocol_set) > 0) {
+        $protocol_str = join(',', @protocol_set);
+        $query .= " WHERE nd_protocol_id IN ($protocol_str) AND type_id = $protocol_markers_cvterm";
+	$countquery .= " WHERE nd_protocol_id IN ($protocol_str) AND type_id = $protocol_markers_cvterm";
+    } else {
+        $query .= " WHERE nd_protocol_id IN (null) AND type_id = $protocol_markers_cvterm";
+	$countquery .= " WHERE nd_protocol_id IN (NULL) AND type_id = $protocol_markers_cvterm";
+    }
+    #print STDERR "query = $query\n";
+    if ($subq2 ne "") {
+	$query .= " AND $subq2";
+	#print STDERR "query = $query\n";
+    }
+    $query .= " ORDER by s.value->>'name'";
+    if ($subq2 ne "") {
+        $countquery .= " AND $subq2";
+	#print STDERR "subq2 = $subq2\n";
+    }
+    $places = ();
+    ($resultcount) = $dbh->selectrow_array($countquery, undef, @$places);
+  }
 
   # Do the query (with limits for pagination)
   my $search_results = $dbh->prepare("$query $limitclause");
@@ -170,16 +251,24 @@ if($form->data('submit') && ($form->data('submit') eq 'Search') || ($form->data(
 	
 	
 	my $tabledata;
-	
-    foreach my $r (@$resultset){
-	my $pos = '';
+	my $headings;
+	my $pos;
+
+    if($form->data('mapped') && $form->data('mapped') eq 'on'){
+      $headings = "headings => ['Marker', 'Protocol', 'Map', 'Chromosome', 'Position', 'Confidence']";
+      foreach my $r (@$resultset){
+	$pos = '';
 	$pos = sprintf("%.2f", $r->{position}) if ($r->{position} > 0 || $r->{lg_name});
       
-      push(@$tabledata, [qq{<a href="/search/markers/markerinfo.pl?marker_id=$r->{marker_id}">$r->{alias}</a>}, $r->{protocol}, $r->{short_name}, $r->{lg_name}, $pos, $r->{confidence_name}]);
-      
+        push(@$tabledata, [qq{<a href="/search/markers/markerinfo.pl?marker_id=$r->{marker_id}">$r->{alias}</a>}, $r->{protocol}, $r->{short_name}, $r->{lg_name}, $pos, $r->{confidence_name}]);
+      }
+    } else {
+      $headings = "headings => ['Marker', 'Protocol', 'Chromosome', 'Position', 'Ref', 'Alt']";
+      foreach my $r (@$resultset){
+	 $protocol_name = $protocol_list{$r->{nd_protocol_id}};
+         push(@$tabledata, [qq{<a href="/search/markers/markerinfo.pl?marker_name=$r->{alias}">$r->{alias}}, $protocol_name, $r->{lg_name}, $r->{position}, $r->{ref}, $r->{alt}]);
+      }
     }
-	
-
 
 	my ($prevparams, $nextparams, $textparams);
 	{
@@ -240,13 +329,22 @@ if($form->data('submit') && ($form->data('submit') eq 'Search') || ($form->data(
 	my $resultsummary = "Showing results $resultstart to $resultend of $resultcount. $textlink<br />$prevlink | $nextlink<br /><br />";
 	
 	# the form was submitted, so we should present some results.
-	print blue_section_html('Marker search results', 
-				"$resultcount results found in $timeelapsed seconds", 
-				$resultsummary
-				. columnar_table_html(
-						      headings => ['Marker', 'Protocol', 'Map', 'Chromosome', 'Position', 'Confidence'],
-						      data => $tabledata));
-	
+	if($form->data('mapped') && $form->data('mapped') eq 'on'){
+        print blue_section_html('Marker search results',
+                                "$resultcount results found in $timeelapsed seconds",
+                                $resultsummary
+                                . columnar_table_html(
+                                                      headings => ['Marker', 'Protocol', 'Map', 'Chromosome', 'Position', 'Confidence'],
+                                                      data => $tabledata));
+	} else {
+	    print blue_section_html('Marker search results for ' . $protos[0],
+                                "$resultcount results found in $timeelapsed seconds",
+                                $resultsummary
+                                . columnar_table_html(
+                                                      headings => ['Marker', 'Protocol', 'Chromosome', 'Position', 'Ref', 'Alt'],
+                                                      data => $tabledata));
+        }
+
 	print '<br /><br />', blue_section_html('Search again', form_html($form));
 	
       } # end of if-else text output

--- a/lib/CXGN/Search/CannedForms.pm
+++ b/lib/CXGN/Search/CannedForms.pm
@@ -607,7 +607,7 @@ sub to_html {
 	  <div class="col-sm-9" >
 	    <input class="btn btn-primary" type="submit" name="$uniq{submit}" value="Search" />&nbsp;&nbsp;&nbsp;&nbsp;
             $checkbox{'mapped','checked'}
-            <span class="help" title="Unmapped markers include candidate markers that have not yet been mapped, and polymorphism surveys.">Find only markers that are mapped</span>
+            <span class="help" title="Unmapped markers include candidate markers that have not yet been mapped, and polymorphism surveys.">Find only markers on <a href=/cview>maps</a></span>
 	  </div>
 	</div>
       </div>
@@ -633,10 +633,10 @@ EOHTML
         $checkbox{overgo_assoc}
         <span class="help" title="The overgo process associates BACs with certain markers from SGN tomato maps.">Overgo associations<small> <a href="/maps/physical/overgo_process_explained.pl">[About the overgo process]</a></small></span><br />
 
-	$checkbox{manual_assoc}
+        $checkbox{manual_assoc}
         <span class="help" title="Some markers have been manually associated with BACs.">Manual associations</span><br />
 
-	$checkbox{comp_assoc}
+        $checkbox{comp_assoc}
         <span class="help" title="Some markers have been BLASTed against our collection of BACs.">Computational associations</span><br />
 
       </div>
@@ -644,22 +644,22 @@ EOHTML
 
       <div class="form-horizontal" >
 	<div class="form-group">
-      	  <label class="col-sm-6 control-label">Show markers mapped in species: </label>
+      	  <label class="col-sm-6 control-label">Show markers in species: </label>
       	  <div class="col-sm-6" >
 	    $species{yeah}
           </div>
 	</div>
 	<div class="form-group">
-      	  <label class="col-sm-6 control-label"><span class="help" title="Protocol definitions: AFLP - Amplified Fragment Length Polymorphisms. CAPS - Cleaved Amplified Polymorphisms. PCR - any unspecified PCR-based method. RFLP - Restriction Fragment Length Polymorphism. SSR - Short Sequence Repeats (microsatellites)">Show markers mapped by: </span></label>
+      	  <label class="col-sm-6 control-label"><span class="help" title="Protocol definitions: AFLP - Amplified Fragment Length Polymorphisms. CAPS - Cleaved Amplified Polymorphisms. PCR - any unspecified PCR-based method. RFLP - Restriction Fragment Length Polymorphism. SSR - Short Sequence Repeats (microsatellites)">Show markers in Protocol: </span></label>
       	  <div class="col-sm-6" >
 	    $protocols{'yeah'}
           </div>
 	</div>
 	<div class="form-group">
-      	  <label class="col-sm-6 control-label"><span class="help" title="Collections: COS - Conserved Ortholog Sequences (tomato and Arabidopsis). COSII - Conserved Ortholog Sequences II (several Asterid species). KFG - Known Function Genes')">Show markers in group: </span></label>
-      	  <div class="col-sm-6" >
+	  <label class="col-sm-6 control-label"><span class="help" title="Collections: COS - Conserved Ortholog Sequences (tomato and Arabidopsis). COSII - Conserved Ortholog Sequences II (several Asterid species). KFG - Known Function Genes')">Show markers in group: </span></label>
+          <div class="col-sm-6" >
 	    $colls{'yeah'}
-          </div>
+	  </div>
 	</div>
       </div>
     </div>
@@ -671,7 +671,7 @@ EOFOO
 
 EOHTML
 
-    $retstring .= blue_section_html( 'Map Locations', <<EOHTML);
+    $retstring .= blue_section_html( 'Map/Marker Locations', <<EOHTML);
 
       <div class="form-horizontal" >
 	<div class="form-group">
@@ -691,9 +691,9 @@ EOHTML
 	  </div>
 	</div>
 	<div class="form-group">
-      	  <label class="col-sm-6 control-label"><span class="help" title="Maps that have been made with MapMaker have confidence values associated with their positions. Leave this setting at &quot;uncalculated&quot; to see all markers on all maps.">Confidence at least: </span></label>
-      	  <div class="col-sm-6" >
-	     $confs{yeah}
+	  <label class="col-sm-6 control-label"><span class="help" title="Maps that have been made with MapMaker have confidence values associated with their positions. Leave this setting at &quot;uncalculated&quot; to see all markers on all maps.">Confidence at least: </span></label>
+          <div class="col-sm-6" >
+             $confs{yeah}
           </div>
 	</div>
 	<div class="form-group">
@@ -907,10 +907,7 @@ sub nametype {
 sub protocol_select {
 
     my $self = shift;
-    my $protolist =
-      $self->{dbh}->selectcol_arrayref(
-"SELECT distinct protocol FROM marker_experiment WHERE protocol <> 'unknown'"
-      );
+    my $protolist = $self->{dbh}->selectcol_arrayref("SELECT distinct protocol FROM marker_experiment WHERE protocol <> 'unknown'");
 
     #push(@$protolist, 'RFLP');
 


### PR DESCRIPTION
query markers from genotype studies in marker search page
when "find only markers on map" is not selected the query will use nd_protocolprop table
-----------------------------------------------------


#3351


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [x ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
