### PR TITLE
Topic/seedlot upload error messages

### DIFF
--- a/mason/breeders_toolbox/seedlots.mas
+++ b/mason/breeders_toolbox/seedlots.mas
@@ -45,7 +45,12 @@ $crossing_trials
     </div>
 </&>
 
-<&| /page/info_section.mas, title=>"Seedlots",  collapsible => 1, subtitle => '<button class="btn btn-sm btn-primary" style="margin:3px" name="add_seedlot_button">Add New Seedlot</button> <button class="btn btn-sm btn-primary" style="margin:3px" name="seedlot_bulk_upload">Upload Seedlots</button> <button class="btn btn-sm btn-primary" style="margin:3px" name="seedlot_upload_inventory">Upload Inventory</button>'&>
+<%perl>
+    my $seedlot_subtitle = !!$c->user() 
+        ? '<button class="btn btn-sm btn-primary" style="margin:3px" name="add_seedlot_button">Add New Seedlot</button> <button class="btn btn-sm btn-primary" style="margin:3px" name="seedlot_bulk_upload">Upload Seedlots</button> <button class="btn btn-sm btn-primary" style="margin:3px" name="seedlot_upload_inventory">Upload Inventory</button>'
+        : "Login to add or upload seedlots";
+</%perl>
+<&| /page/info_section.mas, title=>"Seedlots",  collapsible => 1, subtitle => $seedlot_subtitle &>
 
 <br/>
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This improves the error messages returned when uploading seedlots:
- include the seedlot name with the error message
- check for undefined accession/cross id before creating a new seedlot
- check for errors returned from the seedlot store function

It also changes the add/upload buttons on the seedlot page to only be displayed when the user is logged in and displays a message to login if they are not.

There is still an issue that a seedlot file can pass validation but fail on storage if the accession name differs in case from the database entry (the validation is case-insensitive but the method to get the stock id from an accession name is case sensitive).

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
