### PR TITLE
Topic/fix download utf8

### DIFF
--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -614,7 +614,7 @@ sub download_action : Path('/breeders/download_action') Args(0) {
         $c->res->header('Content-Disposition', qq[attachment; filename="$file_name"]);
 
 	my $output = "";
-	open(my $F, "< :encoding(UTF-8)", $tempfile) || die "Can't open file $tempfile for reading.";
+	open(my $F, "< :raw", $tempfile) || die "Can't open file $tempfile for reading.";
 	while (<$F>) {
 	    $output .= $_;
 	}


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes an issue with the download of pedigrees on the download page that contain characters in utf-8.
In essence, the read_file function of File::Slurp does not handle UTF-8 correctly, and should not be used in any code... (that was new to me too).

Thanks to Martin Lague for pointing out the issue.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
