### PR TITLE
Pressing enter in change plot accession feature functions properly

### DIFF
--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -1320,8 +1320,13 @@ jQuery(document).ready( function() {
     jQuery("#hm_accession").autocomplete({
         appendTo: "#hm_replace_plot_accessions_dialog",
         source: '/ajax/stock/accession_autocomplete',
-    }); 
-    
+    });
+
+    jQuery("#hm_replace_plot_accession_form").submit( function() {
+      event.preventDefault();
+      hm_replace_plotAccession_fieldMap();
+    });
+
     jQuery('#hm_replace_plot_accession_submit').click( function() {
       hm_replace_plotAccession_fieldMap();
     });


### PR DESCRIPTION
There was no event handler for pressing enter on the change accessions form so it's default behavior was just to refresh the page
without calling the appropriate function. 
Now pressing enter does not refresh the page and calls the hm_replace_plotAccession_fieldMap() function as it should.

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
