### PR TITLE
Topic/sequence metadata markers

### DIFF
--- a/lib/CXGN/Marker/SearchMatView.pm
+++ b/lib/CXGN/Marker/SearchMatView.pm
@@ -1,0 +1,180 @@
+package CXGN::Marker::SearchMatView;
+
+=head1 NAME
+
+CXGN::Marker::SearchMatView - class to search for markers based on name or 
+position using the unified marker materialized view
+
+=head1 USAGE
+
+To perform a marker search, first create a marker search object with a bio chado schema:
+    use CXGN::Marker::SearchMatView;
+    my $msearch = CXGN::Marker::SearchMatView->new(bcs_schema => $schema);
+
+Then call the query function with the desired filter parameters
+example: filter markers based on position:
+    my $results = $msearch->query(
+        chrom => '1A',
+        start => '1000',
+        end => '2000',
+        species_name => 'Triticum aestivum',
+        reference_genome_name => 'RefSeq_v1'
+    );
+example: filter markers based on name:
+    my $results = $msearch->query(
+        name => '1WA10'
+    );
+example: filter markers based on a substring of the name:
+    my $results = $msearch->query(
+        name_substring => 'IWA'
+    );
+example: filter markers based on name for a particular set of genotype protocols:
+    my @genotype_protocols = (37, 38);
+    my $results = $msearch->query(
+        name => 'IWA10',
+        nd_protocol_ids => \@genotype_protocols
+    );
+
+=head1 AUTHORS
+
+David Waring <djw64@cornell.edu>
+
+=cut
+
+
+use strict;
+use warnings;
+use Moose;
+
+
+has 'bcs_schema' => (
+    isa => 'Bio::Chado::Schema',
+    is => 'rw',
+    required => 1
+);
+
+
+sub BUILD {
+    my $self = shift;
+}
+
+
+#
+# Search the unified marker materialized view for markers matching the provided search criteria
+#
+# Arguments:
+#   - chrom = (required if start or end are provided) chromosome name
+#   - start = (optional) start position of query range
+#   - end = (optional) end position of query range
+#   - species_name = (required if chrom, start, or end are provided) species name
+#   - reference_genome_name (required if chrom, start, or end are provided) reference genome name
+#   - name = (optional) marker name or alias
+#   - name_substring = (optional) part of marker name or alias
+#   - nd_protocol_ids = (optional) array ref of genotype protocol ids
+#
+# Returns an array of hashes containing the marker info with the following keys"
+#   - nd_protocol_id = genotype protocol id
+#   - species_name = species name
+#   - reference_genome_name = reference genome name
+#   - marker_name = marker name (from genotype protocol)
+#   - alias = marker alias (uniformly generated marker name)
+#   - chrom = chromosome name
+#   - pos = chromosome position
+#   - ref = reference allele
+#   - alt = alternate allele
+#
+sub query {
+    my $self = shift;
+    my $args = shift;
+    my $chrom = $args->{chrom};
+    my $start = $args->{start};
+    my $end = $args->{end};
+    my $species = $args->{species_name};
+    my $reference_genome = $args->{reference_genome_name};
+    my $name = $args->{name};
+    my $name_substring = $args->{name_substring};
+    my $nd_protocol_ids = $args->{nd_protocol_ids};
+
+    my $schema = $self->bcs_schema;
+    my $dbh = $schema->storage->dbh();
+
+    # Build query
+    my $query = "SELECT nd_protocol_id, species_name, reference_genome_name, marker_name, alias, chrom, pos, ref, alt";
+    $query .= " FROM sgn.markers_all";
+
+    # Add filter parameters
+    my @where = ();
+    my @args = ();
+    if ( defined $species ) {
+        push(@where, "species_name = ?");
+        push(@args, $species);
+    }
+    if ( defined $reference_genome ) {
+        push(@where, "reference_genome_name = ?");
+        push(@args, $reference_genome);
+    }
+    if ( defined $chrom && defined $species && defined $reference_genome ) {
+        my $pw = "chrom = ?";
+        push(@args, $chrom);
+        if ( defined $start ) {
+            $pw .= " AND pos >= ?";
+            push(@args, $start);
+        }
+        if ( defined $end ) {
+            $pw .= " AND pos <= ?";
+            push(@args, $end);
+        }
+        push(@where, $pw);
+    }
+    if ( defined $name ) {
+        push(@where, "(marker_name = ? OR alias = ?)");
+        push(@args, $name, $name);
+    }
+    if ( defined $name_substring ) {
+        push(@where, "(marker_name LIKE ? OR alias LIKE ?)");
+        push(@args, '%' . $name_substring . '%', '%' . $name_substring . '%');
+    }
+    if ( defined $nd_protocol_ids && @$nd_protocol_ids ) {
+        my $pw = "nd_protocol_id IN (@{[join',', ('?') x @$nd_protocol_ids]})";
+        push(@where, $pw);
+        push(@args, @$nd_protocol_ids);
+    }
+    if ( @where ) {
+        $query .= " WHERE " . join(' AND ', @where);
+    }
+
+    # print STDERR "QUERY:\n";
+    # print STDERR "$query\n";
+    # use Data::Dumper;
+    # print STDERR "ARGS:\n";
+    # print STDERR Dumper \@args;
+
+    # Perform the Query
+    my $h = $dbh->prepare($query);
+    $h->execute(@args);
+
+    # Parse the results
+    my @results = ();
+    while (my ($nd_protocol_id, $species_name, $reference_genome_name, $marker_name, $alias, $chrom, $pos, $ref, $alt) = $h->fetchrow_array()) {
+        my %result = (
+            nd_protocol_id => $nd_protocol_id,
+            species_name => $species_name,
+            reference_genome_name => $reference_genome_name,
+            marker_name => $marker_name,
+            alias => $alias,
+            chrom => $chrom,
+            pos => $pos,
+            ref => $ref,
+            alt => $alt
+        );
+        push(@results, \%result);
+    }
+
+    # print STDERR "RESULTS: " . scalar(@results) . " markers\n";
+
+    # Return the results
+    return(\@results);
+}
+
+
+1;

--- a/lib/CXGN/Marker/SearchMatView.pm
+++ b/lib/CXGN/Marker/SearchMatView.pm
@@ -99,8 +99,9 @@ sub query {
     my $dbh = $schema->storage->dbh();
 
     # Build query
-    my $query = "SELECT nd_protocol_id, species_name, reference_genome_name, marker_name, alias, chrom, pos, ref, alt";
+    my $query = "SELECT markers_all.nd_protocol_id, nd_protocol.name AS nd_protocol_name, species_name, reference_genome_name, marker_name, alias, chrom, pos, ref, alt";
     $query .= " FROM sgn.markers_all";
+    $query .= " LEFT JOIN nd_protocol USING (nd_protocol_id)";
 
     # Add filter parameters
     my @where = ();
@@ -143,6 +144,9 @@ sub query {
         $query .= " WHERE " . join(' AND ', @where);
     }
 
+    # Sort by Marker Name
+    $query .= " ORDER BY marker_name";
+
     # print STDERR "QUERY:\n";
     # print STDERR "$query\n";
     # use Data::Dumper;
@@ -155,9 +159,10 @@ sub query {
 
     # Parse the results
     my @results = ();
-    while (my ($nd_protocol_id, $species_name, $reference_genome_name, $marker_name, $alias, $chrom, $pos, $ref, $alt) = $h->fetchrow_array()) {
+    while (my ($nd_protocol_id, $nd_protocol_name, $species_name, $reference_genome_name, $marker_name, $alias, $chrom, $pos, $ref, $alt) = $h->fetchrow_array()) {
         my %result = (
             nd_protocol_id => $nd_protocol_id,
+            nd_protocol_name => $nd_protocol_name, 
             species_name => $species_name,
             reference_genome_name => $reference_genome_name,
             marker_name => $marker_name,

--- a/lib/SGN/Controller/AJAX/SequenceMetadata.pm
+++ b/lib/SGN/Controller/AJAX/SequenceMetadata.pm
@@ -367,6 +367,7 @@ sub sequence_metadata_upload_verify_POST : Args(0) {
 #   - new_protocol_description = description of new protocol
 #   - new_protocol_sequence_metadata_type = cvterm id of sequence metadata type
 #   - new_protocol_reference_genome = name of reference genome
+#   - new_protocol_species = name of species
 #   - new_protocol_score_description = description of score field
 #   - new_protocol_attribute_count = max number of attributes to read (some may be missing if an attribute was removed)
 #   - new_protocol_attribute_key_{n} = key name of nth attribute
@@ -414,6 +415,7 @@ sub sequence_metadata_store_POST : Args(0) {
         my $protocol_description = $c->req->param('new_protocol_description');
         my $protocol_sequence_metadata_type_id = $c->req->param('new_protocol_sequence_metadata_type');
         my $protocol_reference_genome = $c->req->param('new_protocol_reference_genome');
+        my $protocol_species = $c->req->param('new_protocol_species');
         my $protocol_score_description = $c->req->param('new_protocol_score_description');
         my $protocol_attribute_count = $c->req->param('new_protocol_attribute_count');
         if ( !defined $protocol_name || $protocol_name eq '' ) {
@@ -432,6 +434,10 @@ sub sequence_metadata_store_POST : Args(0) {
             $c->stash->{rest} = {error => 'The new protocol reference genome must be defined!'};
             $c->detach();
         }
+        if ( !defined $protocol_species || $protocol_species eq '' ) {
+            $c->stash->{rest} = {error => 'The new protocol species must be defined!'};
+            $c->detach();
+        }
 
         my $sequence_metadata_type_cvterm = $schema->resultset('Cv::Cvterm')->find({ cvterm_id => $protocol_sequence_metadata_type_id });
         if ( !defined $sequence_metadata_type_cvterm ) {
@@ -442,7 +448,8 @@ sub sequence_metadata_store_POST : Args(0) {
         my %sequence_metadata_protocol_props = (
             sequence_metadata_type_id => $protocol_sequence_metadata_type_id,
             sequence_metadata_type => $sequence_metadata_type_cvterm->name(),
-            reference_genome => $protocol_reference_genome
+            reference_genome => $protocol_reference_genome,
+            species => $protocol_species
         );
         if ( defined $protocol_score_description && $protocol_score_description ne '' ) {
             $sequence_metadata_protocol_props{'score_description'} = $protocol_score_description;

--- a/lib/SGN/Controller/AJAX/SequenceMetadata.pm
+++ b/lib/SGN/Controller/AJAX/SequenceMetadata.pm
@@ -20,6 +20,48 @@ __PACKAGE__->config(
     map       => { 'application/json' => 'JSON', 'text/html' => 'JSON' },
 );
 
+
+#
+# Get a list of genotype protocols and their properties
+# PATH: GET /ajax/sequence_metadata/genotype_protocols
+# RETURNS:
+#   - genotype_protocols: an array of genotype protocols
+#       - protocol_id: genotype protocol id
+#       - protocol_name: genotype protocol name
+#       - protocol_description: genotype protocol description
+#       - species_name: species name of organism sampled by genotype protocol
+#       - reference_genome_name: name of the reference genome used by the genotype protocol
+#       - marker_count: number of markers included in the genotype protocol
+#
+sub get_genotype_protocols : Path('/ajax/sequence_metadata/genotype_protocols') :Args(0) {
+    my $self = shift;
+    my $c = shift;
+    my $schema = $c->dbic_schema("Bio::Chado::Schema");
+
+    # Get Genotype Protocols
+    my $protocol_search_result = CXGN::Genotype::Protocol::list_simple($schema);
+
+    # Get reference genomes from the protocols
+    my @results = ();
+    foreach my $protocol (@$protocol_search_result) {
+        my %result = (
+            protocol_id => $protocol->{protocol_id},
+            protocol_name => $protocol->{protocol_name},
+            protocol_description => $protocol->{protocol_description},
+            species_name => $protocol->{species_name},
+            reference_genome_name => $protocol->{reference_genome_name},
+            marker_count => $protocol->{marker_count}
+        );
+        push(@results, \%result);
+    }
+
+    # Return the results
+    $c->stash->{rest} = {
+        genotype_protocols => \@results
+    };
+}
+
+
 #
 # Get a list of reference genomes from loaded genotype protocols
 # PATH: GET /ajax/sequence_metadata/reference_genomes

--- a/mason/tools/sequence_metadata/query_sequence_metadata.mas
+++ b/mason/tools/sequence_metadata/query_sequence_metadata.mas
@@ -210,44 +210,6 @@
 </div>
 
 
-<!-- MARKER SEARCH GENOTYPE PROTOCOL SELECTION -->
-<div class="modal fade" id="sequence_metadata_genotype_protocol_dialog" name="sequence_metadata_genotype_protocol_dialog" tabindex="-1" role="dialog" aria-labelledby="DeleteModelDataDialog">
-    <div class="modal-dialog " role="document">
-        <div class="modal-content">
-            <div class="modal-header" style="text-align: center">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title" id="DeleteModelDataDialog">Select Genotype Protocol(s)</h4>
-            </div>
-            <div class="modal-body">
-                <div class="container-fluid">
-                    <h4>Marker Search</h4>
-
-                    <p>You can search for markers located within the range of a sequence metadata feature. Here you can choose which genotype protocols to 
-                    include in that search.  NOTE: Including more genotype protocols increases the amount of time to perform the marker search.</p>
-
-                    <br />
-
-                    <!-- Genotype Protocols -->
-                    <div class="form-group">
-                        <label class="col-sm-2 control-label">Genotype Protocol(s): </label>
-                        <div class="col-sm-10">
-                            <select class="form-control" id="sequence_metadata_filter_genoproto" size="10" multiple disabled>
-                                <option value="">Loading...</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button id="close_delete_model_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                <button type="button" class="btn btn-primary" name="sequence_metadata_genotype_protocol_dialog_update" id="sequence_metadata_genotype_protocol_dialog_update">Set Genotype Protocol(s)</button>
-            </div>
-        </div>
-    </div>
-</div>
-
-
-
 <!-- JBROWSE CONFIGURATION -->
 <!-- OVERWRITE THIS FILE IN THE INSTANCE-SPECIFIC MASON REPO TO CONFIGURE -->
 <& /tools/sequence_metadata/jbrowse_config_sequence_metadata.mas &>
@@ -259,8 +221,6 @@ var features = [];                          // List of sequence metadata feature
 var data_types = [];                        // List of sequence metadata data types fetched from the database
 var protocols = [];                         // List of existing sequence metadata protocols fetched from the database
 var attribute_filter_count = 0;             // Current count of attribute filters added by user
-var genotype_protocols = [];                // List of genotype protocols fetched from the database
-var genotype_protocols_selected;            // List of user selected genotype protocols for the marker search
 var markers;                                // Object of queried markers from the database for specific ranges
 
 jQuery(document).ready(function() {
@@ -302,11 +262,6 @@ jQuery(document).ready(function() {
 
     // Return to Query
     jQuery('#sequence_metadata_filter_return').click(toggle_sections);
-
-    // Setup/Start Marker Search
-    jQuery('#sequence_metadata_filter_results').on('click', '.sequence_metadata_genotype_protocol_selection_button', setupMarkerSearch);
-    jQuery('#sequence_metadata_genotype_protocol_dialog_update').click(updateMarkerSearchGenotypeProtocols);
-    jQuery('#sequence_metadata_filter_results').on('click', '.sequence_metadata_marker_search_button', startMarkerSearch);
 
 
     //
@@ -367,16 +322,16 @@ jQuery(document).ready(function() {
             { title: "Feature", data: "feature_name" },
             { title: "Start", data: "start" },
             { title: "End", data: "end" },
-            { title: "Markers", data: renderMarkersColumn },
             { title: "Score", data: "score" },
-            { title: "Attributes", data: "attributes", render: renderAttributesColumn }
+            { title: "Attributes", data: "attributes", render: renderAttributesColumn },
+            { title: "Markers", data: renderMarkersColumn }
         ],
         buttons: DT_BUTTONS
     });
 
     // Update the Marker Search display when the table is redrawn (on page change, etc...)
     jQuery('#sequence_metadata_filter_results').DataTable().on('draw.dt', function() {
-        updateMarkerColumn();
+        updateMarkers();
     });
 
 });
@@ -869,7 +824,6 @@ function handle_query_results(response) {
 
     // Reset Markers
     markers = undefined;
-    updateMarkerColumn();
 
     // Reset Query Button
     jQuery('#sequence_metadata_filter_query').html('Query');
@@ -971,58 +925,63 @@ function getJBrowseURL(config) {
 
 
 /**
- * Setup the marker search by having the user select the genotype protocols to use
+ * Update the contents of the marker column in the results table
+ * for the currently displayed rows of results
  */
-function setupMarkerSearch() {
-    jQuery('#sequence_metadata_genotype_protocol_dialog').modal('show');
-    return false;
+function updateMarkers() {
+    let containers = jQuery('.sequence_metadata_marker_search_markers');
+    for ( let i = 0; i < containers.length; i++ ) {
+        let container = jQuery(containers[i]);
+        let feature_id = container.data("feature-id");
+        let start = container.data("start");
+        let end = container.data("end");
+        let key = [feature_id, start, end].join("-");
+        if ( markers && markers[key] ) {
+            displayMarkers(key);
+        }
+        else {
+            let nd_protocol_id = container.data("nd-protocol-id");
+            getMarkers(nd_protocol_id, feature_id, start, end);
+        }
+    }
+
 }
 
-
 /**
- * Update the list of genotype protocols selected by the user
+ * Get markers matching the specified sequence metadata
+ * - Query the DB for matching markers
+ * - Update the display of the markers
+ * @param {int} nd_protocol_id ID of the sequence metadata protocol
+ * @param {int} feature_id ID of the sequence metadata's associated feature
+ * @param {int} start Start position of the sequence metadata
+ * @praam {int} end End position of the sequence metadata
  */
-function updateMarkerSearchGenotypeProtocols() {
-    genotype_protocols_selected = jQuery("#sequence_metadata_filter_genoproto").val();
-    markers = undefined;
-    updateMarkerColumn();
-    jQuery('#sequence_metadata_genotype_protocol_dialog').modal('hide');
-}
-
-
-/**
- * Perform a marker search on the selected row's feature and sequence range, 
- * optionally filtered by the user's selected genotype protocols
- */
-function startMarkerSearch() {
-    let parent = jQuery(this).parents(".sequence_metadata_marker_search_markers");
-    let feature_id = parent.data("feature-id");
-    let start = parent.data("start");
-    let end = parent.data("end");
+function getMarkers(nd_protocol_id, feature_id, start, end) {
     let key = [feature_id, start, end].join("-");
 
-    // Update the DataTables
+    // Display searching
     if ( !markers ) markers = {};
     markers[key] = "Searching...";
-    updateMarkerColumn();
+    displayMarkers(key);
 
     // Query the Database for Markers
     jQuery.ajax({
         type: 'GET',
         url: '/ajax/sequence_metadata/markers',
         data: {
+            nd_protocol_id: nd_protocol_id,
             feature_id: feature_id,
             start: start,
-            end: end,
-            nd_protocol_id: genotype_protocols_selected ? genotype_protocols_selected.join(',') : undefined
+            end: end
         },
         dataType: 'json',
         success: function(data) {
 
             // Save the markers and update the DataTables
             if ( data && data.results ) {
+                if ( !markers ) markers = {};
                 markers[key] = data.results;
-                updateMarkerColumn();
+                displayMarkers(key);
             }
 
         },
@@ -1030,63 +989,31 @@ function startMarkerSearch() {
             alert("ERROR: Could not perform marker search");
         }
     });
-
-    return false;
 }
+
 
 /**
- * Update the contents of the marker column in the results table
+ * Display the marker info for the specified sequence metadata row
+ * @param {string} key Sequence Metadata results key (feature_id-start-end)
  */
-function updateMarkerColumn() {
-
-    // Update the markers (add search button or marker links)
-    // only if genotype protocol(s) has been selected
-    if ( genotype_protocols_selected ) {
-        jQuery('.sequence_metadata_marker_search_markers').each(function() {
-            let feature_id = jQuery(this).data("feature-id");
-            let start = jQuery(this).data("start");
-            let end = jQuery(this).data("end");
-            let key = [feature_id, start, end].join("-");
-            
-            let marker_html = "";
-            if ( markers && markers.hasOwnProperty(key) ) {
-                let value = markers[key];
-                if ( typeof value === 'string' ) {
-                    marker_html = "<p>" + value + "</p>";
-                }
-                else if ( Array.isArray(value) ) {
-                    if ( value.length === 0 ) {
-                        marker_html = "<p>No Markers Found</p>";
-                    }
-                    else {
-                        for ( let i = 0; i < value.length; i++ ) {
-                            marker_html += "<strong><a href='/markerGeno/" + value[i].marker_name + "/details'>" + value[i].marker_name + "</a></strong> "
-                            marker_html += "(<a href='/breeders_toolbox/protocol/" + value[i].nd_protocol_id + "'>" + value[i].nd_protocol_name + "</a>)<br />";
-                        }
-                        marker_html += "<br />";
-                    }
-                }
+function displayMarkers(key) {
+    let marker_info = markers[key];
+    let container = jQuery('.sequence_metadata_marker_search_markers_' + key);
+    if ( typeof marker_info === 'string' ) {
+        container.html('<p>' + marker_info + '</p>');
+    }
+    else if ( Array.isArray(marker_info) ) {
+        let html = [];
+        for ( let i = 0; i < marker_info.length; i++ ) {
+            let name = marker_info[i].marker_name;
+            let protocol = marker_info[i].nd_protocol_name;
+            if ( name !== '.' ) {
+                html.push("<a href='/markerGeno/" + name + "/details'><strong>" + name + "</strong> (" + protocol + ")</a>");
             }
-            else {
-                marker_html = "<p><a class='sequence_metadata_marker_search_button' href='#'>Search for Markers</a></p>";
-            }
-            jQuery('.sequence_metadata_marker_search_markers_' + key).html(marker_html);
-        });
+        }
+        container.html(html.join("<br />"));
     }
-
-    // Update the protocol buttons for all rows
-    let protocol_label = "";
-    if ( !genotype_protocols_selected ) {
-        protocol_label = "Select Genotype Protocols";
-    }
-    else {
-        protocol_label = "Update Genotype Protocols";
-    }
-    let protocol_html = "<a class='sequence_metadata_genotype_protocol_selection_button' href='#'>" + protocol_label + "</a>";
-    jQuery('.sequence_metadata_marker_search_protocols').html(protocol_html);
-
 }
-
 
 
 //
@@ -1100,12 +1027,11 @@ function updateMarkerColumn() {
  * @returns {String} The text/html to display in the table
  */
 function renderMarkersColumn(row, type) {
-    let data = "data-feature-id='" + row.feature_id + "' data-start='" + row.start + "' data-end='" + row.end + "'";
-    let key = row.feature_id + "-" + row.start + "-" + row.end;
+    let data = "data-feature-id='" + row.feature_id + "' data-start='" + row.start + "' data-end='" + row.end + "' data-nd-protocol-id='" + row.nd_protocol_id + "'";
+    let key = [row.feature_id, row.start, row.end].join("-");
     
     let html = "<div class='sequence_metadata_marker_search'>";
     html += "<div class='sequence_metadata_marker_search_markers sequence_metadata_marker_search_markers_" + key + "' " + data + "></div>";
-    html += "<div class='sequence_metadata_marker_search_protocols'></div>";
     html += "</div>";
 
     return html;

--- a/mason/tools/sequence_metadata/query_sequence_metadata.mas
+++ b/mason/tools/sequence_metadata/query_sequence_metadata.mas
@@ -74,90 +74,98 @@
                 <p>Loading...</p>
             </div>
         </div>
-        <br /><br />
 
-        <h4>Attributes</h4>
+        <br /><br /><br />
 
-        <!-- Score Min / Max -->
-        <div class="form-group">
-            <label class="col-sm-2 control-label">Score: </label>
-            <div class="col-sm-3">
-                <label class="control-label">Protocol</label><br />
-                <select class="form-control" id="sequence_metadata_filter_score_protocol" disabled>
-                    <option value="">Loading...</option>
-                </select>
-            </div>
-            <div class="col-sm-3">
-                <label class="control-label">Comparison</label><br />
-                <select class="form-control" id="sequence_metadata_filter_score_comparison">
-                    <option value="eq">Equal</option>
-                    <option value="lte">Less Than or Equal</option>
-                    <option value="lt">Less Than</option>
-                    <option value="gte">Greater Than or Equal</option>
-                    <option value="gt">Greater Than</option>
-                </select>
-            </div>
-            <div class="col-sm-3">
-                <label class="control-label">Value</label><br />
-                <input class="form-control" id="sequence_metadata_filter_score_value" type="text" value="">
-            </div>
-            <div class="col-sm-1">
-                <br />
-                <button id="sequence_metadata_filter_score_add" class="btn btn-info">Add</button>
-            </div>
-        </div>
-        <br /><br />
+        <&| /page/info_section.mas, title=>'Advanced Search', subtitle=>'Filter by attribute values', collapsible=>1, collapsed=>1 &>
 
-        <!-- Attribute Value -->
-        <div class="form-group">
-            <label class="col-sm-2 control-label">Attribute: </label>
-            <div class="col-sm-3">
-                <label class="control-label">Protocol</label><br />
-                <select class="form-control" id="sequence_metadata_filter_attribute_protocol" disabled>
-                    <option value="">Loading...</option>
-                </select>
-            </div>
-            <div class="col-sm-2">
-                <label class="control-label">Key</label><br />
-                <select class="form-control" id="sequence_metadata_filter_attribute_key" disabled>
-                    <option value="">Loading...</option>
-                </select>
-            </div>
-            <div class="col-sm-2">
-                <label class="control-label">Comparison</label><br />
-                <select class="form-control" id="sequence_metadata_filter_attribute_comparison">
-                    <option value="con">Contains</option>
-                    <option value="eq">Equal</option>
-                    <option value="lte">Less Than or Equal</option>
-                    <option value="lt">Less Than</option>
-                    <option value="gte">Greater Than or Equal</option>
-                    <option value="gt">Greater Than</option>
-                </select>
-            </div>
-            <div class="col-sm-2">
-                <label class="control-label">Value</label><br />
-                <input class="form-control" id="sequence_metadata_filter_attribute_value" type="text" value="">
-            </div>
-            <div class="col-sm-1">
-                <br />
-                <button id="sequence_metadata_filter_attribute_add" class="btn btn-info">Add</button>
-            </div>
-        </div>
-        <br />
+            <p>Return only sequence metadata features that have attribute values that match the added comparisons.  If more than one attribute 
+            filter is added, the sequence metadata feature must match all of the filters.</p>
 
-        <!-- Attribute Table -->
-        <div>
-            <p><strong>Attribute Filters:</strong></p>
-            <table id="sequence_metadata_filter_attributes_table" class="table table-striped table-hover">
-                <tr>
-                    <th>Protocol</th>
-                    <th>Attribute</th>
-                    <th>Comparison</th>
-                    <th>Value</th>
-                    <th></th>
-                </tr>
-            </table>
-        </div>
+            <br />
+
+            <!-- Score Min / Max -->
+            <div class="form-group">
+                <label class="col-sm-2 control-label">Score: </label>
+                <div class="col-sm-3">
+                    <label class="control-label">Protocol</label><br />
+                    <select class="form-control" id="sequence_metadata_filter_score_protocol" disabled>
+                        <option value="">Loading...</option>
+                    </select>
+                </div>
+                <div class="col-sm-3">
+                    <label class="control-label">Comparison</label><br />
+                    <select class="form-control" id="sequence_metadata_filter_score_comparison">
+                        <option value="eq">Equal</option>
+                        <option value="lte">Less Than or Equal</option>
+                        <option value="lt">Less Than</option>
+                        <option value="gte">Greater Than or Equal</option>
+                        <option value="gt">Greater Than</option>
+                    </select>
+                </div>
+                <div class="col-sm-3">
+                    <label class="control-label">Value</label><br />
+                    <input class="form-control" id="sequence_metadata_filter_score_value" type="text" value="">
+                </div>
+                <div class="col-sm-1">
+                    <br />
+                    <button id="sequence_metadata_filter_score_add" class="btn btn-info">Add</button>
+                </div>
+            </div>
+            <br /><br />
+
+            <!-- Attribute Value -->
+            <div class="form-group">
+                <label class="col-sm-2 control-label">Attribute: </label>
+                <div class="col-sm-3">
+                    <label class="control-label">Protocol</label><br />
+                    <select class="form-control" id="sequence_metadata_filter_attribute_protocol" disabled>
+                        <option value="">Loading...</option>
+                    </select>
+                </div>
+                <div class="col-sm-2">
+                    <label class="control-label">Key</label><br />
+                    <select class="form-control" id="sequence_metadata_filter_attribute_key" disabled>
+                        <option value="">Loading...</option>
+                    </select>
+                </div>
+                <div class="col-sm-2">
+                    <label class="control-label">Comparison</label><br />
+                    <select class="form-control" id="sequence_metadata_filter_attribute_comparison">
+                        <option value="con">Contains</option>
+                        <option value="eq">Equal</option>
+                        <option value="lte">Less Than or Equal</option>
+                        <option value="lt">Less Than</option>
+                        <option value="gte">Greater Than or Equal</option>
+                        <option value="gt">Greater Than</option>
+                    </select>
+                </div>
+                <div class="col-sm-2">
+                    <label class="control-label">Value</label><br />
+                    <input class="form-control" id="sequence_metadata_filter_attribute_value" type="text" value="">
+                </div>
+                <div class="col-sm-1">
+                    <br />
+                    <button id="sequence_metadata_filter_attribute_add" class="btn btn-info">Add</button>
+                </div>
+            </div>
+            <br />
+
+            <!-- Attribute Table -->
+            <div>
+                <p><strong>Attribute Filters:</strong></p>
+                <table id="sequence_metadata_filter_attributes_table" class="table table-striped table-hover">
+                    <tr>
+                        <th>Protocol</th>
+                        <th>Attribute</th>
+                        <th>Comparison</th>
+                        <th>Value</th>
+                        <th></th>
+                    </tr>
+                </table>
+            </div>
+
+        </&>
 
         <br /><br /><br />
         
@@ -202,6 +210,43 @@
 </div>
 
 
+<!-- MARKER SEARCH GENOTYPE PROTOCOL SELECTION -->
+<div class="modal fade" id="sequence_metadata_genotype_protocol_dialog" name="sequence_metadata_genotype_protocol_dialog" tabindex="-1" role="dialog" aria-labelledby="DeleteModelDataDialog">
+    <div class="modal-dialog " role="document">
+        <div class="modal-content">
+            <div class="modal-header" style="text-align: center">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="DeleteModelDataDialog">Select Genotype Protocol(s)</h4>
+            </div>
+            <div class="modal-body">
+                <div class="container-fluid">
+                    <h4>Marker Search</h4>
+
+                    <p>You can search for markers located within the range of a sequence metadata feature. Here you can choose which genotype protocols to 
+                    include in that search.  NOTE: Including more genotype protocols increases the amount of time to perform the marker search.</p>
+
+                    <br />
+
+                    <!-- Genotype Protocols -->
+                    <div class="form-group">
+                        <label class="col-sm-2 control-label">Genotype Protocol(s): </label>
+                        <div class="col-sm-10">
+                            <select class="form-control" id="sequence_metadata_filter_genoproto" size="10" multiple disabled>
+                                <option value="">Loading...</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="close_delete_model_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" name="sequence_metadata_genotype_protocol_dialog_update" id="sequence_metadata_genotype_protocol_dialog_update">Set Genotype Protocol(s)</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+
 
 <!-- JBROWSE CONFIGURATION -->
 <!-- OVERWRITE THIS FILE IN THE INSTANCE-SPECIFIC MASON REPO TO CONFIGURE -->
@@ -210,10 +255,13 @@
 
 <script type="text/javascript">
 
-var features = [];
-var data_types = [];
-var protocols = [];
-var attribute_filter_count = 0;
+var features = [];                          // List of sequence metadata features fetched from the database
+var data_types = [];                        // List of sequence metadata data types fetched from the database
+var protocols = [];                         // List of existing sequence metadata protocols fetched from the database
+var attribute_filter_count = 0;             // Current count of attribute filters added by user
+var genotype_protocols = [];                // List of genotype protocols fetched from the database
+var genotype_protocols_selected;            // List of user selected genotype protocols for the marker search
+var markers = {};                           // Object of queried markers from the database for specific ranges
 
 jQuery(document).ready(function() {
 
@@ -221,6 +269,12 @@ jQuery(document).ready(function() {
     get_features();
     get_types();
     get_protocols();
+    get_genotype_protocols();
+
+
+    //
+    // CLICK AND CHANGE LISTENERS
+    //
 
     // Toggle info boxes
     jQuery('#sequence_metadata_filter_type_info_btn').click(function() {
@@ -248,6 +302,16 @@ jQuery(document).ready(function() {
 
     // Return to Query
     jQuery('#sequence_metadata_filter_return').click(toggle_sections);
+
+    // Setup/Start Marker Search
+    jQuery('#sequence_metadata_filter_results').on('click', '.sequence_metadata_genotype_protocol_selection_button', setupMarkerSearch);
+    jQuery('#sequence_metadata_genotype_protocol_dialog_update').click(updateMarkerSearchGenotypeProtocols);
+    jQuery('#sequence_metadata_filter_results').on('click', '.sequence_metadata_marker_search_button', startMarkerSearch);
+
+
+    //
+    // DATATABLES SETUP
+    //
 
     // Set DataTables Buttons
     let DT_BUTTONS = [
@@ -299,41 +363,23 @@ jQuery(document).ready(function() {
         autoWidth: false,
         data: [],
         columns: [
-            { title: "Type", data: "type_name" },
             { title: "Protocol", data: "nd_protocol_name" },
             { title: "Feature", data: "feature_name" },
             { title: "Start", data: "start" },
             { title: "End", data: "end" },
+            { title: "Markers", data: renderMarkersColumn },
             { title: "Score", data: "score" },
-            { 
-                title: "Attributes", 
-                data: "attributes", 
-                render: function(data, type, row) {
-                    let rtn = [];
-                    let sep = type === 'export' ? ';' : '<br />';
-                    if ( data ) {
-                        var keys = Object.keys(data);
-                        keys.sort();
-                        for ( var i=0; i<keys.length; ++i ) {
-                            let key = keys[i];
-                            let value = data[keys[i]];
-                            if ( type === 'export' ) {
-                                rtn.push(key + '=' + value);
-                            }
-                            else {
-                                rtn.push("<strong>" + key + ":</strong>&nbsp;" + value);
-                            }
-                        }
-                    }
-                    return rtn.join(sep);
-                } 
-            }
+            { title: "Attributes", data: "attributes", render: renderAttributesColumn }
         ],
         buttons: DT_BUTTONS
     });
 
 });
 
+
+//
+// DATABASE QUERIES AND RESPONSE HANDLERS
+//
 
 /**
  * Get the features associated with stored sequence metadata
@@ -555,6 +601,65 @@ function set_protocols() {
 
 
 /**
+ * Get the genotype protocols from the database
+ * - populate the options for the genotype protocol select box
+ */
+function get_genotype_protocols() {
+    jQuery.ajax({
+        type: 'GET',
+        dataType: 'json',
+        url: '/ajax/sequence_metadata/genotype_protocols',
+        success: function(data) {
+            if ( data && data.genotype_protocols ) {
+                data.genotype_protocols.sort((a, b) => (a.protocol_name > b.protocol_name) ? 1 : -1)
+                genotype_protocols = data.genotype_protocols;
+                set_genotype_protocols();
+            }
+        },
+        error: function() {
+            alert("ERROR: Could not load genotype protocols");
+        }
+    });
+}
+
+/**
+ * Set the options for the genotype protocols select box
+ */
+function set_genotype_protocols() {
+    let options = "";
+
+    // Parse the genotype protocols into options
+    let parsed = {};
+    for ( let i = 0; i < genotype_protocols.length; i++ ) {
+        let id = genotype_protocols[i].protocol_id;
+        let name = genotype_protocols[i].protocol_name;
+        let species = genotype_protocols[i].species_name;
+        let markers = genotype_protocols[i].marker_count;
+        if ( !parsed.hasOwnProperty(species) ) {
+            parsed[species] = [];
+        }
+        let text = name + " (" + markers + " markers)";
+        let option = "<option value='" + id + "'>" + text + "</option>";
+        parsed[species].push(option);
+    }
+
+    // Group the options by species
+    for (let species in parsed) {
+        if ( parsed.hasOwnProperty(species) ) {
+            options += "<optgroup label='" + species + "'>";
+            let items = parsed[species];
+            for ( let i = 0; i < items.length; i++ ) {
+                options += items[i];
+            }
+            options += "</optgroup>";
+        }
+    }
+
+    jQuery("#sequence_metadata_filter_genoproto").html(options);
+    jQuery("#sequence_metadata_filter_genoproto").prop('disabled', false);
+}
+
+/**
  * Set the protocol lists for the score and attribute select menus
  */
 function set_attribute_protocols() {
@@ -656,6 +761,12 @@ function add_attribute_filter(type) {
         });
     }
 }
+
+
+
+//
+// QUERY FUNCTIONS
+//
 
 
 /**
@@ -840,6 +951,155 @@ function getJBrowseURL(config) {
 }
 
 
+
+//
+// MARKER SEARCH FUNCTIONS
+//
+
+
+/**
+ * Setup the marker search by having the user select the genotype protocols to use
+ */
+function setupMarkerSearch() {
+    jQuery('#sequence_metadata_genotype_protocol_dialog').modal('show');
+    return false;
+}
+
+
+/**
+ * Update the list of genotype protocols selected by the user
+ */
+function updateMarkerSearchGenotypeProtocols() {
+    genotype_protocols_selected = jQuery("#sequence_metadata_filter_genoproto").val();
+    markers = {};
+    refreshDataTables();
+    jQuery('#sequence_metadata_genotype_protocol_dialog').modal('hide');
+}
+
+
+/**
+ * Perform a marker search on the selected row's feature and sequence range, 
+ * optionally filtered by the user's selected genotype protocols
+ */
+function startMarkerSearch() {
+    let feature_id = jQuery(this).data("feature-id");
+    let start = jQuery(this).data("start");
+    let end = jQuery(this).data("end");
+    let key = feature_id + "-" + start + "-" + end;
+
+    // Update the DataTables
+    markers[key] = "Searching...";
+    refreshDataTables();
+
+    // Query the Database for Markers
+    jQuery.ajax({
+        type: 'GET',
+        url: '/ajax/sequence_metadata/markers',
+        data: {
+            feature_id: feature_id,
+            start: start,
+            end: end,
+            nd_protocol_id: genotype_protocols_selected ? genotype_protocols_selected.join(',') : undefined
+        },
+        dataType: 'json',
+        success: function(data) {
+
+            // Save the markers and update the DataTables
+            if ( data && data.results ) {
+                markers[key] = data.results;
+                refreshDataTables();
+            }
+
+        },
+        error: function() {
+            alert("ERROR: Could not perform marker search");
+        }
+    });
+
+    return false;
+}
+
+
+
+//
+// DATA TABLE RENDER FUNCTIONS
+//
+
+/**
+ * Render the Markers column
+ * @param {Object} row The current row's data
+ * @param {String} type The display type
+ * @returns {String} The text/html to display in the table
+ */
+function renderMarkersColumn(row, type) {
+    let data = "data-feature-id='" + row.feature_id + "' data-start='" + row.start + "' data-end='" + row.end + "'";
+    let key = row.feature_id + "-" + row.start + "-" + row.end;
+    let html = "";
+    
+    if ( !genotype_protocols_selected ) {
+        html = "<a class='sequence_metadata_genotype_protocol_selection_button' href='#'>Select Genotype Protocols</a>";
+    }
+    else if ( markers.hasOwnProperty(key) ) {
+        let value = markers[key];
+        if ( typeof value === 'string' ) {
+            html = "<p>" + value + "</p><br />";
+        }
+        else if ( Array.isArray(value) ) {
+            if ( value.length === 0 ) {
+                html = "<p>No Markers Found</p>";
+            }
+            else {
+                for ( let i = 0; i < value.length; i++ ) {
+                    html += "<strong><a href='/markerGeno/" + value[i].marker_name + "/details'>" + value[i].marker_name + "</a></strong> "
+                    html += "(<a href='/breeders_toolbox/protocol/" + value[i].nd_protocol_id + "'>" + value[i].nd_protocol_name + "</a>)<br />";
+                }
+                html += "<br />";
+            }
+        }
+        html +="<a class='sequence_metadata_genotype_protocol_selection_button' href='#'>Update Genotype Protocols</a>";
+    }
+    else {
+        html = "<a class='sequence_metadata_marker_search_button' " + data + " href='#'>Search for Markers</a><br /><br />";
+        html +="<a class='sequence_metadata_genotype_protocol_selection_button' href='#'>Update Genotype Protocols</a>";
+    }
+    
+    return html;
+}
+
+/**
+ * Render the Attributes column
+ * @param data The column's data for the current row
+ * @param {String} type The display type
+ * @param {Object} row The current row's data
+ * @returns {String} The text/html to display in the table
+ */
+function renderAttributesColumn(data, type, row) {
+    let rtn = [];
+    let sep = type === 'export' ? ';' : '<br />';
+    if ( data ) {
+        var keys = Object.keys(data);
+        keys.sort();
+        for ( var i=0; i<keys.length; ++i ) {
+            let key = keys[i];
+            let value = data[keys[i]];
+            if ( type === 'export' ) {
+                rtn.push(key + '=' + value);
+            }
+            else {
+                rtn.push("<strong>" + key + ":</strong>&nbsp;" + value);
+            }
+        }
+    }
+    return rtn.join(sep);
+} 
+
+
+
+//
+// HELPER FUNCTIONS
+//
+
+
 /**
  * Toggle the display of the query and results sections
  */
@@ -878,6 +1138,17 @@ function download(url, name) {
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
+}
+
+/**
+ * Refresh the display of the DataTables displaying the filter results
+ */
+function refreshDataTables() {
+    let dt = jQuery('#sequence_metadata_filter_results').DataTable();
+    let d = dt.rows().data();
+    dt.clear();
+    dt.rows.add(d);
+    dt.draw(false);
 }
 
 </script>

--- a/mason/tools/sequence_metadata/query_sequence_metadata.mas
+++ b/mason/tools/sequence_metadata/query_sequence_metadata.mas
@@ -261,7 +261,7 @@ var protocols = [];                         // List of existing sequence metadat
 var attribute_filter_count = 0;             // Current count of attribute filters added by user
 var genotype_protocols = [];                // List of genotype protocols fetched from the database
 var genotype_protocols_selected;            // List of user selected genotype protocols for the marker search
-var markers = {};                           // Object of queried markers from the database for specific ranges
+var markers;                                // Object of queried markers from the database for specific ranges
 
 jQuery(document).ready(function() {
 
@@ -372,6 +372,11 @@ jQuery(document).ready(function() {
             { title: "Attributes", data: "attributes", render: renderAttributesColumn }
         ],
         buttons: DT_BUTTONS
+    });
+
+    // Update the Marker Search display when the table is redrawn (on page change, etc...)
+    jQuery('#sequence_metadata_filter_results').DataTable().on('draw.dt', function() {
+        updateMarkerColumn();
     });
 
 });
@@ -846,6 +851,8 @@ function query() {
  *                 response.results array of sequence metadata objects
  */
 function handle_query_results(response) {
+
+    // Update DataTable
     let dt = jQuery('#sequence_metadata_filter_results').DataTable();
     dt.clear();
     if ( response && response.error ) {
@@ -860,8 +867,14 @@ function handle_query_results(response) {
     }
     dt.draw();
 
+    // Reset Markers
+    markers = undefined;
+    updateMarkerColumn();
+
+    // Reset Query Button
     jQuery('#sequence_metadata_filter_query').html('Query');
     jQuery('#sequence_metadata_filter_query').attr('disabled', false);
+
 }
 
 
@@ -971,8 +984,8 @@ function setupMarkerSearch() {
  */
 function updateMarkerSearchGenotypeProtocols() {
     genotype_protocols_selected = jQuery("#sequence_metadata_filter_genoproto").val();
-    markers = {};
-    refreshDataTables();
+    markers = undefined;
+    updateMarkerColumn();
     jQuery('#sequence_metadata_genotype_protocol_dialog').modal('hide');
 }
 
@@ -982,14 +995,16 @@ function updateMarkerSearchGenotypeProtocols() {
  * optionally filtered by the user's selected genotype protocols
  */
 function startMarkerSearch() {
-    let feature_id = jQuery(this).data("feature-id");
-    let start = jQuery(this).data("start");
-    let end = jQuery(this).data("end");
-    let key = feature_id + "-" + start + "-" + end;
+    let parent = jQuery(this).parents(".sequence_metadata_marker_search_markers");
+    let feature_id = parent.data("feature-id");
+    let start = parent.data("start");
+    let end = parent.data("end");
+    let key = [feature_id, start, end].join("-");
 
     // Update the DataTables
+    if ( !markers ) markers = {};
     markers[key] = "Searching...";
-    refreshDataTables();
+    updateMarkerColumn();
 
     // Query the Database for Markers
     jQuery.ajax({
@@ -1007,7 +1022,7 @@ function startMarkerSearch() {
             // Save the markers and update the DataTables
             if ( data && data.results ) {
                 markers[key] = data.results;
-                refreshDataTables();
+                updateMarkerColumn();
             }
 
         },
@@ -1017,6 +1032,59 @@ function startMarkerSearch() {
     });
 
     return false;
+}
+
+/**
+ * Update the contents of the marker column in the results table
+ */
+function updateMarkerColumn() {
+
+    // Update the markers (add search button or marker links)
+    // only if genotype protocol(s) has been selected
+    if ( genotype_protocols_selected ) {
+        jQuery('.sequence_metadata_marker_search_markers').each(function() {
+            let feature_id = jQuery(this).data("feature-id");
+            let start = jQuery(this).data("start");
+            let end = jQuery(this).data("end");
+            let key = [feature_id, start, end].join("-");
+            
+            let marker_html = "";
+            if ( markers && markers.hasOwnProperty(key) ) {
+                let value = markers[key];
+                if ( typeof value === 'string' ) {
+                    marker_html = "<p>" + value + "</p>";
+                }
+                else if ( Array.isArray(value) ) {
+                    if ( value.length === 0 ) {
+                        marker_html = "<p>No Markers Found</p>";
+                    }
+                    else {
+                        for ( let i = 0; i < value.length; i++ ) {
+                            marker_html += "<strong><a href='/markerGeno/" + value[i].marker_name + "/details'>" + value[i].marker_name + "</a></strong> "
+                            marker_html += "(<a href='/breeders_toolbox/protocol/" + value[i].nd_protocol_id + "'>" + value[i].nd_protocol_name + "</a>)<br />";
+                        }
+                        marker_html += "<br />";
+                    }
+                }
+            }
+            else {
+                marker_html = "<p><a class='sequence_metadata_marker_search_button' href='#'>Search for Markers</a></p>";
+            }
+            jQuery('.sequence_metadata_marker_search_markers_' + key).html(marker_html);
+        });
+    }
+
+    // Update the protocol buttons for all rows
+    let protocol_label = "";
+    if ( !genotype_protocols_selected ) {
+        protocol_label = "Select Genotype Protocols";
+    }
+    else {
+        protocol_label = "Update Genotype Protocols";
+    }
+    let protocol_html = "<a class='sequence_metadata_genotype_protocol_selection_button' href='#'>" + protocol_label + "</a>";
+    jQuery('.sequence_metadata_marker_search_protocols').html(protocol_html);
+
 }
 
 
@@ -1034,35 +1102,12 @@ function startMarkerSearch() {
 function renderMarkersColumn(row, type) {
     let data = "data-feature-id='" + row.feature_id + "' data-start='" + row.start + "' data-end='" + row.end + "'";
     let key = row.feature_id + "-" + row.start + "-" + row.end;
-    let html = "";
     
-    if ( !genotype_protocols_selected ) {
-        html = "<a class='sequence_metadata_genotype_protocol_selection_button' href='#'>Select Genotype Protocols</a>";
-    }
-    else if ( markers.hasOwnProperty(key) ) {
-        let value = markers[key];
-        if ( typeof value === 'string' ) {
-            html = "<p>" + value + "</p><br />";
-        }
-        else if ( Array.isArray(value) ) {
-            if ( value.length === 0 ) {
-                html = "<p>No Markers Found</p>";
-            }
-            else {
-                for ( let i = 0; i < value.length; i++ ) {
-                    html += "<strong><a href='/markerGeno/" + value[i].marker_name + "/details'>" + value[i].marker_name + "</a></strong> "
-                    html += "(<a href='/breeders_toolbox/protocol/" + value[i].nd_protocol_id + "'>" + value[i].nd_protocol_name + "</a>)<br />";
-                }
-                html += "<br />";
-            }
-        }
-        html +="<a class='sequence_metadata_genotype_protocol_selection_button' href='#'>Update Genotype Protocols</a>";
-    }
-    else {
-        html = "<a class='sequence_metadata_marker_search_button' " + data + " href='#'>Search for Markers</a><br /><br />";
-        html +="<a class='sequence_metadata_genotype_protocol_selection_button' href='#'>Update Genotype Protocols</a>";
-    }
-    
+    let html = "<div class='sequence_metadata_marker_search'>";
+    html += "<div class='sequence_metadata_marker_search_markers sequence_metadata_marker_search_markers_" + key + "' " + data + "></div>";
+    html += "<div class='sequence_metadata_marker_search_protocols'></div>";
+    html += "</div>";
+
     return html;
 }
 
@@ -1138,17 +1183,6 @@ function download(url, name) {
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
-}
-
-/**
- * Refresh the display of the DataTables displaying the filter results
- */
-function refreshDataTables() {
-    let dt = jQuery('#sequence_metadata_filter_results').DataTable();
-    let d = dt.rows().data();
-    dt.clear();
-    dt.rows.add(d);
-    dt.draw(false);
 }
 
 </script>

--- a/mason/tools/sequence_metadata/upload_sequence_metadata_workflow.mas
+++ b/mason/tools/sequence_metadata/upload_sequence_metadata_workflow.mas
@@ -361,7 +361,7 @@ function complete_data_type_step() {
           let rg_name = data.reference_genomes[i].reference_genome;
           let sp_name = data.reference_genomes[i].species_name;
           let rg_label = rg_name + " (" + sp_name + ")";
-          options += "<option value='" + rg_name + "'>" + rg_label + "</option>";
+          options += "<option value='" + rg_name + "' data-species='" + sp_name + "'>" + rg_label + "</option>";
         }
         jQuery('#sequence_metadata_upload_protocol_reference_genome').html(options);
         jQuery('#sequence_metadata_upload_protocol_reference_genome').prop('disabled', false);
@@ -583,6 +583,7 @@ function store() {
     formData.append('new_protocol_description', new_protocol_description);
     formData.append('new_protocol_sequence_metadata_type', jQuery('#sequence_metadata_upload_type_select option:selected').val());
     formData.append('new_protocol_reference_genome', jQuery('#sequence_metadata_upload_protocol_reference_genome option:selected').val());
+    formData.append('new_protocol_species', jQuery('#sequence_metadata_upload_protocol_reference_genome option:selected').attr('data-species'));
     formData.append('new_protocol_score_description', jQuery('#sequence_metadata_upload_score_description').val());
     formData.append('new_protocol_attribute_count', new_attribute_count);
     for ( let i = 1; i <= new_attribute_count; i++ ) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR adds the ability to use the Search Wizard as a guided/step-by-step workflow for creating a new dataset with specific parameters/dimensions set.  The idea is to use this with the various analysis tools that can use datasets as an input to to the tool and help users that may not know what a dataset is, how to create one, or what dimensions are required in the dataset for the tool to work.

![Screen Shot 2021-04-09 at 10 17 52 AM](https://user-images.githubusercontent.com/7526014/114193861-ed0b3200-991c-11eb-86b7-0c2521584f7a.png)

To enable the workflow, add two query parameters to the existing Search Wizard path (`/breeders/search/`):
- `dsp`: dataset parameters
    - a comma separated list of data set parameters for each column
    - multiple types for a single column can be separated by a |
    - multiple sets of parameters can be provided by including additional dsp query parameters
    - Examples:
        - `dsp=trials,accessions` -- require trials as the first parameter and accessions as the second parameter
        - `dsp=trials|traits,accessions` -- require trials or traits as the first parameter and accessions as the second parameter
        - `dsp=trials,accessions&dsp=accessions,trials` -- require trials as the first and accessions as the second parameters OR accessions as the first and trials as the second parameters
- `dsr`: dataset return URL
    - Example: `dsr=/solgs/search`

Fixes #3301 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
