### PR TITLE
Topic/dataset creation pipeline

### DIFF
--- a/js/source/entries/wizard.js
+++ b/js/source/entries/wizard.js
@@ -144,11 +144,11 @@ export function WizardSetup(main_id){
       if(private_lists.error) private_lists = [];
       resolve(private_lists.concat(public_lists))
     })).then(lists=>lists.reduce((acc,cur)=>{
-        acc[cur[0]] = cur[1];
+        acc[cur[0]] = { name: cur[1], type: cur[5] }
         return acc;
       },{}
     )).then(listdict=>{
-      // Dictionary of {"listID":"listName"} pairs, sets or resets lists show in dropdowns
+      // Dictionary of {"listID":{name:"listName",type:"typeName"}} pairs, sets or resets lists show in dropdowns
       wiz.lists(listdict)
     });
     

--- a/js/source/modules/wizard-datasets.js
+++ b/js/source/modules/wizard-datasets.js
@@ -126,6 +126,9 @@ export function WizardDatasets(main_id,wizard){
         alert(`Dataset ${name} created with\: ${details}`);
         load_datasets();
         d3.select(this).attr("disabled",null);
+        if ( DSP_ENABLED ) {
+          returnToSource();
+        }
       })
     }
   });

--- a/js/source/modules/wizard-search.js
+++ b/js/source/modules/wizard-search.js
@@ -489,12 +489,13 @@ export function Wizard(main_id,col_number){
 
   function set_lists(list_dict){
     list_dict = list_dict || {};
-    var lists = Object.keys(list_dict).map(k=>({id:k,name:list_dict[k]}));
+    var lists = Object.keys(list_dict).map(k=>({id:k,name:list_dict[k].name,type:list_dict[k].type}));
     lists = lists.sort((a,b)=>a.name.toLowerCase() < b.name.toLowerCase() ? -1 : b.name.toLowerCase() < a.name.toLowerCase() ? 1 : 0);
     var opts = allCols.selectAll(".wizard-lists-group").selectAll("option")
       .data(lists);
     opts.enter().append("option").merge(opts)
       .attr("value",d=>list_prefix+d.id)
+      .attr("data-type",d=>d.type)
       .text(d=>d.name);
   }
 

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -6,6 +6,8 @@ $dataset_id => undef
 <& /util/import_javascript.mas, entries => ["wizard"] &>
 <& /util/import_css.mas, paths => ['wizard.css'] &>
 
+<& /breeders_toolbox/breeder_search_page_dataset_overlay.mas &>
+
 <& /page/page_title.mas, title=>"Search Wizard" &>
 
 <div class="row">

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -6,8 +6,6 @@ $dataset_id => undef
 <& /util/import_javascript.mas, entries => ["wizard"] &>
 <& /util/import_css.mas, paths => ['wizard.css'] &>
 
-<& /breeders_toolbox/breeder_search_page_dataset_overlay.mas &>
-
 <& /page/page_title.mas, title=>"Search Wizard" &>
 
 <div class="row">
@@ -16,6 +14,8 @@ $dataset_id => undef
     <button id="update_wizard_show" class="btn btn-default">Update Wizard</button>
   </div>
 </div>
+
+<& /breeders_toolbox/breeder_search_page_dataset_overlay.mas &>
 
 <div id="wizard" class="row">
   <span class="wizard-main">

--- a/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
+++ b/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
@@ -23,6 +23,7 @@
     <div id="dsp-help-container">
         <p id="dsp-help-instructions"></p>
         <button id="dsp-help-next" class='btn btn-primary'><span id="dsp-help-next-label">Next</span>&nbsp;<span class="glyphicon glyphicon-chevron-right"></span></button>
+        <a id="dsp-help-cancel" href="#"><span class='glyphicon glyphicon-remove'></span></a>
     </div>
 </div>
 
@@ -46,6 +47,9 @@
 
                 // Add event listener for the selected items lists
                 jQuery('.wizard-list-selected').on('DOMSubtreeModified', selectionListener)
+
+                // Add cancel button listener
+                jQuery('#dsp-help-cancel').click(disableDatasetPipeline);
 
             }
             else {
@@ -237,6 +241,22 @@
             jQuery("#dsp-help-next").prop('disabled', true);
         }
     }
+
+    /**
+     * Disable the dataset creation pipeline and restore the normal search wizard
+     */
+    function disableDatasetPipeline() {
+        var r = confirm("Are you sure you want to close the dataset creation help?");
+        if ( r == true ) {
+            DSP_ENABLED = false;
+            jQuery("#dsp-help").css('display', 'none');
+            jQuery('.wizard-panel').removeClass('wizard-panel-selected');
+            jQuery('.wizard-datasets > .panel').removeClass('wizard-panel-selected');
+            jQuery('.wizard-type-select').prop('disabled', false);
+            jQuery('.wizard-type-select option').prop('disabled', false);
+        }
+        return false;
+    }
 </script>
 
 <style>
@@ -246,7 +266,7 @@
     #dsp-help-container {
         display: flex;
         align-items: center;
-        margin: 15px 0;
+        margin: 5px 0 15px 0;
         width: 100%;
         min-height: 50px;
         background-color: #ffc107;
@@ -262,6 +282,14 @@
     #dsp-help-next {
         height: 40px;
         margin: 5px;
+    }
+    #dsp-help-cancel {
+        margin: 10px;
+        color: #000;
+        opacity: 70%;
+    }
+    #dsp-help-cancel:hover {
+        opacity: 85%;
     }
     
     .wizard-panel-selected {

--- a/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
+++ b/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
@@ -15,64 +15,26 @@
             ?dsp=trials|traits,accessions -- require trials or traits as the first parameter and accessions as the second parameter
             ?dsp=trials,accessions&dsp=accessions,trials -- require trials as the first and accessions as the second parameters 
                                                               OR accessions as the first and trials as the second parameters
-
+    dsr: dataset return URL
+        Example: &dsr=/solgs/search
 -->
-
-<style>
-    #dsp-help {
-        display: none;
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        height: 50px;
-        background-color: #5bc0de;
-        z-index: 99999;
-    }
-    #dsp-help-instructions {
-        padding: 0 15px;
-        margin: 0;
-        position: absolute;
-        top: 50%;
-        -ms-transform: translateY(-50%);
-        transform: translateY(-50%);
-        color: #fff;
-    }
-    #dsp-help-next {
-        float: right;
-        height: 40px;
-        margin: 5px;
-    }
-    
-    .wizard-panel-selected {
-        border: 5px solid #5bc0de;
-    }
-    
-    .wizard-type-select option {
-        color: #000;
-        font-weight: 500;
-    }
-    .wizard-type-select option:disabled {
-        color: #999;
-        font-weight: 100;
-        font-style: italic;
-    }
-</style>
 
 <div id="dsp-help">
     <p id="dsp-help-instructions"></p>
-    <button id="dsp-help-next" class='btn btn-success'>Next&nbsp;<span class="glyphicon glyphicon-chevron-right"></span></button>
+    <button id="dsp-help-next" class='btn btn-primary'><span id="dsp-help-next-label">Next</span>&nbsp;<span class="glyphicon glyphicon-chevron-right"></span></button>
 </div>
 
 <script type='text/javascript'>
 
     let DSP_ENABLED = false;    // Flag to enable the dataset creation pipeline
     let DSP_COLS = [];          // Allowed dataset column types
+    let DSP_RETURN;             // Return URL for dataset creation
 
     jQuery(document).ready(function() {
 
         parseArgs();
         if ( DSP_ENABLED ) {
+            jQuery('.wizard-type-select').prop('disabled', true);
             setCol(0);
         }
 
@@ -85,6 +47,7 @@
      * - Set DSP_COLS -- the allowed column type selections
      */
     function parseArgs() {
+        console.log("==> PARSE ARGS");
 
         // Parse query params and get 'dsp' parameter(s)
         let urlParams = new URLSearchParams(window.location.search);
@@ -112,6 +75,8 @@
 
             }
 
+            // Set Return URL
+            DSP_RETURN = urlParams.get("dsr");
         }
 
         console.log("DSP_COLS:");
@@ -119,6 +84,10 @@
     }
 
 
+    /**
+     * Setup the selections and instructions for selecting items from the specified column
+     * @param {int} col Column indx
+     */
     function setCol(col) {
         console.log("==> SET COLUMN #" + col);
         
@@ -127,7 +96,7 @@
         for ( let i = 0; i < col; i++ ) {
             prev_sel_col_types.push(jQuery('.wizard-type-select')[i].value);
         }
-        console.log("SELECTIONS");
+        console.log("PREV SELECTIONS");
         console.log(prev_sel_col_types);
         
         // Get items from DSP_COLS that match selected data types in previous columns
@@ -149,41 +118,138 @@
         // Get valid data types for the current column, from the list of valid_dsp_cols
         let valid_col_types = [];
         for ( let i = 0; i < valid_dsp_cols.length; i++ ) {
-            for ( let j = 0; j < valid_dsp_cols[i][col].length; j++ ) {
-                let t = valid_dsp_cols[i][col][j];
-                if ( !valid_col_types.includes(t) ) {
-                    valid_col_types.push(t);
+            if ( valid_dsp_cols[i][col] ) {
+                for ( let j = 0; j < valid_dsp_cols[i][col].length; j++ ) {
+                    let t = valid_dsp_cols[i][col][j];
+                    if ( !valid_col_types.includes(t) ) {
+                        valid_col_types.push(t);
+                    }
                 }
             }
         }
         console.log("VALID COL TYPES:");
         console.log(valid_col_types);
 
-        // Disable invalid selection options for the current column
-        jQuery(jQuery('.wizard-type-select')[col]).find('option').each(function () {
-            let enabled = valid_col_types.includes(this.value) || valid_col_types.includes(jQuery(this).attr('data-type'));
-            jQuery(this).attr('disabled', !enabled);
-        });
+        // Update column with valid column types
+        if ( valid_col_types && valid_col_types.length > 0 ) {
+            
+            // Enable the column
+            jQuery(jQuery('.wizard-type-select')[col]).prop('disabled', false);
 
-        // Display the instructions
-        showHelpCol(col, valid_col_types);
+            // Disable invalid selection options for the current column
+            jQuery(jQuery('.wizard-type-select')[col]).find('option').each(function () {
+                let enabled = valid_col_types.includes(this.value) || valid_col_types.includes(jQuery(this).attr('data-type'));
+                jQuery(this).attr('disabled', !enabled);
+            });
+
+            // Highlight Column
+            jQuery('.wizard-panel').removeClass('wizard-panel-selected');
+            jQuery(jQuery('.wizard-panel')[col]).addClass('wizard-panel-selected');
+
+            // Update Instructions
+            let step = col+1;
+            let html = "<strong>Step " + step + ":</strong> Choose items of type <strong>" + valid_col_types.join(" or ") + "</strong> from column " + step + ".";
+            jQuery('#dsp-help-instructions').html(html);
+            jQuery('#dsp-help-next-label').html("Next");
+            jQuery('#dsp-help-next').css('display', 'block');
+            jQuery('#dsp-help-next').click(function() {
+                setCol(col+1);
+            });
+            jQuery('#dsp-help').css('display', 'block');
+
+        }
+
+        // Move on to saving...
+        else {
+            saveDataset(col+1);
+        }
     }
-
 
     /**
-     * Display help instructions for selecting items from a column
-     * @param {int} col Column index to select
-     * @param {String[]} types List of valid types for the column
+     * Prompt the user to save a new dataset
      */
-    function showHelpCol(col, types) {
-        let step = col+1;
-        let html = "<strong>Step " + step + ":</strong> Choose items of type " + types.join(" or ") + " from column " + step + ".";
-        jQuery('#dsp-help-instructions').html(html);
-        jQuery('#dsp-help').css('display', 'block');
+    function saveDataset(step) {
+
+        // Scroll to Datasets
+        let anchor = jQuery('.wizard-datasets');
+        jQuery('html,body').animate({scrollTop: anchor.offset().top}, 'fast');
+
+        // Highlight Panel
         jQuery('.wizard-panel').removeClass('wizard-panel-selected');
-        jQuery(jQuery('.wizard-panel')[col]).addClass('wizard-panel-selected');
-        jQuery('#dsp-help-next').click(function() {
-            setCol(col+1);
-        });
+        jQuery('.wizard-datasets > .panel').addClass('wizard-panel-selected');
+
+        // Focus dataset name
+        jQuery('.wizard-dataset-name').focus();
+
+        // Update Instructions
+        let html = "<strong>Step " + step + ":</strong> Enter a name for your dataset and click the <strong>Create</strong> button.";
+        jQuery('#dsp-help-instructions').html(html);
+        jQuery('#dsp-help-next').css('display', 'none');
+
+    }
+
+    /**
+     * Return to the source page when dataset is created
+     */
+    function returnToSource() {
+
+        // Remove Highlight
+        jQuery('.wizard-datasets > .panel').removeClass('wizard-panel-selected');
+
+        // Update Instructions
+        let html = "<strong>Dataset Created:</strong> Return to the Analysis tool";
+        jQuery('#dsp-help-instructions').html(html);
+
+        // Set Return Button
+        if ( DSP_RETURN ) {
+            jQuery('#dsp-help-next-label').html("Return");
+            jQuery('#dsp-help-next').click(function() {
+                window.location = DSP_RETURN;
+                return false;
+            });
+            jQuery('#dsp-help-next').css('display', 'block');
+        }
+
     }
 </script>
+
+<style>
+    #dsp-help {
+        display: none;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 50px;
+        background-color: #ffc107;
+        z-index: 99999;
+    }
+    #dsp-help-instructions {
+        padding: 0 15px;
+        margin: 0;
+        position: absolute;
+        top: 50%;
+        -ms-transform: translateY(-50%);
+        transform: translateY(-50%);
+        color: #000;
+    }
+    #dsp-help-next {
+        float: right;
+        height: 40px;
+        margin: 5px;
+    }
+    
+    .wizard-panel-selected {
+        border: 5px solid #ffc107;
+    }
+    
+    .wizard-type-select option {
+        color: #000;
+        font-weight: normal;
+    }
+    .wizard-type-select option:disabled {
+        color: #999;
+        font-weight: 100;
+        font-style: italic;
+    }
+</style>

--- a/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
+++ b/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
@@ -37,9 +37,16 @@
         parseArgs();
         if ( DSP_ENABLED ) {
             if ( isLoggedIn() ) {
+
+                // Disable the columns (they are enabled as we proceed through the steps)
                 jQuery('.wizard-type-select').prop('disabled', true);
+
+                // Start the first step (setup the first column)
                 setCol(0);
-                
+
+                // Add event listener for the selected items lists
+                jQuery('.wizard-list-selected').on('DOMSubtreeModified', selectionListener)
+
             }
             else {
                 jQuery('#site_login_dialog').modal("show");
@@ -159,6 +166,7 @@
             let html = "<strong>Step " + step + ":</strong> Choose items of type <strong>" + valid_col_types.join(" or ") + "</strong> from column " + step + ".";
             jQuery('#dsp-help-instructions').html(html);
             jQuery('#dsp-help-next-label').html("Next");
+            jQuery("#dsp-help-next").prop('disabled', true);
             jQuery('#dsp-help-next').css('display', 'block');
             jQuery('#dsp-help-next').off('click').on('click', function() {
                 setCol(col+1);
@@ -214,6 +222,20 @@
             jQuery('#dsp-help-next').css('display', 'block');
         }
 
+    }
+
+    /**
+     * Listener for the selected item lists
+     * - Enable the next button if there are selected items, disable if none
+     */
+    function selectionListener() {
+        let children = jQuery(this).children().length;
+        if ( children > 2 ) {
+            jQuery("#dsp-help-next").prop('disabled', false);
+        }
+        else {
+            jQuery("#dsp-help-next").prop('disabled', true);
+        }
     }
 </script>
 

--- a/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
+++ b/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
@@ -1,0 +1,189 @@
+
+<!-- 
+    DATASET CREATION PIPELINE FOR SEACH WIZARD:
+    When provided with the proper query params, the search wizard will walk the user through 
+    creating a dataset with the required parameters, save the dataset, and return to the 
+    originating page.
+
+    URL QUERY PARAMETERS:
+    dsp: dataset parameters
+            - a comma separated list of data set parameters for each column
+            - multiple types for a single column can be separated by a |
+            - multiple sets of parameters can be provided by including additional dsp query parameters
+        Examples:
+            ?dsp=trials,accessions -- require trials as the first parameter and accessions as the second parameter
+            ?dsp=trials|traits,accessions -- require trials or traits as the first parameter and accessions as the second parameter
+            ?dsp=trials,accessions&dsp=accessions,trials -- require trials as the first and accessions as the second parameters 
+                                                              OR accessions as the first and trials as the second parameters
+
+-->
+
+<style>
+    #dsp-help {
+        display: none;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 50px;
+        background-color: #5bc0de;
+        z-index: 99999;
+    }
+    #dsp-help-instructions {
+        padding: 0 15px;
+        margin: 0;
+        position: absolute;
+        top: 50%;
+        -ms-transform: translateY(-50%);
+        transform: translateY(-50%);
+        color: #fff;
+    }
+    #dsp-help-next {
+        float: right;
+        height: 40px;
+        margin: 5px;
+    }
+    
+    .wizard-panel-selected {
+        border: 5px solid #5bc0de;
+    }
+    
+    .wizard-type-select option {
+        color: #000;
+        font-weight: 500;
+    }
+    .wizard-type-select option:disabled {
+        color: #999;
+        font-weight: 100;
+        font-style: italic;
+    }
+</style>
+
+<div id="dsp-help">
+    <p id="dsp-help-instructions"></p>
+    <button id="dsp-help-next" class='btn btn-success'>Next&nbsp;<span class="glyphicon glyphicon-chevron-right"></span></button>
+</div>
+
+<script type='text/javascript'>
+
+    let DSP_ENABLED = false;    // Flag to enable the dataset creation pipeline
+    let DSP_COLS = [];          // Allowed dataset column types
+
+    jQuery(document).ready(function() {
+
+        parseArgs();
+        if ( DSP_ENABLED ) {
+            setCol(0);
+        }
+
+    });
+
+
+    /**
+     * Parse the query parameters for the dataset pipeline arguments
+     * - Set DSP_ENABLED -- flag to indicate the dataset pipeline is enabled
+     * - Set DSP_COLS -- the allowed column type selections
+     */
+    function parseArgs() {
+
+        // Parse query params and get 'dsp' parameter(s)
+        let urlParams = new URLSearchParams(window.location.search);
+        if ( urlParams.has("dsp") ) {
+            DSP_ENABLED = true;
+            
+            // Parse each instance of the 'dsp' parameter
+            let dsp = urlParams.getAll("dsp");
+            for ( let i = 0; i < dsp.length; i++ ) {
+
+                // Parse each column of the 'dsp' parameter
+                let p = dsp[i].split(',');
+                let pa = [];
+                for ( let j = 0; j < p.length; j++ ) {
+                    let c = p[j].split('|');
+                    let ca = [];
+                    for ( let k = 0; k < c.length; k++ ) {
+                        ca.push(c[k].toLowerCase());
+                    }
+                    pa.push(ca);
+                }
+                
+                // Add the allowed column selections
+                DSP_COLS.push(pa);
+
+            }
+
+        }
+
+        console.log("DSP_COLS:");
+        console.log(JSON.stringify(DSP_COLS, null, 2));
+    }
+
+
+    function setCol(col) {
+        console.log("==> SET COLUMN #" + col);
+        
+        // Get selected data types of previous columns
+        let prev_sel_col_types = [];
+        for ( let i = 0; i < col; i++ ) {
+            prev_sel_col_types.push(jQuery('.wizard-type-select')[i].value);
+        }
+        console.log("SELECTIONS");
+        console.log(prev_sel_col_types);
+        
+        // Get items from DSP_COLS that match selected data types in previous columns
+        let valid_dsp_cols = DSP_COLS;
+        for ( let i = 0; i < col; i++ ) {
+            valid_dsp_cols = [];
+            let sel = prev_sel_col_types[i];
+            console.log("==> col " + i + " = " + sel);
+            for ( let j = 0; j < DSP_COLS.length; j++ ) {
+                console.log("--> allowed: " + DSP_COLS[j][i].toString());
+                if ( DSP_COLS[j][i].includes(sel) ) {
+                    valid_dsp_cols.push(DSP_COLS[j]);
+                }
+            }
+        }
+        console.log("VALID DSP COLS:");
+        console.log(JSON.stringify(valid_dsp_cols, null, 2));
+
+        // Get valid data types for the current column, from the list of valid_dsp_cols
+        let valid_col_types = [];
+        for ( let i = 0; i < valid_dsp_cols.length; i++ ) {
+            for ( let j = 0; j < valid_dsp_cols[i][col].length; j++ ) {
+                let t = valid_dsp_cols[i][col][j];
+                if ( !valid_col_types.includes(t) ) {
+                    valid_col_types.push(t);
+                }
+            }
+        }
+        console.log("VALID COL TYPES:");
+        console.log(valid_col_types);
+
+        // Disable invalid selection options for the current column
+        jQuery(jQuery('.wizard-type-select')[col]).find('option').each(function () {
+            let enabled = valid_col_types.includes(this.value) || valid_col_types.includes(jQuery(this).attr('data-type'));
+            jQuery(this).attr('disabled', !enabled);
+        });
+
+        // Display the instructions
+        showHelpCol(col, valid_col_types);
+    }
+
+
+    /**
+     * Display help instructions for selecting items from a column
+     * @param {int} col Column index to select
+     * @param {String[]} types List of valid types for the column
+     */
+    function showHelpCol(col, types) {
+        let step = col+1;
+        let html = "<strong>Step " + step + ":</strong> Choose items of type " + types.join(" or ") + " from column " + step + ".";
+        jQuery('#dsp-help-instructions').html(html);
+        jQuery('#dsp-help').css('display', 'block');
+        jQuery('.wizard-panel').removeClass('wizard-panel-selected');
+        jQuery(jQuery('.wizard-panel')[col]).addClass('wizard-panel-selected');
+        jQuery('#dsp-help-next').click(function() {
+            setCol(col+1);
+        });
+    }
+</script>

--- a/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
+++ b/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
@@ -34,8 +34,13 @@
 
         parseArgs();
         if ( DSP_ENABLED ) {
-            jQuery('.wizard-type-select').prop('disabled', true);
-            setCol(0);
+            if ( isLoggedIn() ) {
+                jQuery('.wizard-type-select').prop('disabled', true);
+                setCol(0);
+            }
+            else {
+                jQuery('#site_login_dialog').modal("show");
+            }
         }
 
     });
@@ -82,7 +87,7 @@
         console.log("DSP_COLS:");
         console.log(JSON.stringify(DSP_COLS, null, 2));
     }
-
+    
 
     /**
      * Setup the selections and instructions for selecting items from the specified column
@@ -152,7 +157,7 @@
             jQuery('#dsp-help-instructions').html(html);
             jQuery('#dsp-help-next-label').html("Next");
             jQuery('#dsp-help-next').css('display', 'block');
-            jQuery('#dsp-help-next').click(function() {
+            jQuery('#dsp-help-next').off('click').on('click', function() {
                 setCol(col+1);
             });
             jQuery('#dsp-help').css('display', 'block');
@@ -203,7 +208,7 @@
         // Set Return Button
         if ( DSP_RETURN ) {
             jQuery('#dsp-help-next-label').html("Return");
-            jQuery('#dsp-help-next').click(function() {
+            jQuery('#dsp-help-next').off('click').on('click', function() {
                 window.location = DSP_RETURN;
                 return false;
             });

--- a/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
+++ b/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
@@ -66,7 +66,6 @@
      * - Set DSP_COLS -- the allowed column type selections
      */
     function parseArgs() {
-        console.log("==> PARSE ARGS");
 
         // Parse query params and get 'dsp' parameter(s)
         let urlParams = new URLSearchParams(window.location.search);
@@ -98,8 +97,6 @@
             DSP_RETURN = urlParams.get("dsr");
         }
 
-        console.log("DSP_COLS:");
-        console.log(JSON.stringify(DSP_COLS, null, 2));
     }
     
 
@@ -108,31 +105,27 @@
      * @param {int} col Column indx
      */
     function setCol(col) {
-        console.log("==> SET COLUMN #" + col);
         
         // Get selected data types of previous columns
         let prev_sel_col_types = [];
         for ( let i = 0; i < col; i++ ) {
-            prev_sel_col_types.push(jQuery('.wizard-type-select')[i].value);
+            let sel = jQuery(jQuery('.wizard-type-select option:selected')[i]);
+            prev_sel_col_types.push((sel.attr("data-type") ? sel.attr("data-type") : sel.html()).toLowerCase());
         }
-        console.log("PREV SELECTIONS");
-        console.log(prev_sel_col_types);
         
         // Get items from DSP_COLS that match selected data types in previous columns
         let valid_dsp_cols = DSP_COLS;
         for ( let i = 0; i < col; i++ ) {
             valid_dsp_cols = [];
             let sel = prev_sel_col_types[i];
-            console.log("==> col " + i + " = " + sel);
             for ( let j = 0; j < DSP_COLS.length; j++ ) {
-                console.log("--> allowed: " + DSP_COLS[j][i].toString());
-                if ( DSP_COLS[j][i].includes(sel) ) {
-                    valid_dsp_cols.push(DSP_COLS[j]);
+                if ( DSP_COLS[j][i] ) {
+                    if ( DSP_COLS[j][i].includes(sel) ) {
+                        valid_dsp_cols.push(DSP_COLS[j]);
+                    }
                 }
             }
         }
-        console.log("VALID DSP COLS:");
-        console.log(JSON.stringify(valid_dsp_cols, null, 2));
 
         // Get valid data types for the current column, from the list of valid_dsp_cols
         let valid_col_types = [];
@@ -146,8 +139,6 @@
                 }
             }
         }
-        console.log("VALID COL TYPES:");
-        console.log(valid_col_types);
 
         // Update column with valid column types
         if ( valid_col_types && valid_col_types.length > 0 ) {
@@ -225,6 +216,9 @@
             });
             jQuery('#dsp-help-next').css('display', 'block');
         }
+
+        // Scroll to Top
+        jQuery(window).scrollTop(0);
 
     }
 

--- a/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
+++ b/mason/breeders_toolbox/breeder_search_page_dataset_overlay.mas
@@ -20,8 +20,10 @@
 -->
 
 <div id="dsp-help">
-    <p id="dsp-help-instructions"></p>
-    <button id="dsp-help-next" class='btn btn-primary'><span id="dsp-help-next-label">Next</span>&nbsp;<span class="glyphicon glyphicon-chevron-right"></span></button>
+    <div id="dsp-help-container">
+        <p id="dsp-help-instructions"></p>
+        <button id="dsp-help-next" class='btn btn-primary'><span id="dsp-help-next-label">Next</span>&nbsp;<span class="glyphicon glyphicon-chevron-right"></span></button>
+    </div>
 </div>
 
 <script type='text/javascript'>
@@ -37,6 +39,7 @@
             if ( isLoggedIn() ) {
                 jQuery('.wizard-type-select').prop('disabled', true);
                 setCol(0);
+                
             }
             else {
                 jQuery('#site_login_dialog').modal("show");
@@ -175,10 +178,6 @@
      */
     function saveDataset(step) {
 
-        // Scroll to Datasets
-        let anchor = jQuery('.wizard-datasets');
-        jQuery('html,body').animate({scrollTop: anchor.offset().top}, 'fast');
-
         // Highlight Panel
         jQuery('.wizard-panel').removeClass('wizard-panel-selected');
         jQuery('.wizard-datasets > .panel').addClass('wizard-panel-selected');
@@ -221,25 +220,24 @@
 <style>
     #dsp-help {
         display: none;
-        position: fixed;
-        bottom: 0;
-        left: 0;
+    }
+    #dsp-help-container {
+        display: flex;
+        align-items: center;
+        margin: 15px 0;
         width: 100%;
-        height: 50px;
+        min-height: 50px;
         background-color: #ffc107;
-        z-index: 99999;
+        border-radius: 5px;
+        vertical-align: middle;
     }
     #dsp-help-instructions {
-        padding: 0 15px;
-        margin: 0;
-        position: absolute;
-        top: 50%;
-        -ms-transform: translateY(-50%);
-        transform: translateY(-50%);
+        flex-grow: 1;
         color: #000;
+        margin: 0;
+        padding-left: 15px;
     }
     #dsp-help-next {
-        float: right;
         height: 40px;
         margin: 5px;
     }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR adds the ability to use the Search Wizard as a guided/step-by-step workflow for creating a new dataset with specific parameters/dimensions set.  The idea is to use this with the various analysis tools that can use datasets as an input to to the tool and help users that may not know what a dataset is, how to create one, or what dimensions are required in the dataset for the tool to work.

![Screen Shot 2021-04-09 at 10 17 52 AM](https://user-images.githubusercontent.com/7526014/114193861-ed0b3200-991c-11eb-86b7-0c2521584f7a.png)

To enable the workflow, add two query parameters to the existing Search Wizard path (`/breeders/search/`):
- `dsp`: dataset parameters
    - a comma separated list of data set parameters for each column
    - multiple types for a single column can be separated by a |
    - multiple sets of parameters can be provided by including additional dsp query parameters
    - Examples:
        - `dsp=trials,accessions` -- require trials as the first parameter and accessions as the second parameter
        - `dsp=trials|traits,accessions` -- require trials or traits as the first parameter and accessions as the second parameter
        - `dsp=trials,accessions&dsp=accessions,trials` -- require trials as the first and accessions as the second parameters OR accessions as the first and trials as the second parameters
- `dsr`: dataset return URL
    - Example: `dsr=/solgs/search`

Fixes #3301 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
