### PR TITLE
NIRS download fixes

### DIFF
--- a/lib/CXGN/Phenotypes/HighDimensionalPhenotypesSearch.pm
+++ b/lib/CXGN/Phenotypes/HighDimensionalPhenotypesSearch.pm
@@ -184,9 +184,11 @@ sub search {
         my $h = $dbh->prepare($q);
         $h->execute($nd_protocol_id);
         while (my ($stock_uniquename, $stock_id, $spectra, $device_type) = $h->fetchrow_array()) {
-            $spectra = decode_json $spectra;
-            $data_matrix{$stock_id}->{spectra} = $spectra;
-            $data_matrix{$stock_id}->{device_type} = $device_type;
+            eval {
+                $spectra = decode_json $spectra;
+                $data_matrix{$stock_id}->{spectra} = $spectra;
+                $data_matrix{$stock_id}->{device_type} = $device_type;
+            };
         }
 
         $protocol_type_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'high_dimensional_phenotype_nirs_protocol', 'protocol_type')->cvterm_id();
@@ -204,8 +206,10 @@ sub search {
         my $h = $dbh->prepare($q);
         $h->execute($nd_protocol_id);
         while (my ($stock_uniquename, $stock_id, $transcriptomics) = $h->fetchrow_array()) {
-            $transcriptomics = decode_json $transcriptomics;
-            $data_matrix{$stock_id}->{transcriptomics} = $transcriptomics;
+            eval {
+                $transcriptomics = decode_json $transcriptomics;
+                $data_matrix{$stock_id}->{transcriptomics} = $transcriptomics;
+            };
         }
 
         $protocol_type_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'high_dimensional_phenotype_transcriptomics_protocol', 'protocol_type')->cvterm_id();
@@ -223,8 +227,10 @@ sub search {
         my $h = $dbh->prepare($q);
         $h->execute($nd_protocol_id);
         while (my ($stock_uniquename, $stock_id, $metabolomics) = $h->fetchrow_array()) {
-            $metabolomics = decode_json $metabolomics;
-            $data_matrix{$stock_id}->{metabolomics} = $metabolomics;
+            eval {
+                $metabolomics = decode_json $metabolomics;
+                $data_matrix{$stock_id}->{metabolomics} = $metabolomics;
+            };
         }
 
         $protocol_type_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'high_dimensional_phenotype_metabolomics_protocol', 'protocol_type')->cvterm_id();

--- a/lib/SGN/Controller/AJAX/HighDimensionalPhenotypes.pm
+++ b/lib/SGN/Controller/AJAX/HighDimensionalPhenotypes.pm
@@ -547,7 +547,7 @@ sub high_dimensional_phenotypes_transcriptomics_upload_verify_POST : Args(0) {
     my @error_status;
     my @warning_status;
 
-    my $parser = CXGN::Phenotypes::ParseUpload->new(); 
+    my $parser = CXGN::Phenotypes::ParseUpload->new();
     my $validate_type = "highdimensionalphenotypes spreadsheet transcriptomics";
     my $metadata_file_type = "transcriptomics spreadsheet";
     my $subdirectory = "spreadsheet_phenotype_upload";
@@ -899,7 +899,7 @@ sub high_dimensional_phenotypes_transcriptomics_upload_store_POST : Args(0) {
         values_hash=>\%parsed_data_agg_coalesced,
         has_timestamps=>0,
         metadata_hash=>\%phenotype_metadata
-    
+
     });
 
     my $warning_status;
@@ -1398,7 +1398,8 @@ sub high_dimensional_phenotypes_download_file_POST : Args(0) {
     my $ds = CXGN::Dataset->new({
         people_schema => $people_schema,
         schema => $schema,
-        sp_dataset_id => $dataset_id
+        sp_dataset_id => $dataset_id,
+        autopopulate_accessions_from_trials => 1
     });
     my $accession_ids = $ds->accessions();
     my $plot_ids = $ds->plots();
@@ -1414,6 +1415,12 @@ sub high_dimensional_phenotypes_download_file_POST : Args(0) {
         plant_list=>$plant_ids
     });
     my ($data_matrix, $identifier_metadata, $identifier_names) = $phenotypes_search->search();
+
+    if ($data_matrix->{error}) {
+        $c->stash->{rest} = {error => $data_matrix->{error}};
+        $c->detach();
+    }
+
     # print STDERR Dumper $data_matrix;
     # print STDERR Dumper $identifier_metadata;
     # print STDERR Dumper $identifier_names;
@@ -1559,7 +1566,8 @@ sub high_dimensional_phenotypes_download_relationship_matrix_file_POST : Args(0)
     my $ds = CXGN::Dataset->new({
         people_schema => $people_schema,
         schema => $schema,
-        sp_dataset_id => $dataset_id
+        sp_dataset_id => $dataset_id,
+        autopopulate_accessions_from_trials => 1
     });
     my $accession_ids = $ds->accessions();
     my $plot_ids = $ds->plots();


### PR DESCRIPTION
NIRS download does not require accessions because the dataset can now autopopulate accessions from field trials, and the NIRS download catches non-json crashing


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
