### PR TITLE
Duplicate Genotypes Download

### DIFF
--- a/js/source/modules/wizard-downloads.js
+++ b/js/source/modules/wizard-downloads.js
@@ -6,14 +6,14 @@ import "../legacy/CXGN/Dataset.js";
  *
  * @class
  * @classdesc links to a wizard and manages showing relavant related data
- * @param  {type} main_id div to draw within 
- * @param  {type} wizard wizard to link to 
+ * @param  {type} main_id div to draw within
+ * @param  {type} wizard wizard to link to
  * @returns {Object}
- */ 
+ */
 export function WizardDownloads(main_id,wizard){
   var main = d3.select(main_id);
   var datasets = new CXGN.Dataset();
-  
+
   var categories = [];
   var selections = {};
   var operations = {};
@@ -21,7 +21,7 @@ export function WizardDownloads(main_id,wizard){
     categories = c;
     selections = s;
     operations = o;
-    
+
     // Genotype downloads
     var accessions = categories.indexOf("accessions")!=-1?
       selections["accessions"]:
@@ -50,8 +50,9 @@ export function WizardDownloads(main_id,wizard){
         var end_position = d3.select(".wizard-download-genotypes-end-position").node().value;
         var download_format = d3.select(".wizard-download-genotypes-format").node().value;
         var compute_from_parents = d3.select(".wizard-download-genotypes-parents-compute").property("checked");
+        var include_duplicate_genotypes = d3.select(".wizard-download-genotypes-duplicates-include").property("checked");
         var marker_set_list_id = d3.select(".wizard-download-genotypes-marker-set-list-id").node().value;
-        var url = document.location.origin+`/breeders/download_gbs_action/?ids=${accession_ids.join(",")}&protocol_id=${protocol_id}&format=accession_ids&chromosome_number=${chromosome_number}&start_position=${start_position}&end_position=${end_position}&trial_ids=${trial_ids.join(",")}&download_format=${download_format}&compute_from_parents=${compute_from_parents}&marker_set_list_id=${marker_set_list_id}`;
+        var url = document.location.origin+`/breeders/download_gbs_action/?ids=${accession_ids.join(",")}&protocol_id=${protocol_id}&format=accession_ids&chromosome_number=${chromosome_number}&start_position=${start_position}&end_position=${end_position}&trial_ids=${trial_ids.join(",")}&download_format=${download_format}&compute_from_parents=${compute_from_parents}&marker_set_list_id=${marker_set_list_id}&include_duplicate_genotypes=${include_duplicate_genotypes}`;
         window.open(url,'_blank');
       });
     main.selectAll(".wizard-download-genetic-relationship-matrix")
@@ -97,7 +98,7 @@ export function WizardDownloads(main_id,wizard){
         var url = document.location.origin+`/breeders/trials/phenotype/download?trial_list=${t_ids}&format=${format}&dataLevel=metadata`;
         window.open(url,'_blank');
       });
-      
+
     // Download Trial Phenotypes
     var trials = categories.indexOf("trials")!=-1 ? selections["trials"] : [];
     var traits = categories.indexOf("traits")!=-1 ? selections["traits"] : [];
@@ -106,8 +107,8 @@ export function WizardDownloads(main_id,wizard){
     var plants = categories.indexOf("plants")!=-1 ? selections["plants"] : [];
     var locations = categories.indexOf("locations")!=-1 ? selections["locations"] : [];
     var years = categories.indexOf("years")!=-1 ? selections["years"] : [];
-    
-    
+
+
     main.selectAll(".wizard-download-phenotypes-info")
       .attr("value",`${trials.length||"Too few"} trials`);
     main.selectAll(".wizard-download-phenotypes")
@@ -121,7 +122,7 @@ export function WizardDownloads(main_id,wizard){
         var plant_ids = JSON.stringify(plants.map(d=>d.id));
         var location_ids = JSON.stringify(locations.map(d=>d.id));
         var year_ids = JSON.stringify(years.map(d=>d.id));
-        
+
         var format = d3.select(".wizard-download-phenotypes-format").node().value;
         var level = d3.select(".wizard-download-phenotypes-level").node().value;
         var timestamp = d3.selectAll('.wizard-download-phenotypes-timestamp').property('checked')?1:0;
@@ -129,7 +130,7 @@ export function WizardDownloads(main_id,wizard){
         var names = JSON.stringify(d3.select(".wizard-download-phenotypes-name").node().value.split(","));
         var min = d3.select(".wizard-download-phenotypes-min").node().value;
         var max = d3.select(".wizard-download-phenotypes-max").node().value;
-        
+
         var url = document.location.origin+
         `/breeders/trials/phenotype/download?trial_list=${trial_ids}`+
         `&format=${format}&trait_list=${trait_ids}&trait_component_list=${comp_ids}`+
@@ -141,6 +142,6 @@ export function WizardDownloads(main_id,wizard){
         window.open(url,'_blank');
       });
 });
-  
-  
+
+
 }

--- a/lib/CXGN/Genotype/Download/DosageMatrix.pm
+++ b/lib/CXGN/Genotype/Download/DosageMatrix.pm
@@ -26,7 +26,8 @@ my $genotypes_search = CXGN::Genotype::Download::DosageMatrix->new({
     offset=>$offset,
     compute_from_parents=>0, #If you want to compute the genotype for accessions given from parents in the pedigree. Useful for hybrids where parents are genotyped.
     forbid_cache=>0 #If you want to get a guaranteed fresh result not from the file cache
-    prevent_transpose=>0 #Prevent transpose of DosageMatrix
+    prevent_transpose=>0, #Prevent transpose of DosageMatrix
+    return_only_first_genotypeprop_for_stock=>1
 });
 my ($total_count, $genotypes) = $genotypes_search->get_genotype_info();
 

--- a/lib/CXGN/Genotype/Download/VCF.pm
+++ b/lib/CXGN/Genotype/Download/VCF.pm
@@ -27,7 +27,8 @@ my $genotypes_search = CXGN::Genotype::Download::VCF->new({
     limit=>$limit,
     offset=>$offset,
     compute_from_parents=>0, #Whether to look at the pedigree to see if parents are genotyped and to calculate genotype from parents
-    forbid_cache=>0 #If you want to get a guaranteed fresh result not from the file cache
+    forbid_cache=>0, #If you want to get a guaranteed fresh result not from the file cache
+    return_only_first_genotypeprop_for_stock=>1
 });
 my ($total_count, $genotypes) = $genotypes_search->get_genotype_info();
 

--- a/lib/CXGN/Genotype/DownloadFactory.pm
+++ b/lib/CXGN/Genotype/DownloadFactory.pm
@@ -29,7 +29,8 @@ my $geno = CXGN::Genotype::DownloadFactory->instantiate(
         offset=>$offset,
         compute_from_parents=>0, #If you want to compute the genotype for accessions given from parents in the pedigree. Useful for hybrids where parents are genotyped.
         forbid_cache=>0, #If you want to get a guaranteed fresh result not from the file cache
-        prevent_transpose=>0 #Prevent transpose of DosageMatrix
+        prevent_transpose=>0, #Prevent transpose of DosageMatrix
+        return_only_first_genotypeprop_for_stock=>1
     }
 );
 my $status = $geno->download();

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -1348,6 +1348,9 @@ sub get_cached_file_dosage_matrix {
                 $genotype_string .= "\n";
             }
             my $genotype_id = $geno->{germplasmName};
+            if (!$self->return_only_first_genotypeprop_for_stock) {
+                $genotype_id = $geno->{germplasmName}."|".$geno->{markerProfileDbId};
+            }
             my $genotype_data_string = "";
             foreach my $m (@all_marker_objects) {
                 my $current_genotype = $geno->{selected_genotype_hash}->{$m->{name}}->{DS};
@@ -1529,7 +1532,12 @@ sub get_cached_file_dosage_matrix_compute_from_parents {
             my $progeny_genotype = $geno->get_hybrid_genotype();
             my $genotype_string_scores = join "\t", @$progeny_genotype;
 
-            $genotype_string .= $accession_stock_id."\t".$genotype_string_scores."\n";
+            my $genotype_id = $accession_stock_id;
+            if (!$self->return_only_first_genotypeprop_for_stock) {
+                $genotype_id = $accession_stock_id."|".$geno->{markerProfileDbId};
+            }
+
+            $genotype_string .= $genotype_id."\t".$genotype_string_scores."\n";
             write_file($tempfile, {append => 1}, $genotype_string);
             $counter++;
         }
@@ -1723,6 +1731,9 @@ sub get_cached_file_VCF {
                 $genotype_string .= "\n";
             }
             my $genotype_id = $geno->{germplasmName};
+            if (!$self->return_only_first_genotypeprop_for_stock) {
+                $genotype_id = $geno->{germplasmName}."|".$geno->{markerProfileDbId};
+            }
             my $genotype_data_string = "";
             foreach my $m (@all_marker_objects) {
                 my @current_geno = ();
@@ -1996,6 +2007,9 @@ sub get_cached_file_VCF_compute_from_parents {
                     $genotype_string .= "\n";
                 }
                 my $genotype_id = $geno->{germplasmName};
+                if (!$self->return_only_first_genotypeprop_for_stock) {
+                    $genotype_id = $geno->{germplasmName}."|".$geno->{markerProfileDbId};
+                }
 
                 my $geno_h = CXGN::Genotype::ComputeHybridGenotype->new({
                     parental_genotypes=>$genotypes,

--- a/lib/CXGN/Genotype/StoreVCFGenotypes.pm
+++ b/lib/CXGN/Genotype/StoreVCFGenotypes.pm
@@ -75,7 +75,7 @@ notice that the info in the markers and markers_array keys are identical, just i
 }
 
 genotype_info shold be a hashref with the following (though the inner object keys are whatever is in the VCF format):
-notice that the top level keys are all the sample names, and the next keys are marker names. 
+notice that the top level keys are all the sample names, and the next keys are marker names.
 {
     'samplename1' => {
         'marker1' => {
@@ -147,10 +147,10 @@ $store_genotypes->store_metadata();
 $store_genotypes->store_identifiers();
 $return = $store_genotypes->store_genotypeprop_table();
 
- # if genotypes are loaded consecutively, as in the transposed 
+ # if genotypes are loaded consecutively, as in the transposed
  # file, each genotype can be loaded as follows:
  #
-foreach $genotype (@genotypes) { 
+foreach $genotype (@genotypes) {
     $store_genotypes->genotype_info($genotype);
     $store_genotypes->observation_unit_uniquenames(\@observation_unit_uniquenames);
     my $return = $store_genotypes->store_identifiers();
@@ -433,18 +433,18 @@ has 'genotyping_facility_cvterm' => (
     isa => 'Ref',
     is => 'rw',
     );
-    
+
 has 'snp_genotypingprop_cvterm_id' => (
     isa => 'Int',
     is => 'rw',
     );
 
-    
+
 has 'snp_genotype_id' => (
     isa => 'Int',
     is => 'rw',
     );
-    
+
 has 'population_stock_id' => (
     isa => 'Maybe[Int]',
     is => 'rw',
@@ -464,7 +464,7 @@ has 'population_cvterm_id' => (
     isa => 'Int',
     is => 'rw',
     );
-    
+
 has 'md_file_id' => (
     isa => 'Int',
     is => 'rw',
@@ -508,7 +508,7 @@ has 'project_year_cvterm' => (
 has 'marker_by_marker_storage' => (
     isa => 'Bool|Undef',
     is => 'rw'
-); 
+);
 
 sub BUILD {
     my $self = shift;
@@ -677,7 +677,7 @@ sub validate {
 
     #check if genotype_info is correct
     #print STDERR Dumper($genotype_info);
-    
+
     while (my ($observation_unit_name, $marker_result) = each %$genotype_info){
         if (!$observation_unit_name || !$marker_result){
             push @error_messages, "No geno info in genotype_info";
@@ -740,19 +740,19 @@ sub store_metadata {
 
     my $population_cvterm_id =  SGN::Model::Cvterm->get_cvterm_row($schema, 'population', 'stock_type')->cvterm_id();
     $self->population_cvterm_id($population_cvterm_id);
-    
+
     my $igd_number_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'igd number', 'genotype_property')->cvterm_id();
     $self->igd_number_cvterm_id($igd_number_cvterm_id);
-    
+
     my $snp_vcf_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'vcf_snp_genotyping', 'genotype_property')->cvterm_id();
     $self->snp_vcf_cvterm_id($snp_vcf_cvterm_id);
-    
+
     my $geno_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'genotyping_experiment', 'experiment_type')->cvterm_id();
     $self->geno_cvterm_id($geno_cvterm_id);
-    
+
     my $snp_genotype_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'snp genotyping', 'genotype_property')->cvterm_id();
     $self->snp_genotype_id($snp_genotype_id);
-    
+
     my $vcf_map_details_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'vcf_map_details', 'protocol_property')->cvterm_id();
     $self->vcf_map_details_id($vcf_map_details_id);
 
@@ -764,13 +764,13 @@ sub store_metadata {
 
     my $population_members_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'member_of', 'stock_relationship')->cvterm_id();
     $self->population_members_id($population_members_id);
-    
+
     my $design_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'design', 'project_property');
     $self->design_cvterm($design_cvterm);
-    
+
     my $project_year_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'project year', 'project_property');
     $self->project_year_cvterm($project_year_cvterm);
-    
+
     my $genotyping_facility_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, 'genotyping_facility', 'project_property');
     $self->genotyping_facility_cvterm($genotyping_facility_cvterm);
 
@@ -814,7 +814,7 @@ sub store_metadata {
         $population_stock_id = $population_stock->stock_id();
     }
     $self->population_stock_id($population_stock_id);
-    
+
     #When protocol_id provided, a new protocol is not created
     my $protocol_id;
     my $protocol_row_check = $schema->resultset("NaturalDiversity::NdProtocol")->find({
@@ -1042,7 +1042,7 @@ sub store_identifiers {
 
                 my $chrom_genotypeprop = $genotypeprop_json->{$chromosome};
 
-                if (!$genotypeprop_id) {
+                if ( (!$genotypeprop_id && $self->marker_by_marker_storage) || !$self->marker_by_marker_storage ) {
 
                     $chrom_genotypeprop->{CHROM} = $chromosome;
 

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -382,7 +382,7 @@ sub download_phenotypes_action : Path('/breeders/trials/phenotype/download') Arg
     $c->res->header('Content-Disposition', qq[attachment; filename="$file_name"]);
 
     my $output = read_file($tempfile);  ## works for xls format
-    
+
     $c->res->body($output);
 }
 
@@ -621,7 +621,7 @@ sub download_action : Path('/breeders/download_action') Args(0) {
 	close($F);
 
 	#$output = read_file($tempfile, binmode=>':raw:utf8');  ## works for xls format
-	
+
         $c->res->body($output);
     }
 }
@@ -632,7 +632,7 @@ sub download_action : Path('/breeders/download_action') Args(0) {
 
 #
 # Download a file of accession properties (in the same format as the accession upload template)
-# 
+#
 # POST Params:
 #   accession_properties_accession_list_list_select = list id of an accession list
 #   file_format: format of the file output (.xls or .csv)
@@ -695,10 +695,10 @@ sub download_accession_properties_action : Path('/breeders/download_accession_pr
           expires => '+1m',
         };
         $c->res->header('Content-Disposition', qq[attachment; filename="$file_name"]);
-	
+
 
         my $output = read_file($file_path);  ### works here because it is xls, otherwise does not work with utf8
-	
+
         $c->res->body($output);
     }
 
@@ -750,7 +750,7 @@ sub download_accession_properties_action : Path('/breeders/download_accession_pr
 
 }
 
-# 
+#
 # Build Accession Properties Info
 #
 # Generate the rows in the accession info table for the specified Accessions
@@ -787,7 +787,7 @@ sub build_accession_properties_info {
     foreach my $stock_id ( @$accession_ids ) {
         my $a = new CXGN::Stock::Accession({ schema => $schema, stock_id => $stock_id});
         my $synonym_string = join(',', @{$a->synonyms()});
-        
+
         # Setup row with required stock props
         my @r = (
             $a->uniquename(),
@@ -805,7 +805,7 @@ sub build_accession_properties_info {
 
         push(@accession_rows, \@r);
     }
-    
+
     return \@accession_rows;
 }
 
@@ -946,6 +946,7 @@ sub download_gbs_action : Path('/breeders/download_gbs_action') {
     }
 
     my $compute_from_parents = $c->req->param('compute_from_parents') eq 'true' ? 1 : 0;
+    $return_only_first_genotypeprop_for_stock = $c->req->param('include_duplicate_genotypes') eq 'true' ? 0 : 1;
     my $marker_set_list_id = $c->req->param('marker_set_list_id');
 
     my @marker_name_list;
@@ -976,7 +977,8 @@ sub download_gbs_action : Path('/breeders/download_gbs_action') {
             end_position=>$end_position,
             compute_from_parents=>$compute_from_parents,
             forbid_cache=>$forbid_cache,
-            marker_name_list=>\@marker_name_list
+            marker_name_list=>\@marker_name_list,
+            return_only_first_genotypeprop_for_stock=>$return_only_first_genotypeprop_for_stock,
             #markerprofile_id_list=>$markerprofile_id_list,
             #genotype_data_project_list=>$genotype_data_project_list,
             #limit=>$limit,

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -161,7 +161,7 @@ $dataset_id => undef
         <div id="wiz-down-1-c" class="panel-collapse collapse" role="tabpanel">
           <table class="table">
             <tr>
-              <td colspan="8">
+              <td colspan="4">
                 <span class="glyphicon glyphicon-info-sign" title="To download related genotype data, select 1 or more Accessions and optionally no more than 1 Genotyping Protocol in the wizard. If no genotyping protocol is selected, the database default protocol will be used. Click the checkbox here to compute genotypes for the selected accessions from genotypes of parents; this works for downloading genotypes, downloading the GRM, and performing GWAS."></span>
                 <span>Download Genotype Data</span>
                 <input class="wizard-download-genotypes-info form-control input-sm" type="text" disabled></input>
@@ -169,6 +169,10 @@ $dataset_id => undef
               <td colspan="4">
                   <span>Compute From Parents</span><br/>
                   <input type="checkbox" class="wizard-download-genotypes-parents-compute">
+              </td>
+              <td colspan="4">
+                  <span>Include Duplicate Genotypes</span><br/>
+                  <input type="checkbox" class="wizard-download-genotypes-duplicates-include">
               </td>
             </tr>
           </table>


### PR DESCRIPTION
Option on wizard download to include duplicate genotypes in returned VCF or DosageMatrix. If the option is selected, the downloaded file will have the unique database genotype_id appended in the header columns.

Fixes bug in upload of duplicate genotypes in the same protocol. If duplicate genotypes were uploaded for the same stock in the same protocol, only the most recent genotypes were stored. Now the upload will actually store all the duplicate genotypes.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->
closes #3453 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
