### PR TITLE
Footer: add git status information

### DIFF
--- a/mason/site/footer/body.mas
+++ b/mason/site/footer/body.mas
@@ -1,3 +1,8 @@
+<%init>
+  my $tag = `git describe --abbrev=0 --tags`;
+  my $commit = `git rev-parse --short HEAD`;
+  my $updated = `git log -1 --format=%cd`;
+</%init>
 
 <!-- BEGIN SITE SPECIFIC FOOTER. -->
 
@@ -5,16 +10,23 @@
 
   <br />
     <div class="container-fluid">
-      <span style="font-face:arial;font-size:10pt;color:darkgreen;font-weight:light;">BREE<b>DB</b>ASE</span> is located at the <a href="https://btiscience.org">Boyce Thompson Institute</a>.<br />
-      <a href="https://btiscience.org"><img src="https://cassavabase.org/static/img/bti_logo_2016.png" width="200"></a>
       <div class="row">
-
-          <div class="col-md-1 col-lg-1 col-xl-2">
-
+          <div class="col-12 col-md-9">
+            <span style="font-face:arial;font-size:10pt;color:darkgreen;font-weight:light;">BREE<b>DB</b>ASE</span> is located at the <a href="https://btiscience.org">Boyce Thompson Institute</a>.<br />
+            <a href="https://btiscience.org"><img src="https://cassavabase.org/static/img/bti_logo_2016.png" width="200"></a>
+          </div>
+          <div class="col-12 col-md-3">
+            <div class="git-version">
+              <p>
+                <strong>Version</strong>
+                <br />
+                <span class="git-version-commit"><a href="https://github.com/solgenomics/sgn/commits/<% $commit %>"><% $commit %></a></span>&nbsp;
+                <span class="git-version-tag"><a href="https://github.com/solgenomics/sgn/commits/<% $tag %>"><% $tag %></a></span>
+                <br />
+                <span class="git-version-updated"><% $updated %></span>
+              </p>
             </div>
-
-            <div class="col-md-1 col-lg-1 col-xl-2">
-            </div>
+          </div>
         </div>
     </div>
 
@@ -34,3 +46,19 @@
 <!-- <script src="https://platform.twitter.com/widgets.js" type="text/javascript"></script> -->
 
 
+<style>
+  .git-version {
+    display: inline-block;
+    margin-top: 10px;
+  }
+  .git-version p {
+    color: #aaa;
+    font-size: 90%;
+  }
+  .git-version a {
+    color: #aaa
+  }
+  span.git-version-tag {
+    float: right;
+  }
+</style>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds git status information about the sgn repo to the footer, such as the latest commit hash, the latest tag, and the timestamp of the last commit.

This is added to the base mason component in /mason/site/footer/body.mas but will probably need to be incorporated into the site-specific mason file.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
