### PR TITLE
add marker annotation feature to nd_protocolprop table

### DIFF
--- a/bin/load_marker_dbxref.pl
+++ b/bin/load_marker_dbxref.pl
@@ -1,0 +1,138 @@
+
+=head1 NAME
+ load_dbxref.pl - a script to link marker_names with cvterm for external database link, this script uses the nd_protocolprop table
+     with a typdef_id
+
+=head1 SYNOPSYS
+
+load_locus_publications.pl -p [person_id] -H [hostname] -D [database name] -c dbxref -j protocol_id file
+
+where file contains a column with marker names
+if marker_name does not exist then do not insert
+nd_protocolprop format { dbxref: dbxref_name, marker: {array of marker_names} }
+To use an existing protocol (not create a new nd_protocol name entry), use -j protocol_id
+
+=head1 COMMAND-LINE OPTIONS
+  ARGUMENTS
+
+-H host name (required) e.g. "localhost"
+-D database name (required) e.g. "cxgn_cassava"
+-j protocol_id (Will associate genotype data to an existing nd_protocol_id)
+
+=head1 AUTHOR
+
+Clay Birkett <clb343@cornell.edu>
+
+=cut
+
+use strict;
+use warnings;
+
+use Getopt::Std;
+use File::Slurp qw | slurp |;
+use CXGN::DB::InsertDBH;
+
+our %opts;
+getopts('p:H:D:j:', \%opts);
+
+my $file = shift;
+
+my @lines = slurp($file);
+chomp(@lines);
+
+my $dbh = CXGN::DB::InsertDBH->new( { dbname => $opts{D},
+				      dbhost => $opts{H},
+				    });
+
+
+my $sth;
+my @row;
+my $alias;
+my $count;
+my $count_add;
+my $marker_id;
+my %alias_list;
+my %marker_list;
+my %unique_list;
+
+my $protocol_id = $opt_j;
+
+#if protocol_id provided, a new one will not be created
+if ($protocol_id){
+    my $protocol = CXGN::Genotype::Protocol->new({
+        bcs_schema => $schema,
+        nd_protocol_id => $protocol_id
+    });
+    $organism_species = $protocol->species_name;
+    $obs_type = $protocol->sample_observation_unit_type_name if !$obs_type;
+}
+
+##get list of current alias entries
+##use (marker_id, alias) as unique key so we don't duplicate entries
+my $key;
+$count = 0;
+$sth = $dbh->prepare("SELECT alias, marker_id, preferred from marker_alias");
+$sth->execute();
+while (@row = $sth->fetchrow_array()) {
+    $count++;
+    $alias = $row[0];
+    if ($row[2]) {
+	$marker_list{$alias} = $row[1];
+    } else {
+        $alias_list{$alias} = $row[1];
+    }
+    $key = $row[0] . $row[1];
+    $unique_list{$key} = 1;
+}
+print "$count from marker_alias\n";
+
+$count = 0;
+$sth = $dbh->prepare("INSERT into marker_alias (marker_id, alias, preferred) values (?, ?, ?)");
+foreach my $l (@lines) { 
+    $count++;
+    push (@marker_list, $alias);
+}
+
+    my ($marker_name, $alias) = split /\t/, $l;
+    my @alias_list = split /\|/, $alias;
+    if (exists($marker_list{$marker_name})) {
+	$marker_id = $marker_list{$marker_name};
+        foreach (@alias_list) {
+	    $key = $_ . $marker_id;
+            if (exists($unique_list{$key})) {
+	    } else {
+		$count_add++;
+		$sth->execute($marker_id, $_, 0);
+		$alias_list{$_} = $marker_id;
+	    }
+        }
+    } else {
+	$sth2 = $dbh->prepare("INSERT into marker (dummy_field) values (null) RETURNING marker_id");
+	$sth2->execute();
+	($marker_id) = $sth2->fetchrow_array();
+	$sth2 = $dbh->prepare("INSERT into marker_alias (marker_id, alias, preferred) values (?, ?, ?)");
+	$sth2->execute($marker_id, $marker_name, 1);
+	print "added marker $marker_name $marker_id\n";
+	foreach (@alias_list) {
+            $key = $_ . $marker_id;
+            if (exists($unique_list{$key})) {
+            } else {
+                $count_add++;
+                $sth->execute($marker_id, $_, 0);
+                $alias_list{$_} = $marker_id;
+            }
+	    print "added alias $_\n";
+        }
+        last;	
+    }
+}
+print "$count total $count_add added\n";
+
+$dbh->commit();
+    
+				
+
+
+
+
+

--- a/db/00141/AddVcfType.pm
+++ b/db/00141/AddVcfType.pm
@@ -1,0 +1,74 @@
+#!/usr/bin/env perl
+
+
+=head1 NAME
+
+ AddVcfType.pm
+
+=head1 SYNOPSIS
+
+mx-run ThisPackageName [options] -H hostname -D dbname -u username [-F]
+
+This patch add new cvterm vcf_snp_dbxref to nd_protocol
+
+=head1 DESCRIPTION
+
+This dbpatch adds vcf_snp_dbxref to nd_protocol and nd_protocolprop to provide external links to marker_names
+
+
+=head1 AUTHOR
+
+ Clay Birkett<clb343@cornell.edu>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2010 Boyce Thompson Institute for Plant Research
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+
+package AddVcfType;
+
+use Moose;
+use Bio::Chado::Schema;
+use Try::Tiny;
+extends 'CXGN::Metadata::Dbpatch';
+
+has '+description' => ( default => <<'' );
+This patch add new cvterm vcf_snp_dbxref to nd_protocol
+
+has '+prereq' => (
+    default => sub {
+        [],
+    },
+  );
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    my $schema = Bio::Chado::Schema->connect( sub { $self->dbh->clone } );
+
+	my $term = 'vcf_snp_dbxref';
+
+	$schema->resultset("Cv::Cvterm")->create_with( {
+		name => $term,
+		cv => 'protocol_property', }
+		);
+
+
+print "You're done!\n";
+}
+
+
+####
+1; #
+####

--- a/lib/SGN/Controller/AJAX/Marker.pm
+++ b/lib/SGN/Controller/AJAX/Marker.pm
@@ -1,0 +1,82 @@
+=head1 NAME
+
+SGN::Controller::AJAX::Marker - a REST controller class to provide the
+backend for object linked with markers
+
+=head1 DESCRIPTION
+
+Add new marker properties, marker dbxrefs and so on.
+
+=head1 AUTHOR
+
+Clay Birkett <clb343@cornell.edu>
+
+=cut
+
+package SGN::Controller::AJAX::Marker;
+
+use strict;
+use Moose;
+use CXGN::DB::Connection;
+use JSON;
+
+BEGIN { extends 'Catalyst::Controller::REST' }
+
+__PACKAGE__->config(
+    default   => 'application/json',
+    stash_key => 'rest',
+    map       => { 'application/json' => 'JSON' },
+   );
+
+
+sub add_markerprop_GET {
+    my $self = shift;
+    my $c = shift;
+    return $self->add_stockprop_POST($c);
+}
+
+=head2 get_markerprops
+
+ Usage:
+ Desc:	Gets the markerprops of type type_id associated with a marker_name
+ Ret:
+ Args:
+
+=cut
+
+sub get_markerprops : Path('/marker/prop/get') : ActionClass('REST') { }
+
+sub get_markerprops_GET {
+    my ($self, $c) = @_;
+
+    my @row;
+    my $marker_id = $c->req->param("marker_id");
+    my $marker_name = $c->req->param("marker_name");
+
+    my $dbh = CXGN::DB::Connection->new();
+
+    my @propinfo = ();
+    my $data;
+
+    my $q = "select cvterm_id from public.cvterm where name = 'vcf_snp_dbxref'";
+    my $h = $dbh->prepare($q);
+    $h->execute();
+    my ($type_id) = $h->fetchrow_array(); 
+
+    $q = "select value from nd_protocolprop where type_id = ?";
+    $h = $dbh->prepare($q);
+    $h->execute($type_id);
+    while (@row = $h->fetchrow_array()) {
+        $data = decode_json($row[0]);
+	foreach (@{$data->{markers}}) {
+	    if ($_->{marker_name} eq $marker_name) {
+	        push @propinfo, { url => $data->{url}, type_name => $data->{dbxref}, marker_name => "$_->{marker_name}", xref_name => "$_->{xref_name}"};
+            }
+       }
+    }
+
+    $c->stash->{rest} = \@propinfo;
+
+}
+
+1;

--- a/mason/markers/external_links.mas
+++ b/mason/markers/external_links.mas
@@ -1,0 +1,87 @@
+<%doc>
+Call this page when using is marker_name
+</%doc>
+
+<%args>
+$marker_name
+$title
+$collapsible
+</%args>
+
+
+<style>
+    #external-links-list {
+        list-style-type: none;
+    }
+</style>
+
+
+<div id="external-links">
+    <li id="external-links-list"></li>
+</div>
+
+
+<& /instance/external_link_sources.mas &>
+<script defer>
+
+    /**
+     * on ready: get the marker props
+     */
+    jQuery(document).ready(function() {
+        getProps();
+        flankingSeq();
+    });
+
+    /**
+     * Get the marker props for the current marker name
+     */
+    function getProps() {
+      jQuery.ajax( {
+        type: 'GET',
+        url: '/marker/prop/get',
+        data: { marker_name: "<% $marker_name %>" },
+        success: function(response) {
+            let props = [];
+            if ( response ) {
+                for ( let i = 0; i < response.length; i++ ) {
+                    props.push(response[i]);
+                }
+            }
+            renderLinks(props);
+        },
+        error: function(response) {
+            console.log("Could not load marker props");
+            console.log(response);
+        }
+      });
+    }
+
+    /**
+     * Generate the external links HTML
+     * @param  {Object[]} props A list of marker_name props
+     */
+    function renderLinks(props) {
+        let html = "<table style=\"border-spacing: 10px; border-collapse: separate;\">";
+        for ( let i = 0; i < props.length; i++ ) {
+            let prop = props[i];
+            let url = prop.url;
+            let type_name = prop.type_name;
+            let marker_name = prop.marker_name;
+            let xref_name = prop.xref_name;
+            html += "<tr><td><a href='" + url + xref_name + "' target='_new'>" + xref_name + "</a><td>" + type_name;
+        }
+	html += "</table>";
+        jQuery("#external-links-list").html(html);
+    }
+
+    /**
+     * Generate the link for marker flanking sequence
+     */
+
+    function flankingSeq() {
+        let html = "<ul></ul>";
+        jQuery("#external-links-list").html(html);
+        console.log("Made it here");
+    }
+
+</script>


### PR DESCRIPTION
use nd_protocol and nd_protocolprop table to store marker annotations
main use is to store links to external references (EnsemblPlant, Graingenes, haplotypes, etc
use type_id and cvterm "vcf_snp_dbxref"


#3482 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
