### PR TITLE
replace missing genotype with valid './.'

### DIFF
--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -1741,6 +1741,7 @@ sub get_cached_file_VCF {
                 my $name = $m->{name};
                 my $format = $m->{format};
                 my @format;
+		my $gt;
 
                 #In case of old genotyping protocols where there was no protocolprop marker info
                 if (!$format) {
@@ -1755,7 +1756,11 @@ sub get_cached_file_VCF {
                 }
 
                 foreach my $format_key (@format) {
-                    push @current_geno, $geno->{selected_genotype_hash}->{$m->{name}}->{$format_key};
+	 	    $gt = $geno->{selected_genotype_hash}->{$m->{name}}->{$format_key};
+		    if ($gt eq '') {
+			$gt = './.';
+		    }
+                    push @current_geno, $gt;
                 }
                 my $current_g = join ':', @current_geno;
                 $genotype_data_string .= $current_g."\t";


### PR DESCRIPTION
When there are multiple genotype projects for one protocol and the set of markers are not identical then the VCF output will have an empty value for missing genotypes. This patch replaces empty value with './.'


#3494 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
