### PR TITLE
update breeding methods call to use female parent values

### DIFF
--- a/lib/CXGN/BrAPI/v2/BreedingMethods.pm
+++ b/lib/CXGN/BrAPI/v2/BreedingMethods.pm
@@ -21,11 +21,11 @@ sub search {
 	my @data_files;
 	my $total_count = 1;
 
-	my $cross_type_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'cross_type', 'nd_experiment_property')->cvterm_id();
+	my $female_parent_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'female_parent', 'stock_relationship')->cvterm_id();
 
-	my $q = "SELECT distinct(value) FROM nd_experimentprop where type_id = ?;";
+	my $q = "SELECT distinct(value) FROM stock_relationship where type_id = ?;";
 	my $h = $self->bcs_schema->storage()->dbh()->prepare($q);
-	$h->execute($cross_type_cvterm_id);
+	$h->execute($female_parent_cvterm_id);
 
 	while (my ($cross_type) = $h->fetchrow_array()) {
 		push @crosstypes, $cross_type;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Switch Brapi breeding methods call to use female parent value (as is now done with brapi germplasm breeding methods).

<!-- If there are relevant issues, link them here: -->

Closes #3523

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
