### PR TITLE
[BI-956] - Bug fixes for brapi observations endpoint

### DIFF
--- a/lib/CXGN/BrAPI/v2/Observations.pm
+++ b/lib/CXGN/BrAPI/v2/Observations.pm
@@ -238,7 +238,7 @@ sub observations_store {
     if ($user_type ne 'submitter' && $user_type ne 'sequencer' && $user_type ne 'curator') {
         print STDERR 'Must have submitter privileges to upload phenotypes! Please contact us!';
         push @$status, {'403' => 'Permission Denied. Must have correct privilege.'};
-        return CXGN::BrAPI::JSONResponse->return_error($status, 'Must have submitter privileges to upload phenotypes! Please contact us!');
+        return CXGN::BrAPI::JSONResponse->return_error($status, 'Must have submitter privileges to upload phenotypes! Please contact us!', 403);
     }
 
     ## Validate request structure and parse data
@@ -251,7 +251,7 @@ sub observations_store {
     if (!$validated_request || $validated_request->{'error'}) {
         my $parse_error = $validated_request ? $validated_request->{'error'} : "Error parsing request structure";
         print STDERR $parse_error;
-        return CXGN::BrAPI::JSONResponse->return_error($status, $parse_error);
+        return CXGN::BrAPI::JSONResponse->return_error($status, $parse_error, 400);
     } elsif ($validated_request->{'success'}) {
         push @$status, {'info' => $validated_request->{'success'} };
     }
@@ -265,7 +265,7 @@ sub observations_store {
     if (!$parsed_request || $parsed_request->{'error'}) {
         my $parse_error = $parsed_request ? $parsed_request->{'error'} : "Error parsing request data";
         print STDERR $parse_error;
-        return CXGN::BrAPI::JSONResponse->return_error($status, $parse_error);
+        return CXGN::BrAPI::JSONResponse->return_error($status, $parse_error, 400);
     } elsif ($parsed_request->{'success'}) {
         push @$status, {'info' => $parsed_request->{'success'} };
         #define units (observationUnits) and variables (observationVariables) from parsed request
@@ -290,7 +290,7 @@ sub observations_store {
     my $archive_error_message = $response->{error_message};
     my $archive_success_message = $response->{success_message};
     if ($archive_error_message){
-        return CXGN::BrAPI::JSONResponse->return_error($status, $archive_error_message);
+        return CXGN::BrAPI::JSONResponse->return_error($status, $archive_error_message, 500);
     }
     if ($archive_success_message){
         push @$status, {'info' => $archive_success_message };
@@ -335,7 +335,7 @@ sub observations_store {
     if ($stored_observation_success) {
         #if no error refresh matviews 
         my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
-        my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'fullview', 'concurrent', $c->config->{basepath});
+        my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath});
 
         print STDERR "Success: $stored_observation_success\n";
         # result need to be updated with v2 format

--- a/lib/CXGN/BrAPI/v2/Observations.pm
+++ b/lib/CXGN/BrAPI/v2/Observations.pm
@@ -330,7 +330,7 @@ sub observations_store {
 
     if ($stored_observation_error) {
         print STDERR "Error: $stored_observation_error\n";
-        return CXGN::BrAPI::JSONResponse->return_error($status, $stored_observation_error);
+        return CXGN::BrAPI::JSONResponse->return_error($status, $stored_observation_error, 500);
     }
     if ($stored_observation_success) {
         #if no error refresh matviews 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
- Refresh only `phenotype` materialized views for observations POST
  - Should speed up the refresh
  - The `traits` materialized view was breaking the refresh with an error ` ERROR: more than one row returned by a subquery used as an expression`, this change avoids that view. 
  - Updated errors to return error codes instead of `200` responses. 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
