### PR TITLE
Refresh both phenoview and the jsonb matview after adding trait data

### DIFF
--- a/bin/refresh_matviews.pl
+++ b/bin/refresh_matviews.pl
@@ -78,7 +78,7 @@ try {
        @mv_names = ('materialized_stockprop');
     }
     if ($mode eq 'phenotypes') {
-       @mv_names = ("materialized_phenotype_jsonb_table");
+       @mv_names = ("materialized_phenoview", "materialized_phenotype_jsonb_table");
     }
 
     my $status = refresh_mvs($dbh, \@mv_names, $concurrent);

--- a/lib/CXGN/BrAPI/v1/Observations.pm
+++ b/lib/CXGN/BrAPI/v1/Observations.pm
@@ -150,7 +150,7 @@ sub observations_store {
 
     ## Will need to initiate refresh matviews in controller instead
     my $bs = CXGN::BreederSearch->new( { dbh=>$c->dbc->dbh, dbname=>$c->config->{dbname}, } );
-    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'fullview', 'concurrent', $c->config->{basepath});
+    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath});
 
     return CXGN::BrAPI::JSONResponse->return_success(\%result, $pagination, \@data_files, $status, $stored_observation_success);
 

--- a/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
+++ b/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
@@ -168,7 +168,7 @@ sub upload_phenotype_store_POST : Args(1) {
 
     push @$success_status, "Metadata saved for archived file.";
     my $bs = CXGN::BreederSearch->new( { dbh=>$c->dbc->dbh, dbname=>$c->config->{dbname}, } );
-    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'fullview', 'concurrent', $c->config->{basepath});
+    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath});
 
     $c->stash->{rest} = {success => $success_status, error => $error_status};
 }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Currently, the `refresh_matviews.pl` script does not refresh the `materialized_phenotype_jsonb_table` matview with a '**fullview**' refresh and the '**phenotypes**' refresh does not update the `materialized_phenoview` matview.  This PR changes the '**phenotypes**' refresh to update both matviews.

The '**phenotypes**' refresh was only being used by the BrAPI v2 store observations function.  This changes the refresh in the BrAPI v1 store observations function and the phenotypes upload AJAX function to use the '**phenotypes**' refresh instead of the '**fullview**' option.

Fixes #3616 



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
