### PR TITLE
Handle mkpath() "file exists" error when tempfiles_subdir is a symlink

### DIFF
--- a/lib/SGN/Role/Site/Files.pm
+++ b/lib/SGN/Role/Site/Files.pm
@@ -230,7 +230,7 @@ sub _default_temp_base {
 sub make_generated_dir {
     my ( $self, $tempdir ) = @_;
 
-    eval { mkpath( "$tempdir" ); };
+    eval { mkpath( readlink($tempdir) || $tempdir ); };
 
     if ($@) { 
 	print STDERR "the following error occurred while attempting to generate $tempdir : $@ (may be ok)\n";


### PR DESCRIPTION
Description
-----------------------------------------------------

Addresses following error apparently caused by sgn/static/documents/tempfiles being a symlink to /tmp/root/SGN-site: 
```
the following error occurred while attempting to generate /home/production/cxgn/sgn/static/documents/tempfiles : mkdir /home/production/cxgn/sgn/static/documents/tempfiles: File exists at /home/production/cxgn/sgn/t/../lib/SGN/Role/Site/Files.pm line 233.
 (may be ok)
dir '/home/production/cxgn/sgn/static/documents/tempfiles' creation failed (No such file or directory) at /home/production/cxgn/sgn/t/../lib/SGN/Role/Site/Files.pm line 241.
tempfiles dir '/home/production/cxgn/sgn/static/documents/tempfiles' does not exist, and could not create (No such file or directory) at /home/production/cxgn/sgn/t/../lib/SGN/Role/Site/Files.pm line 202.
CHOWNING WITH 33, 33
Can't locate object method "children" via package "Path::Class::File" at /home/production/cxgn/sgn/t/../lib/SGN/Role/Site/Mason.pm line 95. 
Compilation failed in require at /home/production/cxgn/local-lib/lib/perl5/Catalyst/Utils.pm line 309.
```


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [X] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
