### PR TITLE
skip tests with dependency on java and high memory.

### DIFF
--- a/t/unit_fixture/CXGN/Uploading/VCFGenotypes.t
+++ b/t/unit_fixture/CXGN/Uploading/VCFGenotypes.t
@@ -68,9 +68,10 @@ $response = $ua->post(
         ]
     );
 
-#print STDERR Dumper $response;
+print STDERR Dumper $response;
 ok($response->is_success);
 my $message = $response->decoded_content;
+
 my $message_hash = decode_json $message;
 print STDERR Dumper $message_hash;
 is_deeply($message_hash, {'missing_stocks' => ['KBH2014_076','KBH2014_1155','KBH2014_124','KBH2014_1241','KBH2014_1463','KBH2014_286','KBH2014_740','KBH2014_968','KBH2015_080','KBH2015_383','KBH2015_BULK','SRLI1_26','SRLI1_52','SRLI1_66','SRLI1_78','SRLI1_90','SRLI2_33','SRLI2_70','UKG1502_022','UKG1503_004','UKG15OP07_038'],'error_string' => 'The following stocks are not in the database: KBH2014_076,KBH2014_1155,KBH2014_124,KBH2014_1241,KBH2014_1463,KBH2014_286,KBH2014_740,KBH2014_968,KBH2015_080,KBH2015_383,KBH2015_BULK,SRLI1_26,SRLI1_52,SRLI1_66,SRLI1_78,SRLI1_90,SRLI2_33,SRLI2_70,UKG1502_022,UKG1503_004,UKG15OP07_038<br>'});
@@ -101,6 +102,7 @@ $response = $ua->post(
 #print STDERR Dumper $response;
 ok($response->is_success);
 $message = $response->decoded_content;
+print STDERR "MESSAGE: ".$message;
 $message_hash = decode_json $message;
 print STDERR Dumper $message_hash;
 is($message_hash->{success}, 1);
@@ -325,6 +327,15 @@ ok($message_hash->{nd_protocol_id});
 
 my $file = $f->config->{basepath}."/t/data/genotype_data/testset_GT-AD-DP-GQ-DS-PL.h5";
 
+
+SKIP: {
+
+    my $skip_hdf5_tests = ! (has_java() && (free_memory() > 12));
+
+    print STDERR "SKIP HDF5 TESTS: $skip_hdf5_tests\n";
+    
+    skip "No java installed or not enough memory", 7 if $skip_hdf5_tests;
+    
 #test upload with file where sample names are not in the database
 my $ua = LWP::UserAgent->new;
 $response = $ua->post(
@@ -349,6 +360,9 @@ $response = $ua->post(
     );
 
 $message = $response->decoded_content;
+
+print STDERR "ANOTHER MESSAGE: ".Dumper($message);
+
 my $message_hash_tassel = decode_json $message;
 print STDERR Dumper $message_hash_tassel;
 is($message_hash_tassel->{success}, 1);
@@ -718,4 +732,28 @@ $response = decode_json $mech->content;
 print STDERR Dumper $response;
 is_deeply($response, {success=>1});
 
+}
+
+
 done_testing();
+
+sub free_memory {
+    my @lines = `free -h`;
+    my ($label, $total, $used, $free) = split /\s+/, $lines[1];
+    $free =~ m/\D+(\d+).*/;
+    $free = $1;
+    print STDERR "FREE MEMORY DETECTED: $free\n";
+    return $free;
+}
+
+sub has_java {
+    my @lines = `java -version`;
+    if ($lines[0]=~/java version/) {
+       return 1;
+    }
+    else {
+    	return 0;
+    }
+}
+       
+    


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fix t/unit_fixuture/CXGN/Uploading/VCFGenotype.t test by skipping some tests that depdend on Java and high memory, if these are not available.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
