### PR TITLE
Adds download buttons on protocol detail page

### DIFF
--- a/mason/breeders_toolbox/genotyping_protocol/genotype_data.mas
+++ b/mason/breeders_toolbox/genotyping_protocol/genotype_data.mas
@@ -52,6 +52,13 @@ jQuery(document).ready(function () {
      }
    });
 
+   jQuery('#genotyping_protocol_genotype_data_detail_page_download_all_vcf').click(function(){
+       window.location.replace("/breeders/download_gbs_action/?protocol_id=<% $protocol_id %>&download_format=VCF&format=accession_ids");
+   });
+   jQuery('#genotyping_protocol_genotype_data_detail_page_download_all_dosagematrix').click(function(){
+       window.location.replace("/breeders/download_gbs_action/?protocol_id=<% $protocol_id %>&download_format=DosageMatrix&format=accession_ids");
+   });
+
 });
 
 </script>

--- a/mason/breeders_toolbox/genotyping_protocol/index.mas
+++ b/mason/breeders_toolbox/genotyping_protocol/index.mas
@@ -41,7 +41,7 @@ $marker_type
 % } else {
     <& /page/detail_page_2_col_section.mas, protocol_id => $protocol_id, info_section_title => "<h4 style='display:inline'>Markers</h4>", info_section_subtitle => 'View information about the markers used in this protocol.', icon_class => "glyphicon glyphicon-map-marker", info_section_id => "genotyping_protocol_markers" &>
 
-    <& /page/detail_page_2_col_section.mas, protocol_id => $protocol_id, info_section_title => "<h4 style='display:inline'>Genotype Data</h4>", info_section_subtitle => 'View and download genotyping data from this protocol.', icon_class => "glyphicon glyphicon-save-file", info_section_id => "genotyping_protocol_genotype_data" &>
+    <& /page/detail_page_2_col_section.mas, protocol_id => $protocol_id, info_section_title => "<h4 style='display:inline'>Genotype Data</h4>", info_section_subtitle => 'View and download genotyping data from this protocol.', icon_class => "glyphicon glyphicon-save-file", info_section_id => "genotyping_protocol_genotype_data", buttons_html => '<button class="btn btn-primary" style="margin:3px" id="genotyping_protocol_genotype_data_detail_page_download_all_vcf">Download All Genotype Data VCF</button><button class="btn btn-primary" style="margin:3px" id="genotyping_protocol_genotype_data_detail_page_download_all_dosagematrix">Download All Genotype Data Dosage Matrix</button>' &>
 % }
 
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Adds download buttons on protocol detail page for downloading all data in VCF and Dosage Matrix formats

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
