### PR TITLE
Topic/new plot name option on change accession

### DIFF
--- a/lib/CXGN/Trial/FieldMap.pm
+++ b/lib/CXGN/Trial/FieldMap.pm
@@ -41,30 +41,6 @@ has 'second_accession_selected' => (isa => "Str",
 	is => 'rw',
 );
 
-has 'new_accession' => (isa => "Str",
-	is => 'rw',
-);
-
-has 'old_accession' => (isa => "Str",
-	is => 'rw',
-);
-
-has 'old_plot_id' => (isa => "Int",
-	is => 'rw',
-);
-
-has 'old_plot_name' => (isa => "Str",
-    is => 'rw',
-);
-
-has 'new_plot_name' => (isa => "Str",
-    is => 'rw',
-);
-
-has 'old_accession_id' => (isa => "Int",
-	is => 'rw',
-);
-
 has 'trial_stock_type' => (isa => "Str",
 	is => 'rw',
 	required => 0,
@@ -394,13 +370,13 @@ sub substitute_accession_fieldmap {
 
 sub replace_plot_accession_fieldMap {
 	my $self = shift;
+	my $new_accession = shift;
+	my $old_accession = shift;
+	my $old_plot_id = shift;
+    my $old_plot_name = shift;
 	my $error;
 	my $schema = $self->bcs_schema;
 	my $dbh = $self->bcs_schema->storage->dbh;
-	my $new_accession = $self->new_accession;
-	my $old_accession = $self->old_accession;
-	my $old_plot_id = $self->old_plot_id;
-    my $old_plot_name = $self->old_plot_name;
 
 	print "New Accession: $new_accession, Old Accession: $old_accession, Old Plot Id: $old_plot_id\n";
 
@@ -425,10 +401,10 @@ sub replace_plot_accession_fieldMap {
 
 sub replace_plot_name_fieldMap {
 	my $self = shift;
+	my $old_plot_id = shift;
+	my $new_plot_name = shift;
 	my $error;
 	my $schema = $self->bcs_schema;
-	my $old_plot_id = $self->old_plot_id;
-	my $new_plot_name = $self->new_plot_name;
 
 	my $new_plot_name_validator = CXGN::List::Validate->new();
     my $valid_new_plot_name = @{$new_plot_name_validator->validate($schema,'plots',[$new_plot_name])->{'missing'}};
@@ -452,11 +428,11 @@ sub replace_plot_name_fieldMap {
 
 sub replace_trial_stock_fieldMap {
 	my $self = shift;
+	my $new_stock = shift;
+	my $old_stock_id = shift;
 	my $error;
 	my $schema = $self->bcs_schema;
 	my $dbh = $self->bcs_schema->storage->dbh;
-	my $new_stock = $self->new_accession;
-	my $old_stock_id = $self->old_accession_id;
 	my $trial_id = $self->trial_id;
     my $trial_stock_type = $self->trial_stock_type;
 

--- a/lib/CXGN/Trial/FieldMap.pm
+++ b/lib/CXGN/Trial/FieldMap.pm
@@ -370,28 +370,28 @@ sub substitute_accession_fieldmap {
 
 sub replace_plot_accession_fieldMap {
 	my $self = shift;
-	my $new_accession = shift;
-	my $old_accession = shift;
-	my $old_plot_id = shift;
-    my $old_plot_name = shift;
+	my $plot_id = shift;
+	my $accession_id = shift;
+	my $plot_of_type_id = shift;
 	my $error;
 	my $schema = $self->bcs_schema;
 	my $dbh = $self->bcs_schema->storage->dbh;
 
-	print "New Accession: $new_accession, Old Accession: $old_accession, Old Plot Id: $old_plot_id\n";
+	my $stockprop_rs = $schema->resultset("Stock::StockRelationship")->search({
+		subject_id => $plot_id,
+		type_id => $plot_of_type_id
+    });
 
-	my $new_accession_id = $schema->resultset("Stock::Stock")->search({uniquename => $new_accession})->first->stock_id();
-	my $old_accession_id = $schema->resultset("Stock::Stock")->search({uniquename => $old_accession})->first->stock_id();
-  	print "NEWID.....: $new_accession_id and OLDID......: $old_accession_id\n";
-
-	my $h_replace = $dbh->prepare("update stock_relationship set object_id =? where object_id=? and subject_id=?;");
-	$h_replace->execute($new_accession_id,$old_accession_id,$old_plot_id);
-
-    my $h_replace_accessionName_in_plotName = $dbh->prepare("UPDATE stock SET uniquename = regexp_replace('$old_plot_name', '$old_accession', '$new_accession', 'i') where stock_id=?;");
-	$h_replace_accessionName_in_plotName->execute($old_plot_id);
-
-    $h_replace_accessionName_in_plotName = $dbh->prepare("UPDATE stock SET name = regexp_replace('$old_plot_name', '$old_accession', '$new_accession', 'i') where stock_id=?;");
-	$h_replace_accessionName_in_plotName->execute($old_plot_id);
+	if ($stockprop_rs->count == 1) {
+		$stockprop_rs->update({
+			object_id => $accession_id,
+		});
+	}
+	elsif ($stockprop_rs->count > 1) {
+		$error = "There should only be one accession linked to the plot via plot_of\n";
+	} else {
+		$error = "Plot entry does not exist in database.\n";
+	}
 
     $self->_regenerate_trial_layout_cache();
 
@@ -401,7 +401,7 @@ sub replace_plot_accession_fieldMap {
 
 sub replace_plot_name_fieldMap {
 	my $self = shift;
-	my $old_plot_id = shift;
+	my $plot_id = shift;
 	my $new_plot_name = shift;
 	my $error;
 	my $schema = $self->bcs_schema;
@@ -409,11 +409,11 @@ sub replace_plot_name_fieldMap {
 	my $new_plot_name_validator = CXGN::List::Validate->new();
     my $valid_new_plot_name = @{$new_plot_name_validator->validate($schema,'plots',[$new_plot_name])->{'missing'}};
     if (!$valid_new_plot_name) {
-		$error = "Plot name $new_plot_name already exists in the database";
+		$error .= "Plot name $new_plot_name already exists in the database";
     } else {
 		my $plot_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
 		my $stock_rs = $schema->resultset("Stock::Stock")->search({
-                stock_id => $old_plot_id,
+                stock_id => $plot_id,
                 type_id => $plot_type_id,
             });
 		$stock_rs->update({

--- a/lib/CXGN/Trial/ParseUpload.pm
+++ b/lib/CXGN/Trial/ParseUpload.pm
@@ -17,7 +17,7 @@ has 'chado_schema' => (
 has 'trial_id' => (
   is => 'ro',
   isa => 'Str',
-  required => 1
+  required => 0
 );
 
 has 'filename' => (

--- a/lib/CXGN/Trial/ParseUpload.pm
+++ b/lib/CXGN/Trial/ParseUpload.pm
@@ -14,6 +14,12 @@ has 'chado_schema' => (
     required => 1
 );
 
+has 'trial_id' => (
+  is => 'ro',
+  isa => 'Str',
+  required => 1
+);
+
 has 'filename' => (
     is => 'ro',
     isa => 'Str',

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessionsCSV.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessionsCSV.pm
@@ -80,7 +80,7 @@ sub _validate_with_plugin {
 
     if (scalar(@plots_missing) > 0) {
         $errors{'missing_plots'} = \@plots_missing;
-        push @error_messages, "The following plots are not in the database as uniquenames or synonyms: ".join(',',@plots_missing);
+        push @error_messages, "The following plots are not in the database as uniquenames or synonyms:<br>".join(", ",@plots_missing)."<br>";
     }
 
     my @accessions = keys %seen_accession_names;
@@ -89,7 +89,7 @@ sub _validate_with_plugin {
 
     if (scalar(@accessions_missing) > 0) {
         $errors{'missing_stocks'} = \@accessions_missing;
-        push @error_messages, "The following accessions are not in the database as uniquenames or synonyms: ".join(',',@accessions_missing);
+        push @error_messages, "The following accessions are not in the database as uniquenames or synonyms:<br>".join(", ",@accessions_missing)."<br>";
     }
 
     if (keys %seen_new_plot_names) {
@@ -104,7 +104,7 @@ sub _validate_with_plugin {
                 }  
             }
             $errors{'not_valid_names'} = \@not_valid_names;
-            push @error_messages, "The following new plot names already exist in the database.: ".join(',', @not_valid_names);
+            push @error_messages, "The following new plot names already exist in the database:<br>".join(", ", @not_valid_names)."<br>";
         }
     }
 

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessionsCSV.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessionsCSV.pm
@@ -15,17 +15,19 @@ sub _validate_with_plugin {
     my $trial_id = $self->get_trial_id();
     my @error_messages;
     my %errors;
-    my %parse_result;
+    my %parse_errors;
 
     my $csv = Text::CSV->new({ sep_char => ',' });
 
     open(my $fh, '<', $filename)
-        or die "Could not open file '$filename' $!";
+        or die "Could not open file '$filename' $!"."<br>";
 
     if (!$fh) {
-        $parse_result{'error'} = "Could not read file.";
+        push @error_messages, "Could not read file."."<br>";
         print STDERR "Could not read file.\n";
-        return \%parse_result;
+        $parse_errors{'error_messages'} = \@error_messages;
+        $self->_set_parse_errors(\%parse_errors);
+        return;
     }
 
     my $header_row = <$fh>;
@@ -33,18 +35,22 @@ sub _validate_with_plugin {
     if ($csv->parse($header_row)) {
         @columns = $csv->fields();
     } else {
-        $parse_result{'error'} = "Could not parse header row.";
+        push @error_messages, "Could not parse header row."."<br>";
         print STDERR "Could not parse header.\n";
-        return \%parse_result;
+        $parse_errors{'error_messages'} = \@error_messages;
+        $self->_set_parse_errors(\%parse_errors);
+        return;
     }
 
     my $num_cols = scalar(@columns);
 
-    if ( $columns[0] ne "plot_name" &&
+    if ( $columns[0] ne "plot_name" ||
         $columns[1] ne "accession_name" ) {
-            $parse_result{'error'} = 'File contents incorrect. Header row must contain:  "plot_name","accession_name"';
+            push @error_messages, 'File contents incorrect. Header row must contain:  "plot_name","accession_name"'."<br>";
             print STDERR "File contents incorrect.\n";
-            return \%parse_result;
+            $parse_errors{'error_messages'} = \@error_messages;
+            $self->_set_parse_errors(\%parse_errors);
+            return;
     }
 
     my %seen_plot_names;
@@ -55,15 +61,15 @@ sub _validate_with_plugin {
         if ($csv->parse($row)) {
             @columns = $csv->fields();
         } else {
-            $parse_result{'error'} = "Could not parse row $row.";
+            push @error_messages, "Could not parse row $row."."<br>";
             print STDERR "Could not parse row $row.\n";
-            return \%parse_result;
+            return;
         }
 
         if (scalar(@columns) != $num_cols){
-            $parse_result{'error'} = 'All lines must have same number of columns as header! Error on row: '.$row;
+            push @error_messages, "All lines must have same number of columns as header! Error on row: $row"."<br>";
             print STDERR "Line $row does not have complete columns.\n";
-            return \%parse_result;
+            return;
         }
 
         $seen_plot_names{$columns[0]}++;
@@ -72,6 +78,10 @@ sub _validate_with_plugin {
             $seen_new_plot_names{$columns[2]}++;
         }
     }
+    if (@error_messages) {
+        $parse_errors{'error_messages'} = \@error_messages;
+        $self->_set_parse_errors(\%parse_errors);
+    }
     close($fh);
 
     my @plots = keys %seen_plot_names;
@@ -79,7 +89,6 @@ sub _validate_with_plugin {
     my @plots_missing = @{$plots_validator->validate($schema,'plots',\@plots)->{'missing'}};
 
     if (scalar(@plots_missing) > 0) {
-        $errors{'missing_plots'} = \@plots_missing;
         push @error_messages, "The following plots are not in the database as uniquenames or synonyms:<br>".join(", ",@plots_missing)."<br>";
     }
 
@@ -88,7 +97,6 @@ sub _validate_with_plugin {
     my @accessions_missing = @{$accession_validator->validate($schema,'accessions',\@accessions)->{'missing'}};
 
     if (scalar(@accessions_missing) > 0) {
-        $errors{'missing_stocks'} = \@accessions_missing;
         push @error_messages, "The following accessions are not in the database as uniquenames or synonyms:<br>".join(", ",@accessions_missing)."<br>";
     }
 
@@ -114,7 +122,6 @@ sub _validate_with_plugin {
     }
 
     if (@not_valid_names) {
-        $errors{'not_valid_names'} = \@not_valid_names;
         push @error_messages, "The following new plot names already exist in the database:<br>".join(", ", @not_valid_names)."<br>";
     }
     
@@ -146,6 +153,11 @@ sub _validate_with_plugin {
                 $validation = 1;
             }
         }
+        for (@plots_missing) {
+            if ($current_name == $_) {
+                $validation = 1;
+            }
+        }
         if (!$validation) {
             push @plots_in_different_trial, $current_name;
         }
@@ -153,7 +165,6 @@ sub _validate_with_plugin {
     }
 
     if (@plots_in_different_trial) {
-        $errors{'not_valid_names'} = \@plots_in_different_trial;
         push @error_messages, "The following plot names belong to a different trial:<br>".join(", ", @plots_in_different_trial)."<br>";
     }
 

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessionsCSV.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessionsCSV.pm
@@ -49,6 +49,7 @@ sub _validate_with_plugin {
 
     my %seen_plot_names;
     my %seen_accession_names;
+    my %seen_new_plot_names;
     while ( my $row = <$fh> ){
         my @columns;
         if ($csv->parse($row)) {
@@ -67,6 +68,9 @@ sub _validate_with_plugin {
 
         $seen_plot_names{$columns[0]}++;
         $seen_accession_names{$columns[1]}++;
+        if ($columns[2]) {
+            $seen_new_plot_names{$columns[2]}++;
+        }
     }
     close($fh);
 
@@ -87,6 +91,30 @@ sub _validate_with_plugin {
         $errors{'missing_stocks'} = \@accessions_missing;
         push @error_messages, "The following accessions are not in the database as uniquenames or synonyms: ".join(',',@accessions_missing);
     }
+
+    if (keys %seen_new_plot_names) {
+        my @new_plot_names = keys %seen_new_plot_names;
+        my $new_plot_name_validator = CXGN::List::Validate->new();
+        my @valid_new_plot_names = @{$new_plot_name_validator->validate($schema,'plots',\@new_plot_names)->{'missing'}};
+        my @not_valid_names;
+        if (scalar(@valid_new_plot_names) != scalar(@new_plot_names)) {
+            for (@new_plot_names) {
+                if (!exists($valid_new_plot_names[$_])) {
+                    push @not_valid_names, $_;
+                }  
+            }
+            $errors{'not_valid_names'} = \@not_valid_names;
+            push @error_messages, "The following new plot names already exist in the database.: ".join(',', @not_valid_names);
+        }
+    }
+
+    if (scalar(@error_messages) >= 1) {
+        $errors{'error_messages'} = \@error_messages;
+        $self->_set_parse_errors(\%errors);
+        return;
+    }
+
+
 
     return 1; #returns true if validation is passed
 }
@@ -113,9 +141,14 @@ sub _parse_with_plugin {
         }
         my $plot_name = $columns[0];
         my $accession_name = $columns[1];
+        my $new_plot_name;
+        if ($columns[2]) {
+            $new_plot_name = $columns[2];
+        }
         $parsed_entries{$counter} = {
             plot_name => $plot_name,
-            accession_name => $accession_name
+            accession_name => $accession_name,
+            new_plot_name => $new_plot_name
         };
         $counter++;
     }

--- a/lib/SGN/Controller/AJAX/Trial.pm
+++ b/lib/SGN/Controller/AJAX/Trial.pm
@@ -948,7 +948,7 @@ sub upload_trial_file_POST : Args(0) {
             #print STDERR Dumper $parse_errors;
 
             foreach my $error_string (@{$parse_errors->{'error_messages'}}){
-                $return_error=$return_error.$error_string."<br>";
+                $return_error .= $error_string."<br>";
             }
         }
 

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -1188,12 +1188,11 @@ sub trial_change_plot_accessions_upload : Chained('trial') PathPart('change_plot
         } else {
             $parse_errors = $parser->get_parse_errors();
             #print STDERR Dumper $parse_errors;
-
             foreach my $error_string (@{$parse_errors->{'error_messages'}}){
                 $return_error .= $error_string."<br>";
             }
         }
-        $c->stash->{rest} = {error => $return_error, missing_plots => $parse_errors->{'missing_plots'}, missing_accessions => $parse_errors->{'missing_stocks'}, invalid_new_plot_name => $parse_errors->{'not_valid_names'}};
+        $c->stash->{rest} = {error => $return_error};
         return;
     }
 
@@ -1263,14 +1262,16 @@ sub trial_change_plot_accessions_upload : Chained('trial') PathPart('change_plot
                 type_id => $plot_of_type_id
             });
 
-            my $stock_rs = $schema->resultset("Stock::Stock")->search({
-                stock_id => $plot_id,
-                type_id => $plot_type_id
-            });
+            if ($new_plot_name) {
+                my $stock_rs = $schema->resultset("Stock::Stock")->search({
+                    stock_id => $plot_id,
+                    type_id => $plot_type_id
+                });
 
-            $stock_rs->update({
-                uniquename => $new_plot_name 
-            });
+                $stock_rs->update({
+                    uniquename => $new_plot_name 
+                });
+            }
 
         }
 
@@ -1774,8 +1775,6 @@ sub replace_trial_stock : Chained('trial') PathPart('replace_stock') Args(0) {
   my $replace_stock_fieldmap = CXGN::Trial::FieldMap->new({
     bcs_schema => $schema,
     trial_id => $trial_id,
-    old_accession_id => $old_stock_id,
-    new_accession => $new_stock,
     trial_stock_type => $trial_stock_type,
 
   });
@@ -1786,7 +1785,7 @@ sub replace_trial_stock : Chained('trial') PathPart('replace_stock') Args(0) {
        return;
      }
 
-  my $replace_return_error = $replace_stock_fieldmap->replace_trial_stock_fieldMap();
+  my $replace_return_error = $replace_stock_fieldmap->replace_trial_stock_fieldMap($new_stock, $old_stock_id);
   if ($replace_return_error) {
     $c->stash->{rest} = { error => $replace_return_error };
     return;
@@ -1796,42 +1795,36 @@ sub replace_trial_stock : Chained('trial') PathPart('replace_stock') Args(0) {
 }
 
 sub replace_plot_accession : Chained('trial') PathPart('replace_plot_accessions') Args(0) {
-  my $self = shift;
-  my $c = shift;
-  my $schema = $c->dbic_schema('Bio::Chado::Schema');
-  my $old_accession = $c->req->param('old_accession');
-  my $new_accession = $c->req->param('new_accession');
-  my $old_plot_id = $c->req->param('old_plot_id');
-  my $old_plot_name = $c->req->param('old_plot_name');
-  my $new_plot_name = $c->req->param('new_plot_name');
-  my $override = $c->req->param('override');
-  my $trial_id = $c->stash->{trial_id};
+    my $self = shift;
+    my $c = shift;
+    my $schema = $c->dbic_schema('Bio::Chado::Schema');
+    my $old_accession = $c->req->param('old_accession');
+    my $new_accession = $c->req->param('new_accession');
+    my $old_plot_id = $c->req->param('old_plot_id');
+    my $old_plot_name = $c->req->param('old_plot_name');
+    my $new_plot_name = $c->req->param('new_plot_name');
+    my $override = $c->req->param('override');
+    my $trial_id = $c->stash->{trial_id};
 
-  if (!$c->user){
-        $c->stash->{rest} = {error=>'You must be logged in to upload this seedlot info!'};
+    if (!$c->user){
+        $c->stash->{rest} = {error=>'You must be logged in to change a plot accession!'};
         return;
     }
 
-  if ($self->privileges_denied($c)) {
-    $c->stash->{rest} = { error => "You have insufficient access privileges to edit this map." };
+    if ($self->privileges_denied($c)) {
+        $c->stash->{rest} = { error => "You have insufficient access privileges to edit this map." };
     return;
-  }
+    }
 
-  if (!$new_accession){
-    $c->stash->{rest} = { error => "Provide new accession name." };
+    if (!$new_accession) {
+        $c->stash->{rest} = { error => "Provide new accession name." };
     return;
-  }
+    }
 
-  my $replace_plot_accession_fieldmap = CXGN::Trial::FieldMap->new({
-    trial_id => $trial_id,
-    bcs_schema => $schema,
-    new_accession => $new_accession,
-    old_accession => $old_accession,
-    old_plot_id => $old_plot_id,
-    old_plot_name => $old_plot_name,
-    new_plot_name => $new_plot_name,
-
-  });
+    my $replace_plot_accession_fieldmap = CXGN::Trial::FieldMap->new({
+        trial_id => $trial_id,
+        bcs_schema => $schema,
+    });
 
     my $return_error = $replace_plot_accession_fieldmap->update_fieldmap_precheck();
     if ($c->user()->check_roles("curator") and $return_error) {
@@ -1844,21 +1837,24 @@ sub replace_plot_accession : Chained('trial') PathPart('replace_plot_accessions'
         return;
     }
 
-  print "Calling Replace Function...............\n";
-  my $replace_return_error = $replace_plot_accession_fieldmap->replace_plot_accession_fieldMap();
-  if ($replace_return_error) {
-    $c->stash->{rest} = { error => $replace_return_error };
-    return;
-  }
 
-  my $replace_plot_name_return_error = $replace_plot_accession_fieldmap->replace_plot_name_fieldMap();
-  if ($replace_plot_name_return_error) {
-    $c->stash->{rest} = { error => $replace_plot_name_return_error };
-    return;
-  }
-  
-  print "OldAccession: $old_accession, NewAcc: $new_accession, OldPlotName: $old_plot_name, NewPlotName: $new_plot_name OldPlotId: $old_plot_id\n";
-  $c->stash->{rest} = { success => 1};
+    print "Calling Replace Function...............\n";
+    my $replace_return_error = $replace_plot_accession_fieldmap->replace_plot_accession_fieldMap($new_accession, $old_accession, $old_plot_id, $old_plot_name);
+    if ($replace_return_error) {
+        $c->stash->{rest} = { error => $replace_return_error };
+        return;
+    }
+
+    if ($new_plot_name) {
+        my $replace_plot_name_return_error = $replace_plot_accession_fieldmap->replace_plot_name_fieldMap($old_plot_id, $new_plot_name);
+        if ($replace_plot_name_return_error) {
+            $c->stash->{rest} = { error => $replace_plot_name_return_error };
+            return;
+        }
+    }
+    
+    print "OldAccession: $old_accession, NewAcc: $new_accession, OldPlotName: $old_plot_name, NewPlotName: $new_plot_name OldPlotId: $old_plot_id\n";
+    $c->stash->{rest} = { success => 1};
 }
 
 sub replace_well_accession : Chained('trial') PathPart('replace_well_accessions') Args(0) {

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -1174,11 +1174,11 @@ sub trial_change_plot_accessions_upload : Chained('trial') PathPart('change_plot
         $c->detach();
     }
     unlink $upload_tempfile;
-    my $parser = CXGN::Trial::ParseUpload->new(chado_schema => $schema, filename => $archived_filename_with_path);
+    my $parser = CXGN::Trial::ParseUpload->new(chado_schema => $schema, filename => $archived_filename_with_path, trial_id => $trial_id);
     $parser->load_plugin('TrialChangePlotAccessionsCSV');
     my $parsed_data = $parser->parse();
     #print STDERR Dumper $parsed_data;
-
+        
     if (!$parsed_data) {
         my $return_error = '';
         my $parse_errors;
@@ -1267,7 +1267,6 @@ sub trial_change_plot_accessions_upload : Chained('trial') PathPart('change_plot
                 stock_id => $plot_id,
                 type_id => $plot_type_id
             });
-
 
             $stock_rs->update({
                 uniquename => $new_plot_name 

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -1803,6 +1803,7 @@ sub replace_plot_accession : Chained('trial') PathPart('replace_plot_accessions'
   my $new_accession = $c->req->param('new_accession');
   my $old_plot_id = $c->req->param('old_plot_id');
   my $old_plot_name = $c->req->param('old_plot_name');
+  my $new_plot_name = $c->req->param('new_plot_name');
   my $override = $c->req->param('override');
   my $trial_id = $c->stash->{trial_id};
 
@@ -1828,6 +1829,7 @@ sub replace_plot_accession : Chained('trial') PathPart('replace_plot_accessions'
     old_accession => $old_accession,
     old_plot_id => $old_plot_id,
     old_plot_name => $old_plot_name,
+    new_plot_name => $new_plot_name,
 
   });
 
@@ -1849,7 +1851,13 @@ sub replace_plot_accession : Chained('trial') PathPart('replace_plot_accessions'
     return;
   }
 
-  print "OldAccession: $old_accession, NewAcc: $new_accession, OldPlotId: $old_plot_id\n";
+  my $replace_plot_name_return_error = $replace_plot_accession_fieldmap->replace_plot_name_fieldMap();
+  if ($replace_plot_name_return_error) {
+    $c->stash->{rest} = { error => $replace_plot_name_return_error };
+    return;
+  }
+  
+  print "OldAccession: $old_accession, NewAcc: $new_accession, OldPlotName: $old_plot_name, NewPlotName: $new_plot_name OldPlotId: $old_plot_id\n";
   $c->stash->{rest} = { success => 1};
 }
 

--- a/mason/breeders_toolbox/trial/change_plot_accessions_dialogs.mas
+++ b/mason/breeders_toolbox/trial/change_plot_accessions_dialogs.mas
@@ -22,13 +22,15 @@ $trial_id
                         <div class="panel panel-default">
                             <div class="panel-body">
                                 <b>Header:</b><br>
-                                The first row (header) must contain the following:
+                                The first row (header) must contain the columns 'plot_name' and 'accession_name'.<br>
+                                An optional additional column, 'new_plot_name' can be added to change the plot names:<br>
 
-                                <table class="table table-bordered table-hover">
+                                <table style="margin-top: 3%;" class="table table-bordered table-hover">
                                   <tbody>
                                   <tr>
                                     <td>plot_name</td>
                                     <td>accession_name</td>
+                                    <td>new_plot_name (optional)</td>
                                   </tr>
                                   </tbody>
                                 </table>
@@ -37,6 +39,8 @@ $trial_id
                         <b>Required columns:</b><br>
                         <b>plot_name:</b> name of plot to change the accession for<br>
                         <b>accession_name:</b> name of the accession that the plot should be connected to.<br>
+                        <br><b>Optional column:</b><br>
+                        <b>new_plot_name:</b> new name for plot.<br>
                     </div>
 
                     <form class="form-horizontal" method="post" enctype="multipart/form-data" encoding="multipart/form-data" id="trial_design_change_accessions_form" name="trial_design_change_accessions_form">

--- a/mason/breeders_toolbox/trial/change_plot_accessions_dialogs.mas
+++ b/mason/breeders_toolbox/trial/change_plot_accessions_dialogs.mas
@@ -107,7 +107,7 @@ $trial_id
                 </div>
             </div>
             <div class="modal-footer">
-                <button id="close_tdfieldmap_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button id="close_replace_accession_dialog" type="button" onclick=location.reload() class="btn btn-default" data-dismiss="modal">Close</button>
             </div>
         </div>
     </div>

--- a/mason/breeders_toolbox/trial/change_plot_accessions_dialogs.mas
+++ b/mason/breeders_toolbox/trial/change_plot_accessions_dialogs.mas
@@ -108,11 +108,38 @@ $trial_id
             </div>
             <div class="modal-footer">
                 <button id="close_tdfieldmap_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<div class="modal  fade" id="change_accession_error_dialog" name="change_accession_error_dialog" tabindex="-1" role="dialog">
+    <div class="modal-dialog " role="document">
+        <div class="modal-content">
+            <div class="modal-header" style="text-align: center">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="change_accsn_err_dialog"><b>Error Changing Plot Accessions</b></h4>
+            </div>
+            <div class="modal-body">
+                <div class="container-fluid">
+                    <p3> Accessions were not changed due to these errors:</p3><br><br>
+                    <div style="background-color: light-gray;" class="well well-sm">
+                        <table>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="close_error_change_accsn" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
 
             </div>
         </div>
     </div>
 </div>
+
+
 
 <script>
 
@@ -144,12 +171,13 @@ jQuery(document).ready(function () {
         },
         complete: function (response) {
             jQuery('#working_modal').modal("hide");
-            console.log(response);
             if (response.warning) {
                 jQuery('#trial_design_change_accessions_dialog').modal("hide");
                 jQuery('#td_replace_accession_curator_warning_message').modal("show");
             } else if (response.error) {
-                alert(response.error);
+                jQuery('#change_accession_error_dialog').modal("show");
+                jQuery('#change_accession_error_dialog tbody').html(response.error);
+                return;
             }
             else {
 	            jQuery('#trial_design_change_accessions_dialog').modal("hide");

--- a/mason/breeders_toolbox/trial/change_plot_accessions_dialogs.mas
+++ b/mason/breeders_toolbox/trial/change_plot_accessions_dialogs.mas
@@ -177,7 +177,6 @@ jQuery(document).ready(function () {
             } else if (response.error) {
                 jQuery('#change_accession_error_dialog').modal("show");
                 jQuery('#change_accession_error_dialog tbody').html(response.error);
-                return;
             }
             else {
 	            jQuery('#trial_design_change_accessions_dialog').modal("hide");

--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -296,7 +296,6 @@ $data_level => 'plot'
                       <div class="form-group">
                         <label class="col-sm-3 control-label">Plot Name: </label>
                         <div class="col-sm-9" id="hm_edit_plot_name">
-
                         </div>
                       </div>
 
@@ -323,6 +322,13 @@ $data_level => 'plot'
                         <label class="col-sm-3 control-label">Enter New Accession: </label>
                         <div class="col-sm-9" >
                           <input class="form-control" id="hm_accession" name="hm_accession"></input>
+                        </div>
+                      </div>
+
+                      <div class="form-group">
+                        <label class="col-sm-3 control-label">New Plot Name:<br> (Optional) </label>
+                        <div class="col-sm-9">
+                          <input class="form-control" id="hm_new_plot_name" name="hm_new_plot_name"></input>
                         </div>
                       </div>
 
@@ -447,7 +453,7 @@ jQuery(document).ready( function() {
             type: 'POST',
             url: '/brapi/v1/phenotypes-search',
             data: {
-                'observationLevel':'<% $data_level %>',
+                'observationLevel':value,
                 'studyDbId':trial_id,
                 'observationVariableDbId':selectedTrait,
                 'pageSize':1000,
@@ -458,7 +464,6 @@ jQuery(document).ready( function() {
                 jQuery("#working_modal").modal("show");
             },
             success: function(response) {
-                console.log(response);
                 var data = response.result.data; 
                 var datasort = data.sort(function(obj1, obj2) {
 	                  // Ascending: first plotNumber less than the previous
@@ -519,7 +524,7 @@ jQuery(document).ready( function() {
                         if (key == 'designType'){
                             design = value;
                         }
-                        if (key == 'observations'){
+                        if (key == 'observations' && value){
                             var valueObs = value[0];
                            pheno_ids.push(valueObs.observationDbId);
                            trait_ids.push(valueObs.observationVariableDbId);
@@ -812,12 +817,11 @@ jQuery(document).ready( function() {
              },
              success: function(response) {
                 var data = response.result.data;
-                console.log(data);
                 var data = data.sort(function(obj1, obj2) {
 	                  // Ascending: first plotNumber less than the previous
 	                return obj1.additionalInfo.plotNumber - obj2.additionalInfo.plotNumber;
                 });
-                console.log(data);
+                // console.log(data);
                 var rows = [];
                 var cols = [];
                 var blocks = [];
@@ -1370,6 +1374,7 @@ jQuery(document).ready( function() {
       jQuery('#working_modal').modal("show");
 
       var new_accession = jQuery('#hm_accession').val();
+      var new_plot_name = jQuery('#hm_new_plot_name').val();
       var old_accession = jQuery('#hm_edit_plot_accession').html();
       var old_plot_id = jQuery('#hm_edit_plot_id').html();
       var old_plot_name = jQuery('#hm_edit_plot_name').html();
@@ -1380,6 +1385,7 @@ jQuery(document).ready( function() {
         dataType: "json",
         data: {
                 'new_accession': new_accession,
+                'new_plot_name': new_plot_name,
                 'old_accession': old_accession,
                 'old_plot_id': old_plot_id,
                 'old_plot_name': old_plot_name,

--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -360,7 +360,7 @@ $data_level => 'plot'
                 </div>
             </div>
             <div class="modal-footer">
-                <button id="close_hmfieldma_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button id="close_replace_accession_dialog" type="button" class="btn btn-default" onclick=location.reload() data-dismiss="modal">Close</button>
 
             </div>
         </div>

--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -453,7 +453,7 @@ jQuery(document).ready( function() {
             type: 'POST',
             url: '/brapi/v1/phenotypes-search',
             data: {
-                'observationLevel':value,
+                'observationLevel':'<% $data_level %>',
                 'studyDbId':trial_id,
                 'observationVariableDbId':selectedTrait,
                 'pageSize':1000,
@@ -524,7 +524,7 @@ jQuery(document).ready( function() {
                         if (key == 'designType'){
                             design = value;
                         }
-                        if (key == 'observations' && value){
+                        if (key == 'observations'){
                             var valueObs = value[0];
                            pheno_ids.push(valueObs.observationDbId);
                            trait_ids.push(valueObs.observationVariableDbId);

--- a/t/unit_fixture/CXGN/Trial/EditFieldMap.t
+++ b/t/unit_fixture/CXGN/Trial/EditFieldMap.t
@@ -19,6 +19,7 @@ ok(my $chado_schema = $fix->bcs_schema);
 ok(my $phenome_schema = $fix->phenome_schema);
 ok(my $dbh = $fix->dbh);
 
+$chado_schema->txn_begin();
 # create a location for the trial
 ok(my $trial_location = "test_location_for_trial");
 ok(my $location = $chado_schema->resultset('NaturalDiversity::NdGeolocation')
@@ -153,7 +154,7 @@ ok(my $plot_1_id = $data[0]->[0][0]);
 ok(my $plot_2_id = $data[0]->[1][0]);
 ok(my $accession_1 = "test_stock_for_fieldmap_trial1");
 ok(my $accession_2 = "test_stock_for_fieldmap_trial2");
-
+$chado_schema->txn_rollback();
 # my $fieldmap = CXGN::Trial::FieldMap->new({
 #   bcs_schema => $chado_schema,
 #   trial_id => $trial_id,

--- a/t/unit_fixture/CXGN/Trial/EditFieldMap.t
+++ b/t/unit_fixture/CXGN/Trial/EditFieldMap.t
@@ -127,7 +127,7 @@ my $replace_accession_fieldmap = CXGN::Trial::FieldMap->new({
   old_accession_id => $stock_id,
   new_accession => $new_accession,
 });
-ok(!$replace_accession_fieldmap->replace_trial_stock_fieldMap(), "replace trial accession");
+ok(!$replace_accession_fieldmap->replace_trial_stock_fieldMap($new_accession, $stock_id), "replace trial accession");
 
 
 my $trial = CXGN::Trial->new( {
@@ -139,32 +139,30 @@ my $trial = CXGN::Trial->new( {
 ok(my @data = $trial->get_plots(), "get plots");
 ok(my $old_plot_id = $data[0]->[0][0]);
 print STDERR Dumper($old_plot_id);
+my $plot_of_type_id = SGN::Model::Cvterm->get_cvterm_row($chado_schema, 'plot_of', 'stock_relationship')->cvterm_id();
+my $accession_id = $chado_schema->resultset('Stock::Stock')->find({'uniquename' => $new_accession})->stock_id(), "get stock id";
 
 my $replace_plot_accession_fieldmap = CXGN::Trial::FieldMap->new({
   bcs_schema => $chado_schema,
   trial_id => $trial_id,
-  new_accession => $new_accession,
-  old_accession => $old_accession,
-  old_plot_id => $old_plot_id,
 
 });
-ok(!$replace_plot_accession_fieldmap->replace_plot_accession_fieldMap(), "replace plot accession");
-
+ok(!$replace_plot_accession_fieldmap->replace_plot_accession_fieldMap($old_plot_id, $accession_id, $plot_of_type_id), "replace plot accession");
 # accessions substitution
 ok(my $plot_1_id = $data[0]->[0][0]);
 ok(my $plot_2_id = $data[0]->[1][0]);
 ok(my $accession_1 = "test_stock_for_fieldmap_trial1");
 ok(my $accession_2 = "test_stock_for_fieldmap_trial2");
 
-my $fieldmap = CXGN::Trial::FieldMap->new({
-  bcs_schema => $chado_schema,
-  trial_id => $trial_id,
-  first_plot_selected => $plot_1_id,
-  second_plot_selected => $plot_2_id,
-  first_accession_selected => $accession_1,
-  second_accession_selected => $accession_2,
-});
+# my $fieldmap = CXGN::Trial::FieldMap->new({
+#   bcs_schema => $chado_schema,
+#   trial_id => $trial_id,
+#   first_plot_selected => $plot_1_id,
+#   second_plot_selected => $plot_2_id,
+#   first_accession_selected => $accession_1,
+#   second_accession_selected => $accession_2,
+# });
 
-ok(!$fieldmap->substitute_accession_fieldmap(), "substituting plots accessions");
+# ok(!$fieldmap->substitute_accession_fieldmap(), "substituting plots accessions");
 
 done_testing();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Resolves  #3649 by implementing new option to change plot name on replace accession features. Additional error handling added for new plot name and for existing plot name.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
