### PR TITLE
overwrite unwanted agricolae plot numbers with correct pattern

### DIFF
--- a/lib/CXGN/Trial/TrialDesign/Plugin/RCBD.pm
+++ b/lib/CXGN/Trial/TrialDesign/Plugin/RCBD.pm
@@ -86,6 +86,9 @@ sub create_design {
     $r_block->add_command('rcbd<-design.rcbd(trt,number_of_blocks,serie='.$serie.',kinds=randomization_method)');
   }
   $r_block->add_command('rcbd<-rcbd$book'); #added for agricolae 1.1-8 changes in output
+  if($plot_start == 1){ #Use row numbers as plot names to avoid unwanted agricolae plot num pattern
+    $r_block->add_command('rcbd$plots <- row.names(rcbd)');
+  }
   $r_block->add_command('rcbd<-as.matrix(rcbd)');
   $r_block->run_block();
   $result_matrix = R::YapRI::Data::Matrix->read_rbase( $rbase,'r_block','rcbd');


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Like breedbase agricolae creates trial designs with 3 plot numbering options, but they don't match up exactly. Argricolae has no option to start plot numbering at 1, so the easiest way to do that in breedbase is use the row names. 

<!-- If there are relevant issues, link them here: -->
closes #3673

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
