### PR TITLE
Allow Lists of Seedlots in Search Wizard

### DIFF
--- a/js/source/entries/wizard.js
+++ b/js/source/entries/wizard.js
@@ -40,6 +40,8 @@ function makeURL(target,id){
     case "accessions":
     case "plants":
     case "plots":
+      return document.location.origin+`/stock/${id}/view`;
+      break;
     case "seedlots":
       return document.location.origin+`/breeders/seedlot/${id}`;
       break;

--- a/js/source/entries/wizard.js
+++ b/js/source/entries/wizard.js
@@ -41,7 +41,7 @@ function makeURL(target,id){
     case "plants":
     case "plots":
     case "seedlots":
-      return document.location.origin+`/stock/${id}/view`;
+      return document.location.origin+`/breeders/seedlot/${id}`;
       break;
     case "breeding_programs":
       return document.location.origin+`/breeders/manage_programs`;

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -1214,8 +1214,11 @@ CXGN.List.prototype = {
             case "plots":
                 new_type = 'plots_2_plot_ids';
                 break;
+            case "seedlots":
+                new_type = 'stocks_2_stock_ids';
+                break;
             default:
-            return { 'error' : "cannot convert the list because of unknown type" };
+                return { 'error' : "cannot convert the list because of unknown type" };
         }
         //if (window.console) console.log("new type = "+new_type);
         var transformed = this.transform(list_id, new_type);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Previously, if a List of Seedlots was selected in the Search Wizard, nothing would be displayed.  This PR allows Lists of Seedlots to be selected in the Search Wizard by supporting `seedlot` as a list type in the `CXGN/List.js` `transform2Ids()` function.

It also updates the URL for a Seedlot item to use the specific Seedlot detail page (instead of the general Stock detail page).

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
