### PR TITLE
Label Designer: add options for start col and row

### DIFF
--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -1337,6 +1337,8 @@ function retrievePageParams() {
         label_format: label,
         label_width: label_sizes[label].label_width,
         label_height: label_sizes[label].label_height,
+        start_col: document.getElementById("start_col").value,
+        start_row: document.getElementById("start_row").value,
     }
     return page_params;
 

--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -151,8 +151,8 @@ __PACKAGE__->config(
        my ($FH, $filename) = $c->tempfile(TEMPLATE=>"labels/$file_prefix-XXXXX", SUFFIX=>".$download_type");
 
        # initialize loop variables
-       my $col_num = 1;
-       my $row_num = 1;
+       my $col_num = $design_params->{'start_col'} || 1;
+       my $row_num = $design_params->{'start_row'} || 1;
        my $key_number = 0;
        my $sort_order = $design_params->{'sort_order'};
 

--- a/mason/tools/label_designer/label_designer_modals.mas
+++ b/mason/tools/label_designer/label_designer_modals.mas
@@ -84,13 +84,13 @@
                     <div class="col-md-1"></div>
                     <div class="col-md-5">
                         <center>
-                            <label>Horizontal Gap:</label><br>
+                            <br><label>Horizontal Gap:</label><br>
                             <input class="form-control" placeholder="Horizontal Gap in pixels (72/inch)" type="number" id="horizontal_gap" style="max-width: 100%;">
                         </center>
                     </div>
                     <div class="col-md-5">
                         <center>
-                            <label>Vertical Gap:</label><br>
+                            <br><label>Vertical Gap:</label><br>
                             <input class="form-control" placeholder="Vertical Gap in pixels (72/inch)" type="number" id="vertical_gap" style="max-width: 100%;">
                         </center>
                     </div>
@@ -100,50 +100,73 @@
                     <div class="col-md-1"></div>
                     <div class="col-md-5">
                         <center>
-                            <br><label>Number of Columns:</label><br>
+                            <br><label>Number of Columns:</label>
                             <input class="form-control" placeholder="Num labels across" type="number" id="number_of_columns" style="max-width: 100%;">
                         </center>
                     </div>
                     <div class="col-md-5">
                         <center>
-                            <br><label>Number of Rows:</label><br>
+                            <br><label>Number of Rows:</label>
                             <input class="form-control" placeholder="Num labels down" type="number" id="number_of_rows" style="max-width: 100%;">
                         </center>
                     </div>
                     <div class="col-md-1"></div>
                 </div>
-                <div class="col-md-12 form-inline">
+                <div class="col-md-12">
                     <div class="col-md-1"></div>
                     <div class="col-md-5">
                         <center>
                         <br><label>Sort Labels by:</label>
                             <select class="form-control" id="sort_order" name="sort_by" style="max-width: 100%">
-                            </select><br>
+                            </select>
                         </center>
                     </div>
-                    <div class="col-md-1"></div>
-                    <div class="col-md-4">
+                    <div class="col-md-5">
                         <center>
                         <br><label>Limit by Rep:</label>
                             <select class="form-control" id="plot_filter" name="plot_filter" style="max-width: 100%">
-                            </select><br>
+                            </select>
                         </center>
                     </div>
                     <div class="col-md-1"></div>
                 </div>
-                <div class="col-md-12 form-inline" id="">
+                <div class="col-md-12">
                     <div class="col-md-1"></div>
-                    <div class="col-md-4">
+                    <div class="col-md-5">
                         <center>
                             <br><label>Copies per label:</label>
                             <input class="form-control" id="copies_per_plot" name="copies_per_plot" type="number" value="1" style="max-width: 100%;">
                         </center>
                     </div>
-                    <div class="col-md-1"></div>
-                    <div class="col-md-4">
+                    <div class="col-md-5">
                         <center>
                             <br><label>Total # to download:</label>
                             <input class="form-control" id="label_designer_labels_to_download" name="label_designer_labels_to_download" type="number" placeholder="10" style="max-width: 100%;">
+                        </center>
+                    </div>
+                    <div class="col-md-1"></div>
+                </div>
+                <div class="col-md-12">
+                    <div class="col-md-1"></div>
+                    <div class="col-md-10">
+                        <br /><br />
+                        <p><strong>Position of First Label:</strong><br />
+                        Set the column and row number of where to print the first label, if using a sheet that has already been partially used</p>
+                    </div>
+                    <div class="col-md-1"></div>
+                </div>
+                <div class="col-md-12">
+                    <div class="col-md-1"></div>
+                    <div class="col-md-5">
+                        <center>
+                            <br><label>Start Column:</label>
+                            <input class="form-control" id="start_col" name="start_col" type="number" value="1" style="max-width: 100%;">
+                        </center>
+                    </div>
+                    <div class="col-md-5">
+                        <center>
+                            <br><label>Start Row:</label>
+                            <input class="form-control" id="start_row" name="start_row" type="number" value="1" style="max-width: 100%;">
                         </center>
                     </div>
                     <div class="col-md-1"></div>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This add options to the Additional Settings of the Label Designer to manually set the column and row positions of the first label -- useful if you want to print labels on a sheet that's been partially used.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
