### PR TITLE
Seedlot Maintenance: minor improvements and fixes

### DIFF
--- a/mason/breeders_toolbox/seedlot_maintenance/record.mas
+++ b/mason/breeders_toolbox/seedlot_maintenance/record.mas
@@ -270,7 +270,7 @@
                 url: '/ajax/breeders/seedlot/maintenance/search',
                 data: JSON.stringify({
                     filters: {
-                        names: [SEEDLOT_NAME], 
+                        names: [{comp: '=', value: SEEDLOT_NAME}],
                         types: [{cvterm_id: cvterm}]
                     }
                 }),

--- a/mason/breeders_toolbox/seedlot_maintenance/record.mas
+++ b/mason/breeders_toolbox/seedlot_maintenance/record.mas
@@ -26,11 +26,14 @@
             <!-- Seedlot Name -->
             <div class="form-group">
                 <label class="col-sm-3 control-label">Name: </label>
-                <div class="col-sm-7">
+                <div class="col-sm-5">
                     <input class="form-control" id="seedlot_event_name" type="text" value="">
                 </div>
                 <div class="col-sm-2">
-                    <button id="seedlot_event_name_barcode" class="btn btn-default"><span class="glyphicon glyphicon-qrcode"></span> Barcode</button>
+                    <button id="seedlot_event_name_update" class="btn btn-block btn-info"><span class="glyphicon glyphicon-refresh"></span> Update</button>
+                </div>
+                <div class="col-sm-2">
+                    <button id="seedlot_event_name_barcode" class="btn btn-block btn-default"><span class="glyphicon glyphicon-qrcode"></span> Barcode</button>
                 </div>
             </div>
 
@@ -108,7 +111,7 @@
             <div class="form-group">
                 <label class="col-sm-3 control-label">Operator: </label>
                 <div class="col-sm-9">
-                    <input class="form-control" id="seedlot_event_operator" type="text" value="<% $operator %>">
+                    <input class="form-control" id="seedlot_event_operator" name="seedlot_event_operator" type="text" value="<% $operator %>">
                 </div>
             </div>
 
@@ -116,7 +119,7 @@
             <div class="form-group">
                 <label class="col-sm-3 control-label">Timestamp: </label>
                 <div class="col-sm-9">
-                    <input class="form-control" id="seedlot_event_timestamp" type="text" value="">
+                    <input class="form-control" id="seedlot_event_timestamp" name="seedlot_event_timestamp" type="text" value="">
                 </div>
             </div>
 
@@ -162,6 +165,7 @@
 
         // Event change / Click listeners
         jQuery('#seedlot_event_name').change(getSeedlotInfo);
+        jQuery('#seedlot_event_name_update').click(getSeedlotInfo);
         jQuery('#seedlot_event_name_barcode').click(scanBarcode);
         jQuery('#seedlot_event_submit').click(submitEvents);
         jQuery('#seedlot_modal_close').click(function() {
@@ -202,7 +206,7 @@
         if ( urlSearchParams.has('seedlot_name') ) {
             let seedlot_name = decodeURIComponent(urlSearchParams.get('seedlot_name'));
             seedlot_name = seedlot_name.includes('seedlot_name=') ? seedlot_name.match(/.*seedlot_name=(.*)/)[1] : seedlot_name;
-            jQuery('#seedlot_event_name').val(seedlot_name);
+            jQuery('input[name="seedlot_event_name"]').val(seedlot_name);
             getSeedlotInfo();
         }
     }
@@ -218,11 +222,15 @@
         let box = "";
         SEEDLOT_NAME = undefined;
         SEEDLOT_ID = undefined;
+
         jQuery.ajax({
             type: 'GET',
             dataType: 'json',
             url: '/ajax/breeders/seedlots?seedlot_name=' + name,
             beforeSend: function() {
+                jQuery('#seedlot_event_name').attr('disabled', true);
+                jQuery('#seedlot_event_name_update').attr('disabled', true);
+                jQuery('#seedlot_event_name_barcode').attr('disabled', true);
                 jQuery(".seedlot_event_info").html("Loading...");
                 jQuery(".seedlot_event_info_cvterm_value").html("");
                 jQuery(".seedlot_event_info_cvterm_notes").html("");
@@ -247,8 +255,13 @@
                 jQuery("#seedlot_event_contents").html(contents);
                 jQuery("#seedlot_event_location").html(location);
                 jQuery("#seedlot_event_box").html(box);
+                jQuery('#seedlot_event_name').attr('disabled', false);
+                jQuery('#seedlot_event_name_update').attr('disabled', false);
+                jQuery('#seedlot_event_name_barcode').attr('disabled', false);
             }
         });
+
+        return false;
     }
 
     /**
@@ -433,7 +446,7 @@
         if ( s <= 9 ) s = '0' + s;
 
         let ts = y + '-' + m + '-' + d + ' ' + h + ':' + i + ':' + s;
-        jQuery("#seedlot_event_timestamp").val(ts);
+        jQuery("input[name='seedlot_event_timestamp']").val(ts);
     }
 
 

--- a/mason/breeders_toolbox/seedlot_maintenance/table.mas
+++ b/mason/breeders_toolbox/seedlot_maintenance/table.mas
@@ -30,9 +30,28 @@
         <form class="form-horizontal" id="seedlot_maintenance_event_form" name="seedlot_maintenance_event_form">
 
 % if ( $multi_seedlot ) {
+
             <!-- Seedlot (by user-input) -->
             <div class="form-group">
                 <label class="col-sm-3 control-label">Seedlot(s): </label>
+                <div class="col-sm-8">
+                    <div class="panel panel-info">
+                        <div class="panel-heading">Seedlot Name Contains</div>
+                        <div class="panel-body">
+                            <input id="event_filter_seedlot_name_contains" class="form-control" placeholder="part of Seedlot name" />
+                        </div>
+                    </div>
+
+                    <div style="text-align: center"><strong>OR</strong></div>
+                </div>
+                <div class="col-sm-1">
+                    <button id="event_filter_seedlot_name_contains_add" class='btn btn-info btn-sm'>Add</button>
+                </div>
+            </div>
+
+            <!-- Seedlot (by user-input) -->
+            <div class="form-group">
+                <label class="col-sm-3 control-label"></label>
                 <div class="col-sm-8">
                     <div class="panel panel-info">
                         <div class="panel-heading">Enter the name(s) of the Seedlot(s) - one per line</div>
@@ -209,6 +228,7 @@ jQuery(document).ready(function() {
     }
 
     // Click and Change Listeners
+    jQuery("#event_filter_seedlot_name_contains_add").click(addSeedlotNameContainsFilter);
     jQuery("#event_filter_seedlot_names_add").click(addSeedlotNamesFilter);
     jQuery("#event_filter_seedlot_list_add").click(addSeedlotListFilter);
     jQuery("#event_filter_date_add").click(addDateFilter);
@@ -313,7 +333,7 @@ function setupDataTable() {
 
     // Init DataTable
     DT = jQuery('#seedlot_maintenance_events').DataTable({
-        dom: 'Bfrt',
+        dom: 'Brt',
         autoWidth: false,
         pageLength: PAGE_SIZE,
         data: [],
@@ -349,7 +369,18 @@ function getEvents() {
     for ( let i = 0; i < FILTERS.length; i++ ) {
         let f = FILTERS[i];
         if ( f.type_id === 'name' ) {
-            names = names.concat(f.value);
+            if ( f.comp === 'includes' ) {
+                names.push({
+                    value: f.value,
+                    comp: 'IN'
+                });
+            }
+            else if ( f.comp === 'contains' ) {
+                names.push({
+                    value: "%" + f.value + "%",
+                    comp: 'LIKE'
+                });
+            }
         }
         else if ( f.type_id === 'date' ) {
             if ( f.comp === '=' ) {
@@ -394,7 +425,10 @@ function getEvents() {
         }
     }
     if ( !MULTI_SEEDLOT ) {
-        names = ["<% $seedlot_name %>"];
+        names.push({
+            value: "<% $seedlot_name %>",
+            comp: "="
+        });
     }
     let body = {
         filters: {
@@ -605,6 +639,15 @@ function setOperators() {
 
 
 /**
+ * Add a Name Filter - Seedlot name contains user-provided substring
+ */
+function addSeedlotNameContainsFilter() {
+    let substring = jQuery("#event_filter_seedlot_name_contains").val();
+    addFilter('name', 'name', substring, 'contains');
+    return false;
+}
+
+/**
  * Add a Name Filter - from the user-entered list of names
  */
 function addSeedlotNamesFilter() {
@@ -683,7 +726,7 @@ function addOperatorFilter() {
  * @param {string|int} type_id ID of the filter type (cvterm_id, date, operator)
  * @param {string} type_name Name of the filter type (cvterm name, date, operator)
  * @param {string|int} value Value of the filter for comparison (type value, date, operator names)
- * @param {string} comp Comparison used for the filter (eq, lte, lt, gte, gt)
+ * @param {string} comp Comparison used for the filter
  */
 function addFilter(type_id, type_name, value, comp) {
     FILTERS.push({
@@ -713,6 +756,7 @@ function displayFilters() {
     for ( let i = 0; i < FILTERS.length; i++ ) {
         let v = FILTERS[i].value;
         if ( !v ) v = "<em>Any Value</em>";
+        if ( Array.isArray(v) && v.length > 20 ) v = v.slice(0, 20).join(',') + "...";
         html += "<tr>";
         html += "<td>" + FILTERS[i].type_name + "</td>";
         html += "<td>" + FILTERS[i].comp + "</td>";

--- a/mason/breeders_toolbox/seedlot_maintenance/table.mas
+++ b/mason/breeders_toolbox/seedlot_maintenance/table.mas
@@ -129,10 +129,10 @@
             <div class="form-group">
                 <label class="col-sm-3 control-label">Operator: </label>
                 <div class="col-sm-8">
-                    <select class="form-control" id="event_filter_operators" multiple disabled><option>Loading...</option></select>
+                    <input class="form-control" id="event_filter_operator" />
                 </div>
                 <div class="col-sm-1">
-                    <button id="event_filter_operators_add" class='btn btn-info btn-sm'>Add</button>
+                    <button id="event_filter_operator_add" class='btn btn-info btn-sm'>Add</button>
                 </div>
             </div>
 
@@ -233,7 +233,7 @@ jQuery(document).ready(function() {
     jQuery("#event_filter_seedlot_list_add").click(addSeedlotListFilter);
     jQuery("#event_filter_date_add").click(addDateFilter);
     jQuery("#event_filter_type_add").click(addTypeFilter);
-    jQuery("#event_filter_operators_add").click(addOperatorFilter);
+    jQuery("#event_filter_operator_add").click(addOperatorFilter);
     jQuery("#event_filter_type").change(setTypeFilterValues);
     jQuery("#event_filter_submit").click(submitFilter);
     jQuery("#seedlot_maintenance_events_prev").click(getPrevPage);
@@ -464,7 +464,6 @@ function getEvents() {
         },
         complete: function() {
             displayEvents();
-            setOperators();
 
             jQuery("#event_filter_submit").html("Filter");
             jQuery("#event_filter_submit").attr("disabled", false);
@@ -621,22 +620,6 @@ function setTypeFilterValues() {
     jQuery("#event_filter_type_value").html(html);
 }
 
-/**
- * Populate the operators select with the event operators
- */
-function setOperators() {
-    let operators = [];
-    for ( let i = 0; i < EVENTS.length; i++ ) {
-        if ( !operators.includes(EVENTS[i].operator)) operators.push(EVENTS[i].operator);
-    }
-    let html = "";
-    for ( let i = 0; i < operators.length; i++ ) {
-        html += "<option value='" + operators[i] + "'>" + operators[i] + "</option>";
-    }
-    jQuery("#event_filter_operators").html(html);
-    jQuery("#event_filter_operators").attr("disabled", false);
-}
-
 
 /**
  * Add a Name Filter - Seedlot name contains user-provided substring
@@ -715,7 +698,7 @@ function addTypeFilter() {
  * Add an Operator Filter
  */
 function addOperatorFilter() {
-    let operators = jQuery('#event_filter_operators').val();
+    let operators = jQuery('#event_filter_operator').val();
     addFilter('operator', 'operator', operators, '=');
     return false;
 }

--- a/mason/breeders_toolbox/seedlot_maintenance/tools/split_seedlot.mas
+++ b/mason/breeders_toolbox/seedlot_maintenance/tools/split_seedlot.mas
@@ -14,11 +14,14 @@
         <!-- Seedlot to Split -->
         <div class="form-group">
             <label class="col-sm-3 control-label" style="text-align: right">Original Seedlot to Split</label>
-            <div class="col-sm-7">
+            <div class="col-sm-5">
                 <input class="form-control" id="seedlot_split_name" type="text" value="">
             </div>
             <div class="col-sm-2">
-                <button id="seedlot_split_name_barcode" class="btn btn-default"><span class="glyphicon glyphicon-qrcode"></span> Barcode</button>
+                <button id="seedlot_split_name_update" class="btn btn-block btn-info"><span class="glyphicon glyphicon-refresh"></span> Update</button>
+            </div>
+            <div class="col-sm-2">
+                <button id="seedlot_split_name_barcode" class="btn btn-block btn-default"><span class="glyphicon glyphicon-qrcode"></span> Barcode</button>
             </div>
         </div>
 
@@ -227,6 +230,7 @@
             return false;
         });
         jQuery('#seedlot_split_name').change(getSeedlotInfo);
+        jQuery('#seedlot_split_name_update').click(getSeedlotInfo);
         jQuery('#seedlot_split_new_create').click(createNewSeedlot);
         jQuery('#seedlot_split_modal_close').click(function() {
             jQuery('#seedlot_split_modal').modal('hide');
@@ -262,6 +266,9 @@
      * - Update the new seedlot properties
      */
     function getSeedlotInfo() {
+        jQuery("#seedlot_split_name").attr("disabled", true);
+        jQuery("#seedlot_split_name_update").attr("disabled", true);
+
         let name = jQuery("#seedlot_split_name").val();
         let contents = "";
         let breeding_program_id = "";
@@ -377,7 +384,9 @@
          */
         function _setNewName(new_name, enabled=true) {
             jQuery("#seedlot_split_new_name").val(new_name);
-            jQuery("#seedlot_split_new_name").prop("disabled", !enabled);
+            jQuery("#seedlot_split_new_name").attr("disabled", !enabled);
+            jQuery("#seedlot_split_name").attr("disabled", !enabled);
+            jQuery("#seedlot_split_name_update").attr("disabled", !enabled);
         }
     }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds some minor improvements and bug fixes related to the Seedlot Maintenance Features

**Bug Fixes:**

- workaround for jQuery bug setting values for random inputs when returning to the record page via the browser back button

**Improvements:**

- allow the Seedlot Maintenance Event filter function to accept multiple seedlot name filters with passed comparisons
- add seedlot name "includes" input to event filters
- truncate list of displayed seedlot names for long lists


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
