### PR TITLE
Create Multiple Fieldbook Layouts from Trial List

### DIFF
--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -315,8 +315,10 @@ sub get_trials_select : Path('/ajax/html/select/trials') Args(0) {
     my $multiple = $c->req->param("multiple") || 0;
     my $live_search = $c->req->param("live_search") || 0;
     my $include_location_year = $c->req->param("include_location_year");
+    my $include_lists = $c->req->param("include_lists") || 0;
 
     my @trials;
+    if ($include_lists) { unshift @trials, [ "", "----INDIVIDUAL TRIALS----" ]; }
     foreach my $project (@$projects) {
       my ($field_trials, $cross_trials, $genotyping_trials) = $p->get_trials_by_breeding_program($project->[0]);
       foreach (@$field_trials) {
@@ -339,6 +341,36 @@ sub get_trials_select : Path('/ajax/html/select/trials') Args(0) {
         @trials = @trials_redef;
     }
     @trials = sort { $a->[1] cmp $b->[1] } @trials;
+
+    if ($include_lists) {
+        my $lists = CXGN::List::available_lists($c->dbc->dbh(), $c->user()->get_sp_person_id());
+        my $public_lists = CXGN::List::available_public_lists($c->dbc->dbh());
+        my $lt = CXGN::List::Transform->new();
+
+        push @trials, ["", "----YOUR LISTS OF TRIALS----"];
+        foreach my $item (@$lists) {
+            if ( @$item[5] eq "trials" ) {
+                my $list = CXGN::List->new({ dbh=>$c->dbc->dbh(), list_id => @$item[0] });
+                my $list_elements = $list->retrieve_elements_with_ids(@$item[0]);
+                my @list_element_names = map { $_->[1] } @$list_elements;
+                my $transform = $lt->transform($schema, 'projects_2_project_ids', \@list_element_names);
+                my @trial_ids = @{$transform->{transform}};
+                push @trials, [join(',', @trial_ids), @$item[1] . ' (' . @$item[3] . ' trials)'];
+            }
+        }
+
+        push @trials, ["", "----PUBLIC LISTS OF TRIALS----"];
+        foreach my $item (@$public_lists) {
+            if ( @$item[5] eq "trials" ) {
+                my $list = CXGN::List->new({ dbh=>$c->dbc->dbh(), list_id => @$item[0] });
+                my $list_elements = $list->retrieve_elements_with_ids(@$item[0]);
+                my @list_element_names = map { $_->[1] } @$list_elements;
+                my $transform = $lt->transform($schema, 'projects_2_project_ids', \@list_element_names);
+                my @trial_ids = @{$transform->{transform}};
+                push @trials, [join(',', @trial_ids), @$item[1] . ' (' . @$item[3] . ' trials)'];
+            }
+        }
+    }
 
     if ($empty) { unshift @trials, [ "", "Please select a trial" ]; }
 

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -318,7 +318,7 @@ sub get_trials_select : Path('/ajax/html/select/trials') Args(0) {
     my $include_lists = $c->req->param("include_lists") || 0;
 
     my @trials;
-    if ($include_lists) { unshift @trials, [ "", "----INDIVIDUAL TRIALS----" ]; }
+    if ($include_lists) { push @trials, [ "", "----INDIVIDUAL TRIALS----" ]; }
     foreach my $project (@$projects) {
       my ($field_trials, $cross_trials, $genotyping_trials) = $p->get_trials_by_breeding_program($project->[0]);
       foreach (@$field_trials) {

--- a/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
@@ -133,7 +133,7 @@ $trial_stock_type => undef
         <div class="container-fluid">
             <p>
               <span class="ui-icon ui-icon-circle-check" style="float: left; margin: 0 7px 50px 0;"></span>
-              The field book layout file was saved successfully
+              The field book layout file(s) were saved successfully
             </p>
             <div id="tablet_field_layout_get_file_<% $download_type %>"></div>
         </div>
@@ -156,7 +156,15 @@ var has_tissue_samples_<% $download_type %> = 0;
 jQuery(document).ready(function() {
 
     if(jQuery("#html_select_trial_for_create_fieldbook_<% $download_type %>").length == 0) {
-        get_select_box('trials', 'select_trial_for_create_fieldbook_<% $download_type %>', { 'name' : 'html_select_trial_for_create_fieldbook_<% $download_type %>', 'id' : 'html_select_trial_for_create_fieldbook_<% $download_type %>' });
+        get_select_box(
+            'trials', 
+            'select_trial_for_create_fieldbook_<% $download_type %>', 
+            { 
+                'name' : 'html_select_trial_for_create_fieldbook_<% $download_type %>', 
+                'id' : 'html_select_trial_for_create_fieldbook_<% $download_type %>',
+                'include_lists' : 1
+            }
+        );
     }
 
     jQuery(document).on('change', '#html_select_trial_for_create_fieldbook_<% $download_type %>', function() {
@@ -201,98 +209,107 @@ jQuery(document).ready(function() {
     });
 
     jQuery('#create_fieldbook_data_level_<% $download_type %>').on('change', function(){
-        var selected_trial_id = parseInt(jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val());
+        var selected_trial_ids = jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val().split(',');
         var level = jQuery('#create_fieldbook_data_level_<% $download_type %>').val();
         if (level == 'plots'){
             show_available_columns_<% $download_type %>('plots');
         } else {
-            new jQuery.ajax({
-                type: 'POST',
-                url: '/ajax/breeders/trial/'+selected_trial_id+'/has_plants',
-                dataType: "json",
-                beforeSend: function() {
-                    jQuery("#working_modal").modal("show");
-                },
-                success: function (response) {
-                    //console.log(response);
-                    jQuery("#working_modal").modal("hide");
-                    if(response.has_plants == 0){
-                        has_plants_<% $download_type %> = 0;
-                        if (level == 'plants'){
-                            alert('This trial does not have '+level);
-                            show_available_columns_<% $download_type %>('plots');
-                            jQuery('#create_fieldbook_data_level_<% $download_type %>').val('plots');
+            let warned = false;
+            for ( let i = 0; i < selected_trial_ids.length; i++ ) {
+                let trial_id = parseInt(selected_trial_ids[i]);
+                if ( trial_id && trial_id !== '' ) {
+                    new jQuery.ajax({
+                        type: 'POST',
+                        url: '/ajax/breeders/trial/'+trial_id+'/has_plants',
+                        dataType: "json",
+                        beforeSend: function() {
+                            jQuery("#working_modal").modal("show");
+                        },
+                        success: function (response) {
+                            //console.log(response);
+                            jQuery("#working_modal").modal("hide");
+                            if(response.has_plants == 0){
+                                has_plants_<% $download_type %> = 0;
+                                if (!warned && level == 'plants'){
+                                    alert('This trial does not have '+level);
+                                    show_available_columns_<% $download_type %>('plots');
+                                    jQuery('#create_fieldbook_data_level_<% $download_type %>').val('plots');
+                                    warned = true;
+                                }
+                            } else {
+                                has_plants_<% $download_type %> = 1;
+                                if (level == 'plants'){
+                                    show_available_columns_<% $download_type %>(level);
+                                }
+                            }
+                        },
+                        error: function () {
+                            jQuery("#working_modal").modal("hide");
+                            alert('An error occurred checking trial for plants or subplots.');
                         }
-                    } else {
-                        has_plants_<% $download_type %> = 1;
-                        if (level == 'plants'){
-                            show_available_columns_<% $download_type %>(level);
+                    });
+                    new jQuery.ajax({
+                        type: 'POST',
+                        url: '/ajax/breeders/trial/'+trial_id+'/has_subplots',
+                        dataType: "json",
+                        beforeSend: function() {
+                            jQuery("#working_modal").modal("show");
+                        },
+                        success: function (response) {
+                            //console.log(response);
+                            jQuery("#working_modal").modal("hide");
+                            if(response.has_subplots == 0){
+                                has_subplots_<% $download_type %> = 0;
+                                if (!warned && level == 'subplots'){
+                                    alert('This trial does not have '+level);
+                                    show_available_columns_<% $download_type %>('plots');
+                                    jQuery('#create_fieldbook_data_level_<% $download_type %>').val('plots');
+                                    warned = true;
+                                }
+                            } else {
+                                has_subplots_<% $download_type %> = 1;
+                                if (level == 'subplots'){
+                                    show_available_columns_<% $download_type %>(level);
+                                }
+                            }
+                        },
+                        error: function () {
+                            jQuery("#working_modal").modal("hide");
+                            alert('An error occurred checking trial for plants or subplots.');
                         }
-                    }
-                },
-                error: function () {
-                    jQuery("#working_modal").modal("hide");
-                    alert('An error occurred checking trial for plants or subplots.');
+                    });
+                    new jQuery.ajax({
+                        type: 'POST',
+                        url: '/ajax/breeders/trial/'+trial_id+'/has_tissue_samples',
+                        dataType: "json",
+                        beforeSend: function() {
+                            jQuery("#working_modal").modal("show");
+                        },
+                        success: function (response) {
+                            //console.log(response);
+                            jQuery("#working_modal").modal("hide");
+                            if(response.has_tissue_samples == 0){
+                                has_tissue_samples_<% $download_type %> = 0;
+                                if (!warned && level == 'field_trial_tissue_samples'){
+                                    alert('This trial does not have '+level);
+                                    show_available_columns_<% $download_type %>('plots');
+                                    jQuery('#create_fieldbook_data_level_<% $download_type %>').val('plots');
+                                    warned = true;
+                                }
+                            } else {
+                                has_tissue_samples_<% $download_type %> = 1;
+                                if (level == 'field_trial_tissue_samples'){
+                                    show_available_columns_<% $download_type %>(level);
+                                }
+                            }
+                        },
+                        error: function () {
+                            jQuery("#working_modal").modal("hide");
+                            alert('An error occurred checking trial for plants or subplots.');
+                        }
+                    });
                 }
-            });
-            new jQuery.ajax({
-                type: 'POST',
-                url: '/ajax/breeders/trial/'+selected_trial_id+'/has_subplots',
-                dataType: "json",
-                beforeSend: function() {
-                    jQuery("#working_modal").modal("show");
-                },
-                success: function (response) {
-                    //console.log(response);
-                    jQuery("#working_modal").modal("hide");
-                    if(response.has_subplots == 0){
-                        has_subplots_<% $download_type %> = 0;
-                        if (level == 'subplots'){
-                            alert('This trial does not have '+level);
-                            show_available_columns_<% $download_type %>('plots');
-                            jQuery('#create_fieldbook_data_level_<% $download_type %>').val('plots');
-                        }
-                    } else {
-                        has_subplots_<% $download_type %> = 1;
-                        if (level == 'subplots'){
-                            show_available_columns_<% $download_type %>(level);
-                        }
-                    }
-                },
-                error: function () {
-                    jQuery("#working_modal").modal("hide");
-                    alert('An error occurred checking trial for plants or subplots.');
-                }
-            });
-            new jQuery.ajax({
-                type: 'POST',
-                url: '/ajax/breeders/trial/'+selected_trial_id+'/has_tissue_samples',
-                dataType: "json",
-                beforeSend: function() {
-                    jQuery("#working_modal").modal("show");
-                },
-                success: function (response) {
-                    //console.log(response);
-                    jQuery("#working_modal").modal("hide");
-                    if(response.has_tissue_samples == 0){
-                        has_tissue_samples_<% $download_type %> = 0;
-                        if (level == 'field_trial_tissue_samples'){
-                            alert('This trial does not have '+level);
-                            show_available_columns_<% $download_type %>('plots');
-                            jQuery('#create_fieldbook_data_level_<% $download_type %>').val('plots');
-                        }
-                    } else {
-                        has_tissue_samples_<% $download_type %> = 1;
-                        if (level == 'field_trial_tissue_samples'){
-                            show_available_columns_<% $download_type %>(level);
-                        }
-                    }
-                },
-                error: function () {
-                    jQuery("#working_modal").modal("hide");
-                    alert('An error occurred checking trial for plants or subplots.');
-                }
-            });
+            }
         }
 
     });
@@ -459,49 +476,74 @@ function include_column_<% $download_type %>(name){
 % if ($download_type eq 'Fieldbook'){
 
 function show_fieldbook_treatments_<% $download_type %>(){
-    var selected_trial_id = parseInt(jQuery("#html_select_trial_for_create_fieldbook_<% $download_type %>").val());
-    get_select_box('treatments', 'create_fieldbook_treatment_<% $download_type %>', { 'name':'html_select_treatment_create_fieldbook_<% $download_type %>', 'id':'html_select_treatment_create_fieldbook_<% $download_type %>', 'trial_id':selected_trial_id, 'empty':1 });
+    var selected_trial_id = jQuery("#html_select_trial_for_create_fieldbook_<% $download_type %>").val();
+    if ( selected_trial_id && !selected_trial_id.includes(',') ) {
+        jQuery("#management_factore").show();
+        get_select_box('treatments', 'create_fieldbook_treatment_<% $download_type %>', { 'name':'html_select_treatment_create_fieldbook_<% $download_type %>', 'id':'html_select_treatment_create_fieldbook_<% $download_type %>', 'trial_id':selected_trial_id, 'empty':1 });
+    }
+    else {
+        jQuery("#management_factore").hide();
+    }
 }
 
 function open_create_fieldbook_dialog_<% $download_type %>() {
     var trial_stock_type = "<% $trial_stock_type %>";
-    new jQuery.ajax({
-        type: 'POST',
-        url: '/ajax/fieldbook/create',
-        dataType: "json",
-        data: {
-            'trial_id': parseInt(jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val()),
-            'data_level': jQuery('#create_fieldbook_data_level_<% $download_type %>').val(),
-            'treatment_project_id': jQuery("#html_select_treatment_create_fieldbook_<% $download_type %>").val(),
-            'selected_columns':JSON.stringify(selected_columns_<% $download_type %>),
-            'include_measured': jQuery('#create_fieldbook_include_measured_<% $download_type %>').prop('checked'),
-            'all_stats': jQuery('#create_fieldbook_all_stats_<% $download_type %>').prop('checked'),
-            'use_synonyms': jQuery('#create_fieldbook_use_synonyms_<% $download_type %>').prop('checked'),
-            'trait_list':jQuery('#create_fieldbook_with_trait_list_select_<% $download_type %>_list_select').val(),
-            'trial_stock_type': trial_stock_type
-        },
-        beforeSend: function() {
-            jQuery("#working_modal").modal("show");
-        },
-        success: function (response) {
-            jQuery("#working_modal").modal("hide");
-            if (response.error){
-                alert(response.error);
-            }
-            else if (response.error_string) {
-                alert(response.error_string);
-            } else {
-                jQuery('#tablet_field_layout_get_file_<% $download_type %>').html('<a href="/fieldbook/trial_download/'+response.file_id+'">'+response.file+'</a>')
-                jQuery("#tablet_field_layout_saved_dialog_message_<% $download_type %>").modal("show");
+    let trial_ids = jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val().split(',');
+    console.log(trial_ids);
+    
+    jQuery("#working_modal").modal("show");
+    for ( let i = 0; i < trial_ids.length; i++ ) {
+        let trial_id = trial_ids[i];
+        console.log(trial_id);
+        new jQuery.ajax({
+            type: 'POST',
+            url: '/ajax/fieldbook/create',
+            dataType: "json",
+            data: {
+                'trial_id': parseInt(trial_id),
+                'data_level': jQuery('#create_fieldbook_data_level_<% $download_type %>').val(),
+                'treatment_project_id': jQuery("#html_select_treatment_create_fieldbook_<% $download_type %>").val(),
+                'selected_columns':JSON.stringify(selected_columns_<% $download_type %>),
+                'include_measured': jQuery('#create_fieldbook_include_measured_<% $download_type %>').prop('checked'),
+                'all_stats': jQuery('#create_fieldbook_all_stats_<% $download_type %>').prop('checked'),
+                'use_synonyms': jQuery('#create_fieldbook_use_synonyms_<% $download_type %>').prop('checked'),
+                'trait_list':jQuery('#create_fieldbook_with_trait_list_select_<% $download_type %>_list_select').val(),
+                'trial_stock_type': trial_stock_type
+            },
+            success: function (response) {
+                if (response.error){
+                    jQuery("#working_modal").modal("hide");
+                    alert(response.error);
+                }
+                else if (response.error_string) {
+                    jQuery("#working_modal").modal("hide");
+                    alert(response.error_string);
+                } else {
+                    _finish(response.file_id, response.file)
+                }
+            },
+            error: function () {
+                jQuery("#working_modal").modal("hide");
+                alert('An error occurred creating the field book.');
                 jQuery('#create_fieldbook_dialog_<% $download_type %>').modal("hide");
             }
-        },
-        error: function () {
+        });
+    }
+
+    let count = 0;
+    let total = trial_ids.length;
+    let html = "<ul>";
+    function _finish(file_id, file_path) {
+        count++;
+        html += '<li><a href="/fieldbook/trial_download/'+file_id+'">'+file_path+'</a></li>';
+        if ( count === total ) {
+            html += "</ul>";
             jQuery("#working_modal").modal("hide");
-            alert('An error occurred creating the field book.');
+            jQuery('#tablet_field_layout_get_file_<% $download_type %>').html(html);
+            jQuery("#tablet_field_layout_saved_dialog_message_<% $download_type %>").modal("show");
             jQuery('#create_fieldbook_dialog_<% $download_type %>').modal("hide");
         }
-    });
+    }
 }
 
 % } elsif ($download_type eq 'TrialLayout') {
@@ -512,7 +554,7 @@ function show_fieldbook_treatments_<% $download_type %>(){
 }
 
 function open_create_fieldbook_dialog_<% $download_type %>() {
-    var trial_id = parseInt(jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val());
+    var trial_ids = jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val().split(',');
     var data_level = jQuery('#create_fieldbook_data_level_<% $download_type %>').val();
     var selected_columns = JSON.stringify(selected_columns_<% $download_type %>);
     var trait_list_id = jQuery('#create_fieldbook_with_trait_list_select_<% $download_type %>_list_select').val();
@@ -520,7 +562,10 @@ function open_create_fieldbook_dialog_<% $download_type %>() {
     var include_measurements = jQuery('#create_fieldbook_include_measured_<% $download_type %>').prop('checked');
     console.log(format);
     //Calls SGN::Controller:BreedersToolbox::Trial
-    window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&selected_columns="+selected_columns+"&trait_list_id="+trait_list_id+"&include_measured="+include_measurements);
+    for ( let i = 0; i < trial_ids.length; i++ ) {
+        let trial_id = parseInt(trial_ids[i]);
+        window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&selected_columns="+selected_columns+"&trait_list_id="+trait_list_id+"&include_measured="+include_measurements);
+    }
 }
 
 % } elsif ($download_type eq 'TrialFieldMapLayout') {
@@ -530,12 +575,15 @@ function show_fieldbook_treatments_<% $download_type %>(){
 }
 
 function open_create_fieldbook_dialog_<% $download_type %>() {
-    var trial_id = parseInt(jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val());
+    var trial_ids = jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val().split(',');
     var data_level = 'plot_fieldMap';
     var selected_columns_TrialFieldMapLayout = {'row_number':1,'col_number':1,'accession_name':1};
     var selected_columns = JSON.stringify(selected_columns_TrialFieldMapLayout);
     var format = jQuery('#create_fieldbook_format_<% $download_type %>').val();
-    window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&selected_columns="+selected_columns);
+    for ( let i = 0; i < trial_ids.length; i++ ) {
+        let trial_id = parseInt(trial_ids[i]);
+        window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&selected_columns="+selected_columns);
+    }
 }
 
 % }

--- a/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
@@ -489,12 +489,10 @@ function show_fieldbook_treatments_<% $download_type %>(){
 function open_create_fieldbook_dialog_<% $download_type %>() {
     var trial_stock_type = "<% $trial_stock_type %>";
     let trial_ids = jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val().split(',');
-    console.log(trial_ids);
     
     jQuery("#working_modal").modal("show");
     for ( let i = 0; i < trial_ids.length; i++ ) {
         let trial_id = trial_ids[i];
-        console.log(trial_id);
         new jQuery.ajax({
             type: 'POST',
             url: '/ajax/fieldbook/create',


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds the option for the user to create more than one Fieldbook Layout file at a time by selecting a List of trials to generate the files for.

**Changes:**

The HTMLSelect endpoint for trials (`/ajax/html/select/trials`) now as an `include_lists` option that when set to `1` will include the user's trial lists and any public trial lists after the individual trial options.

The Trial Select in the `download_layout_interface_dialog.mas` component now includes Lists of Trials as an option.  Additional changes were made to handle more than one selected trial:

- Management Factors are only selectable if a single Trial is selected
- The checks for data levels occur for each Trial - if one does not include the selected data level, the selection is reverted to Plots
- Each Trial is submitted to `/ajax/fieldbook/create` individually
- Once all Fieldbook files are created, the success modal displays links to each individual file to download


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
