### PR TITLE
identify username for account when resetting password

### DIFF
--- a/lib/SGN/Controller/AJAX/User.pm
+++ b/lib/SGN/Controller/AJAX/User.pm
@@ -331,7 +331,7 @@ sub reset_password :Path('/ajax/user/reset_password') Args(0) {
         my $person = CXGN::People::Login->new( $c->dbc->dbh(), $pid);
         $person->update_confirm_code($email_reset_token);
         print STDERR "Sending reset link $reset_link\n";
-        $self->send_reset_email_message($c, $pid, $email, $reset_link);
+        $self->send_reset_email_message($c, $pid, $email, $reset_link, $person->{username});
         push @reset_links, $reset_link;
         push @reset_tokens, $email_reset_token;
     }
@@ -385,6 +385,7 @@ sub send_reset_email_message {
     my $pid = shift;
     my $private_email = shift;
     my $reset_link = shift;
+    my $person = shift;
 
     my $subject = "[SGN] E-mail Address Confirmation Request";
     my $main_url = $c->config->{main_production_site_url};
@@ -393,7 +394,7 @@ sub send_reset_email_message {
 
 Hi,
 
-you have requested a password reset on $main_url.
+The user $person has requested a password reset on $main_url.
 
 If this request did not come from you, please let us know.
 

--- a/mason/user/reset_password_form.mas
+++ b/mason/user/reset_password_form.mas
@@ -76,6 +76,7 @@ $token
            if (r.error) { alert(r.error); }
            else { 
              alert(r.message);
+             window.location = "/user/login?goto_url=%2F";
            }
          }
        });


### PR DESCRIPTION
We had several users who forgot their username so were not able to login or reset password
This change adds username to the email that gives link to password reset

After resetting password the screen was disabled with popup that could not be closed
This change adds redirect to home screen after succesfull password reset
goto home page after password reset


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
