### PR TITLE
add option to use smtp server without authentication

### DIFF
--- a/lib/CXGN/Contact.pm
+++ b/lib/CXGN/Contact.pm
@@ -111,6 +111,26 @@ sub send_email {
                   -body       => $body
               );
 
+            } elsif ( $smtp_server ) {
+
+              my ($mail,$error) = Email::Send::SMTP::Gmail->new(
+                  -smtp  => $smtp_server,
+                  -layer => $smtp_layer,
+                  -port  => $smtp_port,
+                  -auth  => 'none'
+              );
+
+              if ($mail == -1) {
+                print STDERR "CXGN::Contact: SMTP error: $error\n";
+              };
+
+              $mail->send(
+                  -from       => $smtp_from,
+                  -to         => $mailto,
+                  -subject    => $subject,
+                  -body       => $body
+              );
+              
             } else {
 
               my %mail = (


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Added a few lines in lib/CXGN/Contact.pm to allow sending emails to a SMTP server that doesn't need authentication (login and password).

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
