### PR TITLE
disable comment characters in GWAS files

### DIFF
--- a/R/solgwas/solgwas_script.R
+++ b/R/solgwas/solgwas_script.R
@@ -10,7 +10,7 @@ library("dplyr")
 ########################################
 args = commandArgs(trailingOnly = TRUE)
 
-pheno <- read.table(args[1], sep = "\t", header = TRUE, stringsAsFactors = FALSE, check.names = FALSE)
+pheno <- read.table(args[1], sep = "\t", header = TRUE, stringsAsFactors = FALSE, check.names = FALSE, comment.char = "")
 colnames(pheno)
 
 #### Current script accepts genotype data with markers as rows and accessions as columns

--- a/bin/load_genotypes_vcf_cxgn_postgres.pl
+++ b/bin/load_genotypes_vcf_cxgn_postgres.pl
@@ -300,7 +300,8 @@ my $store_args = {
     user_id=>$sp_person_id,
     archived_filename=>$archived_filename_with_path,
     archived_file_type=>'genotype_vcf', #can be 'genotype_vcf' or 'genotype_dosage' to disntiguish genotyprop between old dosage only format and more info vcf format
-    temp_file_sql_copy=>$opt_B
+    temp_file_sql_copy=>$opt_B,
+    genotyping_data_type=>'SNP'
 };
 
 if ($opt_c eq 'VCF') {


### PR DESCRIPTION
when reading phenotype files a # character in description causes problems
in loading VCF files set default type to SNP, change to SSR if needed


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
