### PR TITLE
GitHub Actions workflow to test PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/home/production/cxgn/sgn
         - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
+      options: --network-alias test_breedbase
 
     services:
       breedbase_db:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,10 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/home/production/cxgn/sgn
         - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
-      options: --network-alias test_breedbase
+      options: >-
+        --device=/dev/tty
+        --network-alias test_breedbase
+        --tty
 
     services:
       breedbase_db:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,27 +5,41 @@ on:
       - '**.md'
 
 jobs:
-  test:
+  test_breedbase:
     runs-on: ubuntu-latest
+    container:
+      image: breedbase/breedbase:v0.31
+      env:
+        HOME: /root
+        MODE: 'TESTING'
+        PGPASSWORD: postgres
+        SGN_TEST_SERVER: http://test_breedbase:3010
+        SGN_REMOTE_SERVER_ADDR: selenium
+      volumes:
+        - ${{ github.workspace }}:/home/production/cxgn/sgn
+        - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
+
+    services:
+      breedbase_db:
+        image: postgres:12.8
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      selenium:
+        image: selenium/standalone-firefox:3.141.59-20210607
+        options: --health-cmd="curl --silent --head http://localhost:4444 || exit 1"
 
     steps:
-      - name: Checkout breedbase_dockerfile
-        uses: actions/checkout@v2
-        with:
-          repository: solgenomics/breedbase_dockerfile
-          # TODO: omit after merged into master
-          ref: fix/prod-npm-git-submodule
-    
-      - name: Remove sgn submodule
-        run: git rm cxgn/sgn
-    
       - name: Checkout sgn
         uses: actions/checkout@v2
-        with:
-          path: cxgn/sgn
     
-      - name: Initialize/update submodules
-        run: git submodule update --init
-
       - name: Run tests
-        run: docker compose -f docker-compose.test.yml run --use-aliases test_breedbase
+        run: /entrypoint.sh t/unit t/unit_fixture t/unit_mech t/selenium2
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/home/production/cxgn/sgn
         - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
-      options: >-
-        --device=/dev/tty
-        --network-alias test_breedbase
-        --tty
+      options: --network-alias test_breedbase
 
     services:
       breedbase_db:
@@ -45,5 +42,6 @@ jobs:
     
       - name: Run tests
         run: /entrypoint.sh t/unit t/unit_fixture t/unit_mech t/selenium2
-
-
+        # work around run_all_patches.pl "what the heck - no TTY??" error
+        # https://github.com/actions/runner/issues/241#issuecomment-842566950
+        shell: 'script --flush --quiet --return --command "bash --noprofile --norc -eo pipefail {0}"'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+on:
+  push: # TODO: switch to "pull_request"
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout breedbase_dockerfile
+        uses: actions/checkout@v2
+        with:
+          repository: solgenomics/breedbase_dockerfile
+          # TODO: omit after merged into master
+          ref: fix/prod-npm-git-submodule
+    
+      - name: Remove sgn submodule
+        run: git rm cxgn/sgn
+    
+      - name: Checkout sgn
+        uses: actions/checkout@v2
+        with:
+          path: cxgn/sgn
+    
+      - name: Initialize/update submodules
+        run: git submodule update --init
+
+      - name: Run tests
+        run: docker compose -f docker-compose.test.yml run --use-aliases test_breedbase

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 on:
-  push: # TODO: switch to "pull_request"
+  pull_request:
     paths-ignore:
       - 'docs/**'
       - '**.md'


### PR DESCRIPTION
Runs all tests for PRs in a breedbase/breedbase_dockerfile environment.

A few relevant nice-to-haves before merging:

* Uses a non-main breedbase/breedbase_dockerfile branch
* The docker-compose.test.yml `cache_from: breedbase/breedbase:v0.31` doesn't seem to use layers from that image as a cache. As a result, the entire image is rebuilt each time (~16 minutes or so).
* Currently the `Run tests` step passes if `docker compose run` of the tests completes, despite test failures. Once all tests pass, the exit status of this step should probably reflect the existence of any test failures.