### PR TITLE
test_fixture.pl exits with non-zero exit status if any tests fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test_breedbase:
     runs-on: ubuntu-latest
     container:
-      image: breedbase/breedbase:v0.31
+      image: breedbase/breedbase:v0.33
       env:
         HOME: /root
         MODE: 'TESTING'
@@ -33,7 +33,7 @@ jobs:
           --health-retries 5
 
       selenium:
-        image: selenium/standalone-firefox:3.141.59-20210607
+        image: selenium/standalone-firefox:3.141.59
         options: --health-cmd="curl --silent --head http://localhost:4444 || exit 1"
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,23 @@ jobs:
     
       - name: Run unit tests
         run: prove --recurse t/unit
-
-      - name: Run fixture tests
-        run: /entrypoint.sh t/unit_fixture t/unit_mech t/selenium2
+      
+      - name: Load/dump fixture database and build node modules
+        run: |
+          echo "--version" > ~/.proverc
+          perl t/test_fixture.pl --dumpupdatedfixture
+          rm ~/.proverc
         # work around run_all_patches.pl "what the heck - no TTY??" error
         # https://github.com/actions/runner/issues/241#issuecomment-842566950
         shell: 'script --flush --quiet --return --command "bash --noprofile --norc -eo pipefail {0}"'
+
+      - name: Run unit_fixture tests
+        # need entrypoint.sh to start slurm
+        # --nopatch to skip running fixture and db patches (already done in previous step)
+        run: /entrypoint.sh --nopatch t/unit_fixture
+
+      - name: Run unit_mech tests
+        run: /entrypoint.sh --nopatch t/unit_mech
+
+      - name: Run selenium tests
+        run: /entrypoint.sh --nopatch t/selenium2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Checkout sgn
         uses: actions/checkout@v2
     
-      - name: Run tests
-        run: /entrypoint.sh t/unit t/unit_fixture t/unit_mech t/selenium2
+      - name: Run unit tests
+        run: prove --recurse t/unit
+
+      - name: Run fixture tests
+        run: /entrypoint.sh t/unit_fixture t/unit_mech t/selenium2
         # work around run_all_patches.pl "what the heck - no TTY??" error
         # https://github.com/actions/runner/issues/241#issuecomment-842566950
         shell: 'script --flush --quiet --return --command "bash --noprofile --norc -eo pipefail {0}"'

--- a/t/test_fixture.pl
+++ b/t/test_fixture.pl
@@ -249,6 +249,7 @@ $SIG{KILL} = sub { kill 9, $server_pid, $prove_pid };
 
 print STDERR "# Start prove (PID $prove_pid)... \n";
 waitpid $prove_pid, 0;
+my $prove_pid_exit_status = $? >> 8;
 print STDERR "# Prove finished, stopping web server PID $server_pid... ";
 
 END { kill 15, $server_pid if $server_pid }
@@ -284,6 +285,7 @@ else {
     print STDERR "# --nocleanup option: not removing db or files.\n";
 }
 print STDERR "# Test run complete.\n\n";
+exit($prove_pid_exit_status); # exit with non-zero exit status if any tests failed
 
 
 

--- a/t/test_fixture.pl
+++ b/t/test_fixture.pl
@@ -26,6 +26,7 @@ my $nocleanup;
 my $noserver;
 my $dumpupdatedfixture;
 my $noparallel = 0;
+my $nopatch;
 my $list_config = "";
 my $logfile = "logfile.$$.txt";
 my $print_environment;
@@ -39,6 +40,7 @@ GetOptions(
     "dumpupdatedfixture" => \$dumpupdatedfixture,
     "noserver"           => \$noserver,
     "noparallel"         => \$noparallel,
+    "nopatch"            => \$nopatch,
     "fixture_path"       => \$fixture_path,
     "list_config"        => \$list_config,
     "logfile=s"            => \$logfile,
@@ -141,7 +143,9 @@ print $NEWCONF $new_conf;
 close($NEWCONF);
 
 #run fixture and db patches.
-system("t/data/fixture/patches/run_fixture_and_db_patches.pl -u postgres -p $db_postgres_password -h $dbhost -d $dbname -e janedoe -s 145");
+if (! $nopatch) {
+    system("t/data/fixture/patches/run_fixture_and_db_patches.pl -u postgres -p $db_postgres_password -h $dbhost -d $dbname -e janedoe -s 145");
+}
 
 # run the materialized views creation script
 #
@@ -352,6 +356,8 @@ t/test_fixture.pl --carpalways -- -v -j5 t/mytest.t  t/mydiroftests/
   --noserver     Do not start webserver (if running unit_fixture tests only)
 
   --noparallel   Do not run the server in parallel mode.
+
+  --nopatch      Do not run fixture and database patches
 
   --fixture_path specify a path to the fixture different from the default
                  (t/data/fixture/cxgn_fixture.pl). Note: You can also set the env

--- a/t/test_fixture.pl
+++ b/t/test_fixture.pl
@@ -150,7 +150,7 @@ system("perl bin/refresh_matviews.pl -H $dbhost -D $dbname -U postgres -P $db_po
 
 if ($dumpupdatedfixture){
     print STDERR "Dumping new updated fixture with all patches run on it to t/data/fixture/cxgn_fixture.sql\n";
-    system("pg_dump -U postgres $dbname > t/data/fixture/cxgn_fixture.sql");
+    system("pg_dump -h $config->{dbhost} -U postgres $dbname > t/data/fixture/cxgn_fixture.sql");
 }
 
 print STDERR "Done.\n";

--- a/t/unit/CXGN/PRepDesign.t
+++ b/t/unit/CXGN/PRepDesign.t
@@ -52,7 +52,7 @@ ok($trial_design->set_design_type("p-rep"), "Set design type to p-rep");
  SKIP: {
 
      print STDERR "SKIPPING...\n";
-     skip "DiGGer not installed, skipping", 6, unless ( -e $ENV{R_LIBS_USER}."/DiGGer";					       
+     skip "DiGGer not installed, skipping", 6, unless ( -e $ENV{R_LIBS_USER}."/DiGGer" );
      ok($trial_design->calculate_design(), "Calculate p-rep trial design");
      ok(%design = %{$trial_design->get_design()}, "Get p-rep trial design");
      ok($design{'1'}->{row_number} == 1, "First plot row_number is 1");


### PR DESCRIPTION
Description
-----------------------------------------------------
test_fixture.pl currently exits with exit status 0 if nothing happens that prevents the tests from running.

This PR proposes making test_fixture.pl exit with a non-zero exit status if any test fails, to allow such failures to be propagated to automated testing (via an existing GitHub Actions workflow).

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [X] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [X] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [X] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
