### PR TITLE
adding get stockprops params to the search page

### DIFF
--- a/lib/CXGN/Stock/Search.pm
+++ b/lib/CXGN/Stock/Search.pm
@@ -447,8 +447,8 @@ sub search {
                 my $start = '%';
                 my $end = '%';
                 if ( $matchtype eq 'exactly' ) {
-                    $start = '';
-                    $end = '';
+                    $start = '%"';
+                    $end = '"%';
                 } elsif ( $matchtype eq 'starts_with' ) {
                     $start = '';
                 } elsif ( $matchtype eq 'ends_with' ) {

--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -409,7 +409,7 @@ jQuery(document).ready(function () {
         _load_stock_search_results(jQuery('#stock_type_select option:selected').text(), editable_stockprops_search, stockprop_extra_columns_view, stockprop_extra_columns_view_array);
     });
 
-    parseArgs();
+    parseArgs(editable_stockprops_search);
     _load_stock_search_results(jQuery('#stock_type_select option:selected').text(), editable_stockprops_search, stockprop_extra_columns_view, stockprop_extra_columns_view_array);
 
     jQuery('#stock_search_results').on( 'draw.dt', function () {
@@ -499,11 +499,21 @@ jQuery(document).ready(function () {
 
 });
 
-function parseArgs() {
+function parseArgs(editable_stockprops_search) {
   const params = new URLSearchParams(window.location.search);
   if ( params.has('any_name') ) {
     jQuery('#any_name').val(params.get('any_name'));
     jQuery('#stock_type_select').val(0);
+  }
+  if ( params.has('stock_type') ) {
+    var type = params.get('stock_type');
+    var value =  jQuery("#stock_type_select option[title="+ type +"]").val();
+    jQuery('#stock_type_select').val(value);
+
+  }
+  if ( params.has('prop') & params.has('value') ) {
+    editable_stockprops_search[params.get('prop')] = {"matchtype": "exactly"};
+    editable_stockprops_search[params.get('prop')]["value"] = params.get('value');
   }
 }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
This PR get optional stock prop parameters given in the url to load the search page

Parameters are prop and value

Ex.
/search/stocks?prop=variety&value=NASE3


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
