### PR TITLE
User Registration Improvements

### DIFF
--- a/lib/SGN/Controller/AJAX/User.pm
+++ b/lib/SGN/Controller/AJAX/User.pm
@@ -73,7 +73,7 @@ sub new_account :Path('/ajax/user/new') Args(0) {
 	= map { $c->req->params->{$_} } (qw|first_name last_name username password confirm_password email_address organization breeding_programs|);
 
     # Set organization from breeding programs, if provided
-    if (ref($breeding_program_ids) ne 'ARRAY') {
+    if ($breeding_program_ids && ref($breeding_program_ids) ne 'ARRAY') {
         $breeding_program_ids = [$breeding_program_ids];
     }
     my @breeding_program_names;
@@ -109,10 +109,6 @@ sub new_account :Path('/ajax/user/new') Args(0) {
 	}
 	if ("$password" ne "$confirm_password") {
 	    push @fail, "Password and confirm password do not match.";
-	}
-
-	if (!$organization) {
-	    push @fail, "'Organization' is required.'";
 	}
 
 	if ($password eq $username) {

--- a/lib/SGN/Controller/AJAX/User.pm
+++ b/lib/SGN/Controller/AJAX/User.pm
@@ -76,7 +76,9 @@ sub new_account :Path('/ajax/user/new') Args(0) {
 	my @fail = ();
 	if (length($username) < 7) {
 	    push @fail, "Username is too short. Username must be 7 or more characters";
-	} else {
+	} elsif ( $username =~ /\s/ ) {
+        push @fail, "Username must not contain spaces";
+    } else {
 	    # does user already exist?
 	    #
 	    my $existing_login = CXGN::People::Login -> get_login($c->dbc()->dbh(), $username);

--- a/lib/SGN/Controller/AJAX/User.pm
+++ b/lib/SGN/Controller/AJAX/User.pm
@@ -105,6 +105,12 @@ sub new_account :Path('/ajax/user/new') Args(0) {
 	if ($email_address !~ m/[^\@]+\@[^\@]+/) {
 	    push @fail, "Email address is invalid.";
 	}
+    if ( $email_address ) {
+        my @person_ids = CXGN::People::Login->get_login_by_email($c->dbc()->dbh(), $email_address);
+        if ( scalar(@person_ids) > 0 ) {
+            push @fail, "Email address is already associated with an account.";
+        }
+    }
 	unless($first_name) {
 	    push @fail,"You must enter a first name or initial.";
 	}

--- a/lib/SGN/Controller/AJAX/User.pm
+++ b/lib/SGN/Controller/AJAX/User.pm
@@ -73,6 +73,9 @@ sub new_account :Path('/ajax/user/new') Args(0) {
 	= map { $c->req->params->{$_} } (qw|first_name last_name username password confirm_password email_address organization breeding_programs|);
 
     # Set organization from breeding programs, if provided
+    if (ref($breeding_program_ids) ne 'ARRAY') {
+        $breeding_program_ids = [$breeding_program_ids];
+    }
     my @breeding_program_names;
     if ( !$organization && $breeding_program_ids ) {
         foreach my $breeding_program_id (@$breeding_program_ids) {

--- a/lib/SGN/Controller/AJAX/User.pm
+++ b/lib/SGN/Controller/AJAX/User.pm
@@ -142,9 +142,6 @@ sub new_account :Path('/ajax/user/new') Args(0) {
     my $subject="[$project_name] Email Address Confirmation Request";
     my $body=<<END_HEREDOC;
 
-Please do *NOT* reply to this message. The return address is not valid.
-Use the contact form instead ($host/contact/form).
-
 This message is sent to confirm the email address for community user
 \"$username\"
 
@@ -155,6 +152,10 @@ $host/user/confirm?username=$username&confirm_code=$confirm_code
 
 Thank you,
 $project_name Team
+
+Please do *NOT* reply to this message. If you have any trouble confirming your 
+email address or have any other questions, please use the contact form instead:
+$host/contact/form
 
 END_HEREDOC
 

--- a/lib/SGN/Controller/User.pm
+++ b/lib/SGN/Controller/User.pm
@@ -80,7 +80,6 @@ sub confirm_user :Path('/user/confirm') Args(0) {
 }
 
 sub confirm_failure {
-    my $self = shift;
     my $c = shift;
     my $reason = shift;
 

--- a/mason/site/login_dialog.mas
+++ b/mason/site/login_dialog.mas
@@ -5,6 +5,10 @@
 $goto_url => '/'
 </%args>
 
+<%init>
+    my $join_breeding_programs = eval{ $c->get_conf('user_registration_join_breeding_programs') };
+</%init>
+
 <div class="modal fade" id="site_login_dialog" name="site_login_dialog" tabindex="-1" role="dialog" aria-labelledby="site_login_dialog_title">
     <div class="modal-dialog modal-sm" role="document">
         <div class="modal-content">
@@ -117,12 +121,21 @@ $goto_url => '/'
                                             <input class="form-control" type="text" name="last_name" value="" />
                                         </div>
                                     </div>
+% if ( $join_breeding_programs ) { 
+                                    <div class="form-group">
+                                        <label class="col-sm-3 control-label">Breeding Program(s): </label>
+                                        <div class="col-sm-9">
+                                            <div id="breeding_programs_div"></div>
+                                      </div>
+                                    </div>
+% } else {  
                                     <div class="form-group">
                                         <label class="col-sm-3 control-label">Organization: </label>
                                         <div class="col-sm-9">
                                             <input class="form-control" type="text" name="organization" value="" />
                                         </div>
                                     </div>
+% }
                                     <div class="form-group">
                                         <label class="col-sm-3 control-label">Username: </label>
                                         <div class="col-sm-9">
@@ -199,6 +212,7 @@ jQuery(document).ready( function() {
         event.preventDefault();
         jQuery('#site_login_new_user_dialog').modal('show');
     });
+    get_select_box('breeding_programs', 'breeding_programs_div', { 'name' : 'breeding_programs', 'id' : 'breeding_programs', 'multiple':1 });
 
     jQuery('#new_account_form').submit(function(event) {
         event.preventDefault();

--- a/mason/site/login_dialog.mas
+++ b/mason/site/login_dialog.mas
@@ -27,21 +27,27 @@ $goto_url => '/'
                         <br />
                         <input class="form-control" style="width:240px" id="password" name="password" placeholder="Password" type="password" value="secretpw"/>
 % } else {
-                        <input class="form-control" style="width:240px" id="username" name="username" placeholder="Username" type="text" />
+                        <div class="input-group">
+                            <input class="form-control" id="username" name="username" placeholder="Username" type="text" tabindex="1" />
+                            <span class="input-group-btn">
+                                <button id="forgot_username_modal_show" class="btn btn-default" type="button" tabindex="4">&nbsp;<span class="glyphicon glyphicon-question-sign"></span>&nbsp;</button>
+                            </span>
+                        </div>
                         <br />
-                        <input class="form-control" style="width:240px" id="password" name="password" placeholder="Password" type="password" />
+                        <div class="input-group">
+                            <input class="form-control" id="password" name="password" placeholder="Password" type="password" tabindex="2" />
+                            <span class="input-group-btn">
+                                <button id="reset_password_modal_show" class="btn btn-default" type="button" tabindex="5">&nbsp;<span class="glyphicon glyphicon-question-sign"></span>&nbsp;</button>
+                            </span>
+                        </div>
 % }
                         <br />
-                        <div style="margin-bottom:40px">
-                            <a class="btn btn-default btn-sm" id="reset_password_modal_show" style="float:left">Forgot password?</a>
-                            <a class="btn btn-default btn-sm" id="new_user_modal_show" style="float:right">New User</a>
-                        </div>
 
                         <input type="hidden" value="<% $goto_url %>" id="goto_url" name="goto_url" />
 
                         <div>
-                            <button class="btn btn-secondary" id="cancel_login" type="reset" style="float:left" >Reset</button>
-                            <button class="btn btn-primary" id="submit_password" name="submit_password" type="submit" style="float:right">Login</button>
+                            <button class="btn btn-default" id="new_user_modal_show" style="float:left" tabindex="6">New User</a>
+                            <button class="btn btn-primary" id="submit_password" name="submit_password" type="submit" style="float:right" tabindex="3">Login</button>
                         </div>
                     </div>
                 </form>
@@ -50,6 +56,35 @@ $goto_url => '/'
 %  if (!$c->config->{require_login}) {
                 <button id="close_site_login_dialog_button" type="button" class="btn btn-default" data-dismiss="modal" style="float:left">Close</button>
 %  }
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="site_login_forgot_username_dialog" name="site_login_forgot_username_dialog" tabindex="-1" role="dialog" aria-labelledby="site_login_forgot_username_dialog_title">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header" style="text-align:center">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h3 class="modal-title" id="site_login_forgot_username_dialog_title">Forgot Username</h3>
+            </div>
+            <div class="modal-body">
+                <div>
+                    If you've forgotten your username, enter your email address below. An email will be sent with any account username(s) associated with your email address.
+                </div>
+                <br />
+                <div style="white-space:nowrap">
+                    <form id="forgot_username_form" name="forgot_username_form" style="white-space:nowrap">
+                        <div style="white-space:nowrap; align:center">
+                            <label class="textlabel">Email Address</label>
+                            <input class="form-control" style="width:200px; white-space:nowrap; float:center" id="forgot_username_email" name="forgot_username_email" /><br />
+                            <button type="submit" class="btn btn-primary" id="submit_forgot_username_email" style="float:center" >Get Username(s)</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="close_site_login_forgot_username_dialog_button" type="button" class="btn btn-default" data-dismiss="modal" style="float:left">Close</button>
             </div>
         </div>
     </div>
@@ -186,6 +221,31 @@ $goto_url => '/'
 <script>
 jQuery(document).ready( function() { 
 
+    jQuery("#site_login_dialog").on('shown.bs.modal', function() {
+        jQuery("#username").focus();
+    });
+
+    jQuery('#forgot_username_modal_show').click(function() {
+        jQuery('#site_login_forgot_username_dialog').modal('show');
+    });
+
+    jQuery('#forgot_username_form').submit(function(event) {
+        event.preventDefault();
+        var form_data = jQuery('#forgot_username_form').serialize();
+        jQuery.ajax( {
+            url: '/ajax/user/forgot_username',
+            data: form_data,
+            error: function(r) { alert('An error occurred! Sorry!');  },
+            success: function(r) {
+                if (r.error) { alert(r.error); }
+                else { 
+                    alert(r.message);
+                    jQuery('#site_login_forgot_username_dialog').modal('hide');
+                }
+            }
+        });
+    });
+
     jQuery('#reset_password_modal_show').click(function(){
         event.preventDefault();
         jQuery('#site_login_reset_password_dialog').modal('show');
@@ -202,7 +262,7 @@ jQuery(document).ready( function() {
                 if (r.error) { alert(r.error); }
                 else { 
                     alert(r.message);
-                    window.history.back();
+                    jQuery('#site_login_reset_password_dialog').modal('hide');
                 }
             }
         });
@@ -212,7 +272,9 @@ jQuery(document).ready( function() {
         event.preventDefault();
         jQuery('#site_login_new_user_dialog').modal('show');
     });
-    get_select_box('breeding_programs', 'breeding_programs_div', { 'name': 'breeding_programs', 'id': 'breeding_programs', 'default': -1, 'multiple': 1 });
+    jQuery("#site_login_new_user_dialog").on('shown.bs.modal', function() {
+        get_select_box('breeding_programs', 'breeding_programs_div', { 'name': 'breeding_programs', 'id': 'breeding_programs', 'default': -1, 'multiple': 1 });
+    });
 
     jQuery('#new_account_form').submit(function(event) {
         event.preventDefault();
@@ -235,7 +297,7 @@ jQuery(document).ready( function() {
                 }
             }
         });
-   });
+    });
 
     jQuery('#login_form').submit( function(event) { 
         event.preventDefault();

--- a/mason/site/login_dialog.mas
+++ b/mason/site/login_dialog.mas
@@ -2,7 +2,7 @@
 <!-- Login Dialog -->
 
 <%args>
-$goto_url => ''
+$goto_url => '/'
 </%args>
 
 <div class="modal fade" id="site_login_dialog" name="site_login_dialog" tabindex="-1" role="dialog" aria-labelledby="site_login_dialog_title">
@@ -239,11 +239,11 @@ jQuery(document).ready( function() {
                     alert(r.error);
                     return;
                 }
-                if (r.goto_url) { 
+                if (r.goto_url && r.goto_url !== "" ) { 
                     location.href=r.goto_url;
                 }
                 else {
-                    location.reload();
+                    location.href='/';
                 }
             }
         });

--- a/mason/site/login_dialog.mas
+++ b/mason/site/login_dialog.mas
@@ -215,8 +215,9 @@ jQuery(document).ready( function() {
                 console.log(r);
                 if (r.error) { alert(r.error); }
                 else {
-                    alert('New account added. Check your email.');
-                    history.back();
+                    alert('New account added. Check your email for the confirmation link - you must confirm your account before you can login.');
+                    jQuery('#site_login_new_user_dialog').modal('hide');
+                    jQuery('#site_login_dialog').modal('hide');
                 }
             }
         });

--- a/mason/site/login_dialog.mas
+++ b/mason/site/login_dialog.mas
@@ -212,7 +212,7 @@ jQuery(document).ready( function() {
         event.preventDefault();
         jQuery('#site_login_new_user_dialog').modal('show');
     });
-    get_select_box('breeding_programs', 'breeding_programs_div', { 'name' : 'breeding_programs', 'id' : 'breeding_programs', 'multiple':1 });
+    get_select_box('breeding_programs', 'breeding_programs_div', { 'name': 'breeding_programs', 'id': 'breeding_programs', 'default': -1, 'multiple': 1 });
 
     jQuery('#new_account_form').submit(function(event) {
         event.preventDefault();

--- a/sgn.conf
+++ b/sgn.conf
@@ -43,6 +43,7 @@ seedlot_maintenance_info_cvterms
 
 project_name SGN
 
+user_registration_join_breeding_programs 0  # when enabled, a new user can choose which breeding programs to join during registration
 disable_login 0
 default_login_janedoe 0
 require_login 0

--- a/t/unit_mech/AJAX/Login.t
+++ b/t/unit_mech/AJAX/Login.t
@@ -24,16 +24,16 @@ is($response->{message}, 'Login successful');
 $mech->get_ok('http://localhost:3010/ajax/user/new?first_name=testfirst&last_name=testlast&username=testusername&password=testpass&confirm_password=testpass&email_address=test@testcassavabase.com');
 $response = decode_json $mech->content;
 print STDERR Dumper $response;
-is_deeply($response, {'error' => 'Account creation failed for the following reason(s): \'Organization\' is required.\''});
-
-$mech->get_ok('http://localhost:3010/ajax/user/new?first_name=testfirst&last_name=testlast&username=testusername&password=testpass&confirm_password=testpass&email_address=test@testcassavabase.com&organization=testorg');
-$response = decode_json $mech->content;
-print STDERR Dumper $response;
 is_deeply($response, {'message' => ' <table summary="" width="80%" align="center">
 <tr><td><p>Account was created with username "testusername". To continue, you must confirm that SGN staff can reach you via email address "test@testcassavabase.com". An email has been sent with a URL to confirm this address. Please check your email for this message and use the link to confirm your email address.</p></td></tr>
 <tr><td><br /></td></tr>
 </table>
 '});
+
+$mech->get_ok('http://localhost:3010/ajax/user/new?first_name=testfirst&last_name=testlast&username=testusername&password=testpass&confirm_password=testpass&email_address=test@testcassavabase.com&organization=testorg');
+$response = decode_json $mech->content;
+print STDERR Dumper $response;
+is_deeply($response, {'error' => 'Account creation failed for the following reason(s): Username "testusername" is already in use. Please pick a different username.'});
 
 #confirm account is still in cgi-bin, so test lacking here. will do manually
 my $q = "update sgn_people.sp_person set disabled = default where username = 'testusername';";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


Some minor improvements to the user registration workflow:

- Rephrase confirmation email message ('The return address is not valid' was confusing some users - thought their request for an account failed)
- Usernames should not contain spaces (this caused the confirmation link in the email to break, possibly other issues?)
- Email addresses can only be registered to one account (we had users creating a lot of duplicate accounts)
- Replace back navigation after registration with closing the modal dialogs
- Fix confirmation error message display on confirmation page
- Fix redirect on login page, if `goto_url` is not specified
- Add a forgot username function (sends email with username(s) associated with the email address)
- Reorganize forgot username / buttons on login dialog

Changes to user organization on registration (**DISABLED BY DEFAULT**):

- When enabled (by the `user_registration_join_breeding_programs` config key):
    - The user can select 0+ breeding programs to join during registration
    - The organization field will be set to a comma-separated list of breeding program names
    - The user will be added to the selected breeding program roles
- When disabled:
    - The user can enter any organization name
    - The organization field is set to the user's input
    - No additional roles are added
- Remove requirement for organization during registration (in case user is not part of any of the pre-defined breeding programs)


Fixes #3216 
Addresses some of the issues in #1906 



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
