### PR TITLE
Multi Trial Upload: improve error message for multiple synonyms

### DIFF
--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
@@ -529,7 +529,11 @@ sub _validate_with_plugin {
       push @error_messages, "Accession(s) <b>".join(',',@accessions_missing)."</b> are not in the database as uniquenames or synonyms.";
   }
   if (scalar(@multiple_synonyms) > 0) {
-      push @error_messages, "Accession(s) <b>".join(',',@multiple_synonyms)."</b> appear in the database as synonyms of more than one unique accession. Please change to the unique accession name or delete the multiple synonyms";
+      my @msgs;
+      foreach my $m (@multiple_synonyms) {
+          push(@msgs, 'Name: ' . @$m[0] . ' = Synonym: ' . @$m[1]);
+      }
+      push @error_messages, "Accession(s) <b>".join(',',@msgs)."</b> appear in the database as synonyms of more than one unique accession. Please change to the unique accession name or delete the multiple synonyms";
   }
 
   ## SEEDLOTS OVERALL VALIDATION


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

A minor bug fix for the error message displayed in the multi-trial upload when multiple synonyms are found.

The`multiple_synonyms` array is a 2D-array where each item is an array of the uniquename and synonym.  This changes the error message to display the name and synonym (rather than the array reference).

**Before:**
![Screen Shot 2021-11-17 at 2 10 09 PM](https://user-images.githubusercontent.com/7526014/142267555-c52c23cf-6241-4e3c-8ea5-20c79a9f9e7e.png)

**After:**
![Screen Shot 2021-11-17 at 2 22 57 PM](https://user-images.githubusercontent.com/7526014/142268758-2bf2736c-e300-464b-8e0d-2fab8a66071f.png)




Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
