### PR TITLE
remove \r characters from line endings in fieldbook file upload

### DIFF
--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/FieldBook.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/FieldBook.pm
@@ -19,6 +19,7 @@ package CXGN::Phenotypes::ParseUpload::Plugin::FieldBook;
 use Moose;
 use File::Slurp;
 use Text::CSV;
+use Data::Dumper;
 
 sub name {
     return "field book";
@@ -39,6 +40,15 @@ sub validate {
 
     ## Check that the file can be read
     my @file_lines = read_file($filename);
+
+    print STDERR "LINES READ ".Dumper(\@file_lines);
+
+    # fix DOS-style line-endings!!!
+    #
+    foreach my $fl (@file_lines) {
+	$fl =~ s/\r//g;
+    }
+    
     if (!@file_lines) {
         $parse_result{'error'} = "Could not read file.";
         print STDERR "Could not read file.\n";

--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/FieldBook.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/FieldBook.pm
@@ -41,8 +41,6 @@ sub validate {
     ## Check that the file can be read
     my @file_lines = read_file($filename);
 
-    print STDERR "LINES READ ".Dumper(\@file_lines);
-
     # fix DOS-style line-endings!!!
     #
     foreach my $fl (@file_lines) {

--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/FieldBook.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/FieldBook.pm
@@ -136,6 +136,13 @@ sub parse {
                 or die "Cannot use CSV: ".Text::CSV->error_diag ();
 
     @file_lines = read_file($filename);
+
+    # fix DOS-style line-endings!!!
+    #
+    foreach my $fl (@file_lines) {
+	$fl =~ s/\r//g;
+    }
+
     $header = shift(@file_lines);
     my $status  = $csv->parse($header);
     my @header_row = $csv->fields();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Interestingly, File::Slurp is not intelligent enough to remove DOS style line endings! Adding a line to do that here, otherwise DOS style file cause the` upload to fail.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
