### PR TITLE
remove extra column in table to fix DataTable warning

### DIFF
--- a/mason/breeders_toolbox/genotyping_data_project/protocols.mas
+++ b/mason/breeders_toolbox/genotyping_data_project/protocols.mas
@@ -13,7 +13,6 @@ $trial_id
                 <th>Description</th>
                 <th>Reference Genome</th>
                 <th>Species Name</th>
-                <th>Sample Type</th>
             </tr>
         </thead>
     </table>


### PR DESCRIPTION
Viewing the trial detail page causes a javascript error popup with DataTable error. This is caused by the genotyping protocols section that has an extra column. Removing the extra column "Sample Type" fixes the problem


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
