### PR TITLE
Allow reciprocal crosses to be included in the same family

### DIFF
--- a/db/00154/AddFamilyTypeCvterm.pm
+++ b/db/00154/AddFamilyTypeCvterm.pm
@@ -1,0 +1,86 @@
+#!/usr/bin/env perl
+
+
+=head1 NAME
+
+ AddFamilyTypeCvterm
+
+=head1 SYNOPSIS
+
+mx-run AddFamilyTypeCvterm [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+This patch adds family_type stock_property cvterm
+This subclass uses L<Moose>. The parent class uses L<MooseX::Runnable>
+
+=head1 AUTHOR
+
+Titima Tantikanjana <tt15@cornell.edu>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2010 Boyce Thompson Institute for Plant Research
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+
+package AddFamilyTypeCvterm;
+
+use Moose;
+use Bio::Chado::Schema;
+use Try::Tiny;
+extends 'CXGN::Metadata::Dbpatch';
+
+
+has '+description' => ( default => <<'' );
+This patch adds the 'family_type' stock_property cvterm
+
+has '+prereq' => (
+	default => sub {
+        [],
+    },
+
+);
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+
+    print STDOUT "\nExecuting the SQL commands.\n";
+    my $schema = Bio::Chado::Schema->connect( sub { $self->dbh->clone } );
+
+
+    print STDERR "INSERTING CV TERMS...\n";
+
+    my $terms = {
+        'stock_property' => [
+            'family_type',
+        ]
+    };
+
+	foreach my $t (keys %$terms){
+		foreach (@{$terms->{$t}}){
+			$schema->resultset("Cv::Cvterm")->create_with({
+				name => $_,
+				cv => $t
+			});
+		}
+	}
+
+
+    print "You're done!\n";
+}
+
+
+####
+1; #
+####

--- a/lib/CXGN/Pedigree/AddFamilyNames.pm
+++ b/lib/CXGN/Pedigree/AddFamilyNames.pm
@@ -75,6 +75,7 @@ sub add_family_name {
         my $male_parent_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($chado_schema,  'male_parent', 'stock_relationship')->cvterm_id();
 		my $family_female_parent_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($chado_schema,  'family_female_parent_of', 'stock_relationship')->cvterm_id();
 		my $family_male_parent_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($chado_schema,  'family_male_parent_of', 'stock_relationship')->cvterm_id();
+		my $family_type_cvterm = SGN::Model::Cvterm->get_cvterm_row($chado_schema,  'family_type', 'stock_property');
 
        #Get stock of type cross matching cross name
         $cross_stock = $self->_get_cross($cross_name);
@@ -157,13 +158,15 @@ sub add_family_name {
 	            });
             }
         } else {
-            my $new_family_name_rs;
-            $new_family_name_rs = $chado_schema->resultset("Stock::Stock")->create({
+            my $new_family_name_rs = $chado_schema->resultset("Stock::Stock")->create({
                 organism_id => $organism_id,
                 name       => $family_name,
                 uniquename => $family_name,
                 type_id    => $family_name_cvterm_id,
             });
+
+            #create family_type stock_property
+            $new_family_name_rs->create_stockprops({$family_type_cvterm->name() => $family_type});
 
             #create relationship between new family_name and cross
             $new_family_name_rs->find_or_create_related('stock_relationship_objects', {

--- a/lib/CXGN/Pedigree/AddFamilyNames.pm
+++ b/lib/CXGN/Pedigree/AddFamilyNames.pm
@@ -113,9 +113,9 @@ sub add_family_name {
 
         if ($family_name_rs){
 
-            my $stored_family_type = $chado_schema->resultset("Stock::Stockprop")->search({ stock_id => $family_name_rs->stock_id(), type_id => $family_type_cvterm->cvterm_id() });
+            my $stored_family_type = $chado_schema->resultset("Stock::Stockprop")->find({ stock_id => $family_name_rs->stock_id(), type_id => $family_type_cvterm->cvterm_id() })->value();
 
-            if ($stored_family_type != $family_type) {
+            if ($stored_family_type ne $family_type) {
                 push @{$return{error}},"The previously stored family type of family: $family_name is not the same as the selected family type";
                 return \%return;
             }

--- a/lib/CXGN/Pedigree/ParseUpload/Plugin/FamilyNameExcel.pm
+++ b/lib/CXGN/Pedigree/ParseUpload/Plugin/FamilyNameExcel.pm
@@ -45,13 +45,22 @@ sub _validate_with_plugin {
 
     #get column headers
     my $cross_name_head;
+    my $family_name_head;
 
     if ($worksheet->get_cell(0,0)) {
         $cross_name_head  = $worksheet->get_cell(0,0)->value();
     }
 
+    if ($worksheet->get_cell(0,1)) {
+        $family_name_head  = $worksheet->get_cell(0,1)->value();
+    }
+
     if (!$cross_name_head || $cross_name_head ne 'cross_unique_id' ) {
         push @error_messages, "Cell A1: cross_unique_id is missing from the header";
+    }
+
+    if (!$family_name_head || $family_name_head ne 'family_name' ) {
+        push @error_messages, "Cell A2: family_name is missing from the header";
     }
 
     my %seen_cross_names;

--- a/lib/SGN/Controller/AJAX/Cross.pm
+++ b/lib/SGN/Controller/AJAX/Cross.pm
@@ -1435,24 +1435,27 @@ sub upload_family_names_POST : Args(0) {
     my $metadata_schema = $c->dbic_schema("CXGN::Metadata::Schema");
     my $phenome_schema = $c->dbic_schema("CXGN::Phenome::Schema");
     my $dbh = $c->dbc->dbh;
-    my $upload;
-    my $upload_type;
     my $same_parents_upload = $c->req->upload('same_parents_file');
     my $reciprocal_parents_upload = $c->req->upload('reciprocal_parents_file');
 
+    my $upload_original_name;
+    my $upload_tempfile;
+    my $family_type;
+
     if ($same_parents_upload) {
-        $upload = $same_parents_upload;
-        $upload_type = ' ';
+        $upload_original_name = $same_parents_upload->filename();
+        $upload_tempfile = $same_parents_upload->tempname;
+        $family_type = 'same_parents';
     }
+
     if ($reciprocal_parents_upload) {
-        $upload = $reciprocal_parents_upload;
-        $upload_type = ' ';
+        $upload_original_name = $reciprocal_parents_upload->filename();
+        $upload_tempfile = $reciprocal_parents_upload->tempname;
+        $family_type = 'reciprocal_parents';
     }
 
     my $parser;
     my $parsed_data;
-    my $upload_original_name = $upload->filename();
-    my $upload_tempfile = $upload->tempname;
     my $subdirectory = "cross_upload";
     my $archived_filename_with_path;
     my $md5;
@@ -1547,6 +1550,7 @@ sub upload_family_names_POST : Args(0) {
                 cross_name => $cross_name,
                 family_name => $family_name,
                 owner_name => $user_name,
+                family_type => $family_type
             });
 
             my $return = $family_name_add->add_family_name();

--- a/lib/SGN/Controller/AJAX/Cross.pm
+++ b/lib/SGN/Controller/AJAX/Cross.pm
@@ -1435,7 +1435,20 @@ sub upload_family_names_POST : Args(0) {
     my $metadata_schema = $c->dbic_schema("CXGN::Metadata::Schema");
     my $phenome_schema = $c->dbic_schema("CXGN::Phenome::Schema");
     my $dbh = $c->dbc->dbh;
-    my $upload = $c->req->upload('family_name_upload_file');
+    my $upload;
+    my $upload_type;
+    my $same_parents_upload = $c->req->upload('same_parents_file');
+    my $reciprocal_parents_upload = $c->req->upload('reciprocal_parents_file');
+
+    if ($same_parents_upload) {
+        $upload = $same_parents_upload;
+        $upload_type = ' ';
+    }
+    if ($reciprocal_parents_upload) {
+        $upload = $reciprocal_parents_upload;
+        $upload_type = ' ';
+    }
+
     my $parser;
     my $parsed_data;
     my $upload_original_name = $upload->filename();

--- a/lib/SGN/Controller/Cross.pm
+++ b/lib/SGN/Controller/Cross.pm
@@ -655,12 +655,10 @@ sub family_name_detail : Path('/family') Args(1) {
         if ($family_prop){
             $family_type = $family_prop->value();
             if ($family_type eq 'same_parents'){
-                $family_type_string = 'This family includes only crosses having the same female accession and the same male accession';
+                $family_type_string = 'This family includes only crosses having the same female parent and the same male parent';
             } elsif ($family_type eq 'reciprocal_parents'){
                 $family_type_string = 'This family includes reciprocal crosses';
             }
-        } else {
-            $family_type_string = 'This family includes only crosses having the same female accession and the same male accession';
         }
     }
 

--- a/lib/SGN/Controller/Cross.pm
+++ b/lib/SGN/Controller/Cross.pm
@@ -642,6 +642,7 @@ sub family_name_detail : Path('/family') Args(1) {
     my $family_id;
     my $family_name;
     my $family_type;
+    my $family_type_string;
 	if (!$family) {
     	$c->stash->{template} = '/generic_message.mas';
     	$c->stash->{message} = 'The requested family name does not exist.';
@@ -649,11 +650,17 @@ sub family_name_detail : Path('/family') Args(1) {
     } else {
         $family_id = $family->stock_id();
         $family_name = $family->uniquename();
-        my $type = $schema->resultset("Stock::Stockprop")->find({ stock_id => $family_id, type_id => $family_type_id})->value();
-        if (($type eq 'same_parents') || ($type eq '')){
-            $family_type = 'This family includes only crosses having the same parental genotypes';
-        } elsif ($type eq 'reciprocal_parents'){
-            $family_type = 'This family includes reciprocal crosses';
+        my $family_prop = $schema->resultset("Stock::Stockprop")->find({ stock_id => $family_id, type_id => $family_type_id});
+
+        if ($family_prop){
+            $family_type = $family_prop->value();
+            if ($family_type eq 'same_parents'){
+                $family_type_string = 'This family includes only crosses having the same female accession and the same male accession';
+            } elsif ($family_type eq 'reciprocal_parents'){
+                $family_type_string = 'This family includes reciprocal crosses';
+            }
+        } else {
+            $family_type_string = 'This family includes only crosses having the same female accession and the same male accession';
         }
     }
 
@@ -661,6 +668,7 @@ sub family_name_detail : Path('/family') Args(1) {
     $c->stash->{user_id} = $c->user ? $c->user->get_object()->get_sp_person_id() : undef;
     $c->stash->{family_id} = $family_id;
     $c->stash->{family_type} = $family_type;
+    $c->stash->{family_type_string} = $family_type_string;
     $c->stash->{template} = '/breeders_toolbox/cross/family.mas';
 
 }

--- a/mason/breeders_toolbox/cross/family.mas
+++ b/mason/breeders_toolbox/cross/family.mas
@@ -4,8 +4,8 @@ $family_id
 $family_name => ''
 $user_id => undef
 $identifier_prefix => ''
-$family_type => ''
-$family_type_string => ''
+$family_type
+$family_type_string
 </%args>
 
 <& /util/import_javascript.mas, classes => ["jquery", "jqueryui", "thickbox", "CXGN.Page.FormattingHelpers", "jquery.cookie", "CXGN.List"] &>

--- a/mason/breeders_toolbox/cross/family.mas
+++ b/mason/breeders_toolbox/cross/family.mas
@@ -4,6 +4,7 @@ $family_id
 $family_name => ''
 $user_id => undef
 $identifier_prefix => ''
+$family_type => ''
 </%args>
 
 <& /util/import_javascript.mas, classes => ["jquery", "jqueryui", "thickbox", "CXGN.Page.FormattingHelpers", "jquery.cookie", "CXGN.List"] &>
@@ -42,7 +43,7 @@ $identifier_prefix => ''
 <& /util/import_javascript.mas, classes => ['jquery','jquery.dataTables'] &>
 <& /util/import_css.mas, paths => ['/documents/inc/datatables/jquery.dataTables.css'] &>
 
-<&| /page/info_section.mas, title => 'Parents', collapsible=>1, collapsed=>0 &>
+<&| /page/info_section.mas, title => "Parents: ($family_type)", collapsible=>1, collapsed=>0 &>
     <div class = "well well-sm">
         <div class = "panel panel-default">
             <div class = "panel-body">

--- a/mason/breeders_toolbox/cross/family.mas
+++ b/mason/breeders_toolbox/cross/family.mas
@@ -5,6 +5,7 @@ $family_name => ''
 $user_id => undef
 $identifier_prefix => ''
 $family_type => ''
+$family_type_string => ''
 </%args>
 
 <& /util/import_javascript.mas, classes => ["jquery", "jqueryui", "thickbox", "CXGN.Page.FormattingHelpers", "jquery.cookie", "CXGN.List"] &>
@@ -43,19 +44,28 @@ $family_type => ''
 <& /util/import_javascript.mas, classes => ['jquery','jquery.dataTables'] &>
 <& /util/import_css.mas, paths => ['/documents/inc/datatables/jquery.dataTables.css'] &>
 
-<&| /page/info_section.mas, title => "Parents: ($family_type)", collapsible=>1, collapsed=>0 &>
+<&| /page/info_section.mas, title => "Parents: ($family_type_string)", collapsible=>1, collapsed=>0 &>
     <div class = "well well-sm">
         <div class = "panel panel-default">
             <div class = "panel-body">
                 <table id = "family_parent_information" class="table table-hover table-striped">
                     <thead>
                         <tr>
+% if ($family_type eq 'same_parents') {
                             <th>Female Parent</th>
                             <th>Female Stock Type</th>
                             <th>Female Ploidy</th>
                             <th>Male Parent</th>
                             <th>Male Stock Type</th>
                             <th>Male Ploidy</th>
+% } elsif ($family_type eq 'reciprocal_parents') {
+                            <th>Parent 1</th>
+                            <th>Parent 1 Stock Type</th>
+                            <th>Parent 1 Ploidy</th>
+                            <th>Parent 2</th>
+                            <th>Parent 2 Stock Type</th>
+                            <th>Parent 2 Ploidy</th>
+%}
                         </tr>
                     </thead>
                 </table>

--- a/mason/breeders_toolbox/cross/progenies_in_crossingtrial.mas
+++ b/mason/breeders_toolbox/cross/progenies_in_crossingtrial.mas
@@ -283,10 +283,30 @@ $trial_id
                     </&>
                     <form class="form-horizontal" role="form" method="post" enctype="multipart/form-data" encoding="multipart/form-data" id="upload_family_name_form" name="upload_family_name_form">
                         <div class="form-group">
-                            <label class="col-sm-2 control-label">Upload File: </label>
-                                <div class="col-sm-10">
-                                    <input type="file" name="family_name_upload_file" id="family_name_upload_file" encoding="multipart/form-data" />
+                            <label class="col-sm-2 control-label">Family Type: </label>
+                            <div class="col-sm-6">
+                                <select class="form-control" id="family_type_option">
+                                    <option value="">Select a family type</option>
+                                    <option value="same_parents">Include only crosses with the same parental genotypes</option>
+                                    <option value="reciprocal_parents">Include reciprocal crosses</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div id="upload_family_with_the_same_parents" style="display:none">
+                            <div class="form-group">
+                                <label class="col-sm-2 control-label">Upload File (.xls): </label>
+                                <div class="col-sm-10" >
+                                    <input type="file" name="same_parents_file" id="same_parents_file" encoding="multipart/form-data" />
                                 </div>
+                            </div>
+                        </div>
+                        <div id="upload_family_with_reciprocal_parents" style="display:none">
+                            <div class="form-group">
+                                <label class="col-sm-2 control-label">Upload File (.xls): </label>
+                                <div class="col-sm-10" >
+                                    <input type="file" name="reciprocal_parents_file" id="reciprocal_parents_file" encoding="multipart/form-data" />
+                                </div>
+                            </div>
                         </div>
                     </form>
                 </div>
@@ -498,7 +518,7 @@ jQuery(document).ready(function(){
             data: {
                 'archived_file_name':archived_file_name,
                 'overwrite_pedigrees':jQuery('#cross_upload_overwrite_pedigrees').is(":checked"),
-                'user_id' : user_id,               
+                'user_id' : user_id,
             },
             beforeSend: function(){
                 jQuery('#working_modal').modal('show');
@@ -532,13 +552,39 @@ jQuery(document).ready(function(){
         jQuery("#upload_family_name_dialog").modal("show");
     });
 
+    jQuery("#family_type_option").change(function(){
+        if (jQuery(this).val() == ""){
+            jQuery("#upload_family_with_the_same_parents").hide();
+            jQuery("#upload_family_with_reciprocal_parents").hide();
+        }
+        if (jQuery(this).val() == "same_parents"){
+            jQuery("#upload_family_with_the_same_parents").show();
+            jQuery("#upload_family_with_reciprocal_parents").hide();
+        }
+        if(jQuery(this).val() == "reciprocal_parents"){
+            jQuery("#upload_family_with_reciprocal_parents").show();
+            jQuery("#upload_family_with_the_same_parents").hide();
+
+        }
+    });
+
     jQuery("#upload_family_name_submit").click(function(){
-        var uploadFile = jQuery("#family_name_upload_file").val();
+        var familyType = jQuery("#family_type_option").val();
+        var sameParentsFile = jQuery("#same_parents_file").val();
+        var reciprocalParentsFile = jQuery("#reciprocal_parents_file").val();
+
         jQuery('#upload_family_name_form').attr("action", "/ajax/cross/upload_family_names");
-        if (uploadFile === ''){
+
+        if (familyType === ''){
+            alert("Please select a family type");
+            return;
+        }
+
+        if (sameParentsFile === '' && reciprocalParentsFile === ''){
             alert("Please select a file");
             return;
         }
+
         jQuery("#upload_family_name_form").submit();
         jQuery("#upload_family_name_dialog").modal("hide");
     });

--- a/mason/breeders_toolbox/cross/progenies_in_crossingtrial.mas
+++ b/mason/breeders_toolbox/cross/progenies_in_crossingtrial.mas
@@ -284,10 +284,10 @@ $trial_id
                     <form class="form-horizontal" role="form" method="post" enctype="multipart/form-data" encoding="multipart/form-data" id="upload_family_name_form" name="upload_family_name_form">
                         <div class="form-group">
                             <label class="col-sm-2 control-label">Family Type: </label>
-                            <div class="col-sm-6">
+                            <div class="col-sm-8">
                                 <select class="form-control" id="family_type_option">
                                     <option value="">Select a family type</option>
-                                    <option value="same_parents">Include only crosses with the same parental genotypes</option>
+                                    <option value="same_parents">Include only crosses with the same female parent and the same male parent</option>
                                     <option value="reciprocal_parents">Include reciprocal crosses</option>
                                 </select>
                             </div>

--- a/mason/breeders_toolbox/cross/progenies_in_crossingtrial.mas
+++ b/mason/breeders_toolbox/cross/progenies_in_crossingtrial.mas
@@ -283,7 +283,7 @@ $trial_id
                     </&>
                     <form class="form-horizontal" role="form" method="post" enctype="multipart/form-data" encoding="multipart/form-data" id="upload_family_name_form" name="upload_family_name_form">
                         <div class="form-group">
-                            <label class="col-sm-2 control-label">Family Type: </label>
+                            <label class="col-sm-3 control-label">Family Type: </label>
                             <div class="col-sm-8">
                                 <select class="form-control" id="family_type_option">
                                     <option value="">Select a family type</option>
@@ -355,14 +355,20 @@ $trial_id
                     </b>
                     <br>
                         (.xlsx format not supported)
-                    <br><br>
+                    <br>
+                    <br>
+                    <b>Family Types:</b>
+                        <ul>
+                            <li>same parents (the family includes only crosses with the same female parent and the same male parent)</li>
+                            <li>reciprocal parents (the family includes reciprocal crosses)</li>
+                            (All families in the same file must have the same family type.)
+                        </ul>
                     <b>
                         Header:
                     </b>
                     <br>
                         The first row (header) must contain the following:
                     <br>
-
                     <table class="table table-bordered table-hover">
                         <tbody>
                             <tr>
@@ -374,7 +380,7 @@ $trial_id
                     <b>Required columns:</b>
                     <ul>
                         <li>cross_unique_id (must exist in the database)</li>
-                        <li>family_name (may be new family name or family name already stored in the database. Crosses in the same family must have the same parental genotypes. If you would like to use family name previously stored in the database, please check the name carefully)</li>
+                        <li>family_name (may be new family name or family name already stored in the database. If you would like to use family name previously stored in the database, please check the name carefully)</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
