### PR TITLE
Download lists instead of displaying in browser

### DIFF
--- a/lib/SGN/Controller/AJAX/List.pm
+++ b/lib/SGN/Controller/AJAX/List.pm
@@ -240,8 +240,11 @@ sub download_list :Path('/list/download') Args(0) {
     }
 
     $list = $self->retrieve_list($c, $list_id);
+    my ($name_ref) = $self->get_list_metadata($c, $list_id);
+    my $name = $name_ref->{name};
 
     $c->res->content_type("text/plain");
+    $c->res->header('Content-Disposition'=>"attachment; filename=$name.txt");
     $c->res->body(join "\n", map { $_->[1] }  @$list);
 }
 
@@ -626,13 +629,13 @@ sub validate_lists :Path('/ajax/list/validate_lists') Args(0) {
 
     my $list_ids_string = $c->req->param('list_ids');
     my $list_types_string = $c->req->param('list_types');
-    
+
     my @list_ids = split /\,/, $list_ids_string;
     my @list_types = split /\,/, $list_types_string;
 
     my @invalid_lists = ();
     for (my $n = 0; $n<@list_ids; $n++)  {
-	
+
 	my $list = $self->retrieve_list($c, $list_ids[$n]);
 
 	my @flat_list = map { $_->[1] } @$list;
@@ -643,7 +646,7 @@ sub validate_lists :Path('/ajax/list/validate_lists') Args(0) {
 
 
 	print STDERR "Return data = ".Dumper($data);
-	
+
 	if ($list_types[$n] eq "accessions" && $data->{valid} == 0) {
 	    print STDERR "list $list_ids[$n] is invalid! ($data->{valid}) \n";
 	    push @invalid_lists, [ $list_ids[$n], $list_types[$n] ];
@@ -651,7 +654,7 @@ sub validate_lists :Path('/ajax/list/validate_lists') Args(0) {
 	elsif ($list_types[$n] ne "accessions" && scalar(@{$data->{missing}}) > 0) {
 	    print STDERR "list $list_ids[$n] is invalid! (missing = ".scalar(@{$data->{missing}}).")\n";
 	    push @invalid_lists, [ $list_ids[$n], $list_types[$n] ];
-	    
+
 	}
 	else {
 	    print STDERR "List $list_ids[$n] of type $list_types[$n] is valid :-) \n";


### PR DESCRIPTION
Description <!--  -->
-----------------------------------------------------
Changes list download behavior from displaying list in browser to giving a pop up to download list.

<!-- -->
Resolves : https://github.com/solgenomics/sgn/issues/3883 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
