### PR TITLE
BrAPI: POST observations force auth

### DIFF
--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -3773,7 +3773,8 @@ sub observations_GET {
 sub observations_POST {
 	my $self = shift;
 	my $c = shift;
-	my ($auth,$user_id,$user_type) = _authenticate_user($c);
+    my $force_authenticate = 1;
+	my ($auth,$user_id,$user_type) = _authenticate_user($c, $force_authenticate);
     my $clean_inputs = $c->stash->{clean_inputs};
     my $data = $clean_inputs;
     my @all_observations;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Minor fix for the BrAPI `POST` `/observations` endpoint to force authentication


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
