### PR TITLE
Fixes issue with multi trial upload

### DIFF
--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
@@ -420,7 +420,7 @@ sub _validate_with_plugin {
     foreach my $treatment_name (@treatment_names){
         if($worksheet->get_cell($row,$treatment_col)){
             my $apply_treatment = $worksheet->get_cell($row,$treatment_col)->value();
-            if (defined($apply_treatment) && $apply_treatment ne '1'){
+            if ( ($apply_treatment ne '') && defined($apply_treatment) && $apply_treatment ne '1'){
                 push @error_messages, "Treatment value for treatment <b>$treatment_name</b> in row $row_name should be either 1 or empty";
             }
         }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
when management factors are specified, the upload expects them to be either undef or 1, but the excel parser returns empty string or 1. This PR allows fields to be empty string as well as undef.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
