### PR TITLE
remove unsupported jQuery.browser call

### DIFF
--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -1215,25 +1215,25 @@ function getData(id, selectText) {
         data = jQuery('#'+id).html();
     }
     if (divType == 'SELECT' && selectText) {
-        if (jQuery.browser.msie) {
-            // Note: MS IE unfortunately removes all whitespace
-            // in the jQuery().text() call. Program it out...
-            //
-            var selectbox = document.getElementById(id);
-            var datalist = new Array();
-            for (var n=0; n<selectbox.length; n++) {
-                if (selectbox.options[n].selected) {
-                    var x=selectbox.options[n].text;
-                    datalist.push(x);
-                }
-            }
-            data = datalist.join("\n");
-            //alert("data:"+data);
+        //if (jQuery.browser.msie) {
+        //    // Note: MS IE unfortunately removes all whitespace
+        //    // in the jQuery().text() call. Program it out...
+        //    //
+        //    var selectbox = document.getElementById(id);
+        //    var datalist = new Array();
+        //    for (var n=0; n<selectbox.length; n++) {
+        //         if (selectbox.options[n].selected) {
+        //             var x=selectbox.options[n].text;
+        //             datalist.push(x);
+        //         }
+        //     }
+        //     data = datalist.join("\n");
+        //     //alert("data:"+data);
 
-        }
-        else {
+        // }
+        // else {
             data = jQuery('#'+id+" option:selected").text();
-        }
+        //}
 
     }
     if (divType == 'SELECT' && ! selectText) {

--- a/js/source/legacy/icon_nav.js
+++ b/js/source/legacy/icon_nav.js
@@ -14,14 +14,14 @@ jQuery( function() {
 
 // for IE below 8, screw up lots of z-Indexes to work around the
 // z-Index bug
-if( jQuery.browser.msie && jQuery.browser.version < 8 ) {
-  jQuery( function() {
-            var zIndexNumber = 1000;
-            jQuery('#siteheader div, #icon_nav div, #icon_nav li, #icon_nav ul')
-              .each( function() {
-                       jQuery(this).css('zIndex', zIndexNumber);
-                       zIndexNumber -= 10;
-                     });
-          });
+//if( jQuery.browser.msie && jQuery.browser.version < 8 ) {
+//  jQuery( function() {
+//            var zIndexNumber = 1000;
+//            jQuery('#siteheader div, #icon_nav div, #icon_nav li, #icon_nav ul')
+//              .each( function() {
+//                       jQuery(this).css('zIndex', zIndexNumber);
+//                       zIndexNumber -= 10;
+//                     });
+//          });
 
-}
+//}

--- a/js/source/legacy/jquery/simpletooltip.js
+++ b/js/source/legacy/jquery/simpletooltip.js
@@ -17,8 +17,9 @@
 				var tipY = e.pageY + 12;
 				$(this).attr("title", "");
 				$("body").append("<div id='simpleTooltip' style='position: absolute; z-index: 100; display: none;'>" + text + "</div>");
-				if($.browser.msie) var tipWidth = $("#simpleTooltip").outerWidth(true)
-				else var tipWidth = $("#simpleTooltip").width()
+				//if($.browser.msie) var tipWidth = $("#simpleTooltip").outerWidth(true)
+			        //else
+				var tipWidth = $("#simpleTooltip").width()
 				$("#simpleTooltip").width(tipWidth);
 				$("#simpleTooltip").css("left", tipX).css("top", tipY).fadeIn("medium");
 			}, function(){


### PR DESCRIPTION
remove unsupported jQuery.browser call that was used to accommodate IE weirdness. This affected the ability to create lists.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
