### PR TITLE
BrAPI observationVariable synonym query

### DIFF
--- a/lib/CXGN/BrAPI/v1/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v1/ObservationVariables.pm
@@ -188,7 +188,7 @@ sub search {
 	my $total_count = 0;
 	my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, dbxref.accession, array_agg(cvtermsynonym.synonym ORDER BY CHAR_LENGTH(cvtermsynonym.synonym)), count(cvterm.cvterm_id) OVER() AS full_count
 		FROM cvterm JOIN dbxref USING(dbxref_id)
-		JOIN db using(db_id) JOIN cvtermsynonym using(cvterm_id)
+		JOIN db using(db_id) LEFT JOIN cvtermsynonym using(cvterm_id)
 		JOIN cvterm_relationship as rel on (rel.subject_id=cvterm.cvterm_id)
 		JOIN cvterm as reltype on (rel.type_id=reltype.cvterm_id)
 		$join WHERE $and_where_clause

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -300,7 +300,7 @@ sub detail {
     my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, db.url, dbxref.accession, array_agg(cvtermsynonym.synonym ORDER BY CHAR_LENGTH(cvtermsynonym.synonym)), cvterm.is_obsolete, count(cvterm.cvterm_id) OVER() AS full_count FROM cvterm ".
         "JOIN dbxref USING(dbxref_id) ".
         "JOIN db using(db_id) ".
-        "JOIN cvtermsynonym using(cvterm_id) ".
+        "LEFT JOIN cvtermsynonym using(cvterm_id) ".
         "JOIN cvterm_relationship as rel on (rel.subject_id=cvterm.cvterm_id) ".
         "JOIN cvterm as reltype on (rel.type_id=reltype.cvterm_id) $join ".
         "WHERE $and_where " .

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -160,7 +160,7 @@ sub search {
     my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, db.url, dbxref.accession, array_agg(cvtermsynonym.synonym ORDER BY CHAR_LENGTH(cvtermsynonym.synonym)), cvterm.is_obsolete, count(cvterm.cvterm_id) OVER() AS full_count FROM cvterm ".
         "JOIN dbxref USING(dbxref_id) ".
         "JOIN db using(db_id) ".
-        "JOIN cvtermsynonym using(cvterm_id) ".
+        "LEFT JOIN cvtermsynonym using(cvterm_id) ".
         "inner JOIN cvterm_relationship as rel on (rel.subject_id=cvterm.cvterm_id) ".
         "JOIN cvterm as reltype on (rel.type_id=reltype.cvterm_id) $join ".
         "WHERE $and_where_clause ".

--- a/lib/CXGN/BrAPI/v2/Traits.pm
+++ b/lib/CXGN/BrAPI/v2/Traits.pm
@@ -36,7 +36,7 @@ sub list {
 	my $offset = $page*$page_size;
 	my $total_count = 0;
 	my @data;
-	my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, dbxref.accession, array_agg(cvtermsynonym.synonym), cvterm.is_obsolete, count(cvterm.cvterm_id) OVER() AS full_count FROM cvterm JOIN dbxref USING(dbxref_id) JOIN db using(db_id) JOIN cvterm_relationship as rel on (rel.subject_id=cvterm.cvterm_id) JOIN cvterm as reltype on (rel.type_id=reltype.cvterm_id) JOIN cvtermsynonym on(cvtermsynonym.cvterm_id=cvterm.cvterm_id) $where_clause group by cvterm.cvterm_id, db.name, db.db_id, dbxref.accession ORDER BY cvterm.name ASC LIMIT $limit OFFSET $offset;";
+	my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, dbxref.accession, array_agg(cvtermsynonym.synonym), cvterm.is_obsolete, count(cvterm.cvterm_id) OVER() AS full_count FROM cvterm JOIN dbxref USING(dbxref_id) JOIN db using(db_id) JOIN cvterm_relationship as rel on (rel.subject_id=cvterm.cvterm_id) JOIN cvterm as reltype on (rel.type_id=reltype.cvterm_id) LEFT JOIN cvtermsynonym on(cvtermsynonym.cvterm_id=cvterm.cvterm_id) $where_clause group by cvterm.cvterm_id, db.name, db.db_id, dbxref.accession ORDER BY cvterm.name ASC LIMIT $limit OFFSET $offset;";
 
 	my $sth = $self->bcs_schema->storage->dbh->prepare($q);
 	$sth->execute();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This changes the JOINs to LEFT JOINs when adding the `cvtermsynonym` table to the `cvterm` table in BrAPI queries to get trait information.

The JOIN would filter out any traits that don't have a synonym set.

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
