### PR TITLE
specify python3 instead of minor version

### DIFF
--- a/sgn_test.conf
+++ b/sgn_test.conf
@@ -1,5 +1,5 @@
 # Database configs
-dbhost breedbase_db
+dbhost breedbase_db11
 dbname db
 dbuser postgres
 dbpass postgres
@@ -41,8 +41,8 @@ brapi_PUT any
 brapi_OPTIONS any
 
 # for drone stuff
-python_executable /usr/bin/python3.5
-python_executable_maskrcnn_env /usr/bin/python3.5
+python_executable /usr/bin/python3
+python_executable_maskrcnn_env /usr/bin/python3
 
 # slurm config
 backend Slurm


### PR DESCRIPTION
The specified minor version might not be availale after an upgrade


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
