### PR TITLE
Speed Improvements: Accession List Validation & Accession Properties Download

### DIFF
--- a/lib/CXGN/List/Validate/Plugin/Accessions.pm
+++ b/lib/CXGN/List/Validate/Plugin/Accessions.pm
@@ -27,71 +27,77 @@ sub validate {
     my @synonyms;
     my @multiple_synonyms;
     
-    foreach my $item (@$list) {
+    # First filter out exact matches
+    my $rs = $schema->resultset("Stock::Stock")->search({
+        uniquename => {
+            in => $list
+        },
+        'me.type_id' => $accession_type_id,
+        is_obsolete => 'F'
+    });
+    my @exact = $rs->get_column('uniquename')->all();
+    my %exact_map = map { $_=>1 } @exact;
+    my @missing = grep { !exists $exact_map{$_} } @$list;
 
-	# first match case sensitively to catch all the missing ones 
-	my $rs = $schema->resultset("Stock::Stock")->search(
-	    { uniquename => $item,
-	      'me.type_id' => $accession_type_id,
-	      is_obsolete => 'F' },
-	    );
+    # Now do more searches on the non-exact matches
+    foreach my $item (@missing) {
 
-	if ($rs->count() == 0) {
-	    push @missing, $item;
-	}
+        # find case-insensitive matches
+        my $rs = $schema->resultset("Stock::Stock")->search({
+            'lower(uniquename)' => lc($item),
+            'me.type_id' => $accession_type_id,
+            is_obsolete => 'F'
+        });
 
+        if ($rs->count() == 1) {
+            my $row = $rs->next();
+            if ($row->uniquename() ne $item) {
+                push @wrong_case, [ $item, $row->uniquename() ];
+            }
+        }
 
-	
-	my $rs = $schema->resultset("Stock::Stock")->search(
-	    { 'lower(uniquename)' => lc($item),
-		  'me.type_id' => $accession_type_id,
-		  is_obsolete => 'F' },
-	    );
-	
-	if ($rs->count() == 1) {
-	    my $row = $rs->next();
-	    if ($row->uniquename() ne $item) {
-		push @wrong_case, [ $item, $row->uniquename() ];
-	    }
-	}
-	
-	elsif ($rs->count() > 1) {
-	    while(my $row = $rs->next()) { 
-		push @multiple_wrong_case, [ $item, $row->uniquename() ];
-	    }
-	}
-	
-    
-	my $rs = $schema->resultset("Stock::Stock")->search( 
-	    { 'lower(stockprops.value)' => lc($item),
-		  'stockprops.type_id' => $synonym_type_id,
-	    }, { join => 'stockprops', '+select' => [ 'stockprops.value' ], '+as' => [ 'stockprops_value' ]} );
+        elsif ($rs->count() > 1) {
+            while(my $row = $rs->next()) { 
+                push @multiple_wrong_case, [ $item, $row->uniquename() ];
+            }
+        }
 
-	if ($rs->count() == 1) { 
-	    my $row = $rs->next();
-	    if ($row->uniquename() ne $item) { ## allow stocks to have the a synonym that is their own name - these synonyms should be removed from the dbs  
-		push @synonyms, { uniquename =>  $row->uniquename(), synonym => $row->get_column('stockprops_value') };
-	    }
-	}
-	elsif($rs->count() > 1)  {
-	    while (my $row = $rs->next()) {
-		push @multiple_synonyms, [ $row->uniquename(), $row->get_column('stockprops_value') ];
-	    }
-	}
-	  
+        # find case-insensitive synonyms
+        my $rs = $schema->resultset("Stock::Stock")->search(
+            {
+                'lower(stockprops.value)' => lc($item),
+                'stockprops.type_id' => $synonym_type_id,
+            }, 
+            { 
+                join => 'stockprops', '+select' => [ 'stockprops.value' ], '+as' => [ 'stockprops_value' ] 
+            }
+        );
+
+        if ($rs->count() == 1) { 
+            my $row = $rs->next();
+            if ($row->uniquename() ne $item) { ## allow stocks to have the a synonym that is their own name - these synonyms should be removed from the dbs  
+                push @synonyms, { uniquename =>  $row->uniquename(), synonym => $row->get_column('stockprops_value') };
+            }
+        }
+        elsif($rs->count() > 1)  {
+            while (my $row = $rs->next()) {
+                push @multiple_synonyms, [ $row->uniquename(), $row->get_column('stockprops_value') ];
+            }
+        }
     }
+    
     my $valid = 0;
     if ( (@multiple_synonyms ==0)  && (@synonyms == 0)  && (@wrong_case == 0) && (@missing == 0) && (@multiple_wrong_case ==0)) {
-	$valid = 1;
+        $valid = 1;
     }
     
     return {
-	missing => \@missing,
-	wrong_case => \@wrong_case,
-	multiple_wrong_case => \@multiple_wrong_case,
-	synonyms => \@synonyms,
-	multiple_synonyms => \@multiple_synonyms,
-	valid => $valid,
+        missing => \@missing,
+        wrong_case => \@wrong_case,
+        multiple_wrong_case => \@multiple_wrong_case,
+        synonyms => \@synonyms,
+        multiple_synonyms => \@multiple_synonyms,
+        valid => $valid,
     };
 }
 

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -796,7 +796,6 @@ sub build_accession_properties_info {
         my $table = "sp" . $count;
         $select .= ", string_agg($table.value, ', ') AS \"$sp\"";
         $joins .= " LEFT JOIN public.stockprop AS $table ON (stock.stock_id = $table.stock_id AND $table.type_id = (SELECT cvterm_id FROM cvterm WHERE name = '$sp' AND cv_id = (SELECT cv_id FROM cv WHERE name = 'stock_property')))";
-        $group .= ", $table.value";
     }
 
     # Build where block using accession ids

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -669,18 +669,12 @@ sub download_accession_properties_action : Path('/breeders/download_accession_pr
     my $accession_id_hash = $t->transform($schema, $acc_t, \@accession_list);
     my @accession_ids = @{$accession_id_hash->{transform}};
 
-    # Create list of accession objects
-    my @accessions = ();
-    foreach (@accession_ids) {
-        push @accessions, CXGN::Accession->new( $dbh, $_ );
-    }
-
     # Create tempfile
     my ($tempfile, $uri) = $c->tempfile(TEMPLATE => "download_accessions_XXXXX", UNLINK=> 0);
 
     # Build Accession Info
     my @editable_stock_props = split ',', $c->config->{editable_stock_props};
-    my $rows = $self->build_accession_properties_info($schema, \@accession_ids, \@editable_stock_props);
+    my $rows = $self->build_accession_properties_info($dbh, \@accession_ids, \@editable_stock_props);
 
     # Create and Return XLS file
     if ( $file_format eq ".xls" ) {
@@ -698,14 +692,12 @@ sub download_accession_properties_action : Path('/breeders/download_accession_pr
         # Return the xls file
         $c->res->content_type('Application/xls');
         $c->res->cookies->{$dl_cookie} = {
-          value => $dl_token,
-          expires => '+1m',
+            value => $dl_token,
+            expires => '+1m',
         };
         $c->res->header('Content-Disposition', qq[attachment; filename="$file_name"]);
 
-
         my $output = read_file($file_path);  ### works here because it is xls, otherwise does not work with utf8
-
         $c->res->body($output);
     }
 
@@ -740,18 +732,17 @@ sub download_accession_properties_action : Path('/breeders/download_accession_pr
         # Return the csv file
         $c->res->content_type('text/csv');
         $c->res->cookies->{$dl_cookie} = {
-          value => $dl_token,
-          expires => '+1m',
+            value => $dl_token,
+            expires => '+1m',
         };
         $c->res->header('Content-Disposition', qq[attachment; filename="$file_name"]);
-        #my $output = read_file($file_path);   ### Does not work with UTF8 text files
-	my $output = "";
-	open(my $F, "< :encoding(UTF-8)", $file_path) || die "Can't open file $file_path for reading.";
-	while (<$F>) {
-	    $output .= $_;
-	}
-	close($F);
 
+        my $output = "";
+        open(my $F, "< :encoding(UTF-8)", $file_path) || die "Can't open file $file_path for reading.";
+        while (<$F>) {
+            $output .= $_;
+        }
+        close($F);
         $c->res->body($output);
     }
 
@@ -762,55 +753,64 @@ sub download_accession_properties_action : Path('/breeders/download_accession_pr
 #
 # Generate the rows in the accession info table for the specified Accessions
 #
-# Usage: my $rows = $self->build_accession_properties_info($schema, \@accession_ids, \@editable_stock_props);
+# Usage: my $rows = $self->build_accession_properties_info($dbh, \@accession_ids, \@editable_stock_props);
 # Returns: an arrayref where each array item is an array of accession properties
 #          the first item is an array of the header values
 #
 sub build_accession_properties_info {
     my $self = shift;
-    my $schema = shift;
+    my $dbh = shift;
     my $accession_ids = shift;
     my $editable_stock_props = shift;
 
     # Setup Stock Props
-    my @required_stock_props = ("accession_name", "species_name", "population_name", "organization", "synonym", "PUI");
-    my @parsed_editable_stock_props = ();
+    my @stock_props = ("organization", "synonym", "PUI");
     foreach my $esp (@$editable_stock_props) {
-        if ( !grep(/^$esp$/, @required_stock_props) ) {
-            push(@parsed_editable_stock_props, $esp)
+        if ( !grep(/^$esp$/, @stock_props) ) {
+            push(@stock_props, $esp)
         }
     }
 
     # Build Header
-    my @accession_headers = ();
-    push(@accession_headers, @required_stock_props);
-    push(@accession_headers, @parsed_editable_stock_props);
+    my @accession_headers = ("accession_name", "species_name", "population_name");
+    push(@accession_headers, @stock_props);
 
     # Add Header to Rows
     my @accession_rows = ();
     push(@accession_rows, \@accession_headers);
 
-    # Build Row for each Accession
-    foreach my $stock_id ( @$accession_ids ) {
-        my $a = new CXGN::Stock::Accession({ schema => $schema, stock_id => $stock_id});
-        my $synonym_string = join(',', @{$a->synonyms()});
+    # Start query blocks
+    my $select = "SELECT stock.uniquename AS accession_name, organism.species AS species_name, string_agg(rs.uniquename, ', ') AS population_name";
+    my $from = "FROM public.stock";
+    my $joins = "LEFT JOIN public.organism USING (organism_id)";
+    $joins .= " LEFT JOIN public.stock_relationship ON (stock.stock_id = stock_relationship.subject_id)";
+    $joins .= " LEFT JOIN public.stock AS rs ON (stock_relationship.object_id = rs.stock_id)";
+    my $group = "GROUP BY stock.stock_id, organism.species";
+    my $order = "ORDER BY stock.uniquename ASC;";
+    my @params;
 
-        # Setup row with required stock props
-        my @r = (
-            $a->uniquename(),
-            $a->get_species(),
-            $a->population_name(),
-            $a->organization_name(),
-            $synonym_string,
-            $a->germplasmPUI()
-        );
+    # Add each of the stock props
+    my $count = 0;
+    foreach my $sp (@stock_props) {
+        $count++;
+        my $table = "sp" . $count;
+        $select .= ", string_agg($table.value, ', ') AS \"$sp\"";
+        $joins .= " LEFT JOIN public.stockprop AS $table ON (stock.stock_id = $table.stock_id AND $table.type_id = (SELECT cvterm_id FROM cvterm WHERE name = '$sp' AND cv_id = (SELECT cv_id FROM cv WHERE name = 'stock_property')))";
+        $group .= ", $table.value";
+    }
 
-        # Add parsed editable stock props
-        foreach my $esp (@parsed_editable_stock_props) {
-            push(@r, $a->_retrieve_stockprop($esp));
-        }
+    # Build where block using accession ids
+    my $where = "WHERE stock.stock_id IN (" . join(',', ('?') x @$accession_ids) . ")";
+    push(@params, @$accession_ids);
 
-        push(@accession_rows, \@r);
+    # Put query together
+    my $q = "$select $from $joins $where $group $order";
+
+    # Execute the query and add results to accession rows
+    my $h = $dbh->prepare($q);
+    $h->execute(@params);
+    while (my @results = $h->fetchrow_array()) {
+        push(@accession_rows, \@results);
     }
 
     return \@accession_rows;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This improves the speed of:

- The accession list validation:
    - For a list of 10,000 accessions it would take ~8 minutes to validate, now it takes ~2 seconds
    - The validation function now makes 1 query to find all of the items that have an exact (case-sensitive) match on the uniquename
    - Then it performs additional searches (case-insensitive uniquename and synonyms) for the items that did not have an exact match 

- The accession properties download (from `/breeders/download`):
    - For a list of 10,000 accessions it would take almost 30 minutes (validation ~8 minutes + download ~18 minutes), now it takes <10 seconds
    - The download function was creating a new Accession/Stock object for each list item, now it makes 1 query to get all of the properties for all of the list items


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
