### PR TITLE
Change VCF missing genotypes from NA to ./.

### DIFF
--- a/lib/CXGN/Genotype/ParseUpload/Plugin/GridFileIntertekCSV.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/GridFileIntertekCSV.pm
@@ -234,8 +234,8 @@ sub _parse_with_plugin {
                         }
                         elsif ($a eq '?' || $a eq 'Uncallable') {
                             $gt_dosage = 'NA';
-                            push @gt_vcf_genotype, 'NA';
-                            push @alt_calls, 'NA';
+                            push @gt_vcf_genotype, './.';
+                            push @alt_calls, './.';
                         } else {
                             push @error_messages, "Allele Call Does Not Match Ref or Alt for Sample: $sample_id_with_lab_id Marker: $marker_name Alt: $alt Ref: $ref Allele: $a";
                         }

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/IntertekCSV.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/IntertekCSV.pm
@@ -347,8 +347,8 @@ sub _parse_with_plugin {
                         }
                         elsif ($a eq '?' || $a eq 'Uncallable') {
                             $gt_dosage = 'NA';
-                            push @gt_vcf_genotype, 'NA';
-                            push @alt_calls, 'NA';
+                            push @gt_vcf_genotype, './.';
+                            push @alt_calls, './.';
                         } else {
                             push @error_messages, "Allele Call Does Not Match Ref or Alt for Sample: $sample_id_with_lab_id Marker: $marker_name Alt: $alt Ref: $ref Allele: $a";
                         }

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/VCF.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/VCF.pm
@@ -298,7 +298,7 @@ sub next_genotype {
     my $self = shift;
     my %genotypeprop_observation_units;
     my $observation_unit_names = $self->observation_unit_names;
-    
+
     my $line;
     my $F = $self->_fh();
 

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/transposedVCF.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/transposedVCF.pm
@@ -5,7 +5,7 @@ CXGN::Genotype::ParseUpload::Plugin::transposedVCF - plugin to load transposed V
 
 =head1 SYNOPSIS
 
- my $up = CXGN::Genotype::ParseUpload->new( { 
+ my $up = CXGN::Genotype::ParseUpload->new( {
     chado_schema => $schema,
     filename => $archived_filename_with_path,
     observation_unit_type_name => $obs_type,
@@ -15,7 +15,7 @@ CXGN::Genotype::ParseUpload::Plugin::transposedVCF - plugin to load transposed V
   });
 
   $up->load_plugin("transposedVCF");
-  if ($up->validate_with_plugin()) { 
+  if ($up->validate_with_plugin()) {
     $up->
 
 
@@ -60,13 +60,13 @@ sub _validate_with_plugin {
     my @fields;
 
     open($F, "<", $filename) || die "Can't open file $filename\n";
-    
+
     my @header_info;
 
     my $chroms;
-    while (<$F>) { 
+    while (<$F>) {
 	chomp;
-	if (m/\#\#/) { 
+	if (m/\#\#/) {
 	    print STDERR "Reading header line $_\n";
 	    push @header_info, $_;
 	}
@@ -85,7 +85,7 @@ sub _validate_with_plugin {
         }
     }
     $self->chroms(\@chroms);
-    
+
     my $pos = <$F>;
     chomp($pos);
     my @pos = split /\t/, $pos;
@@ -107,37 +107,37 @@ sub _validate_with_plugin {
     }
     $self->ids(\@ids);
     #print STDERR "IDS = ".Dumper(\@ids);
-    
+
     my $refs = <$F>;
     chomp($refs);
     my @refs = split /\t/, $refs;
     $self->refs(\@refs);
     #print STDERR "REFS = ".Dumper(\@refs);
-    
+
     my $alts = <$F>;
     chomp($alts);
     my @alts = split /\t/, $alts;
     $self->alts(\@alts);
     #print STDERR "ALTS = ".Dumper(\@alts);
-    
+
     my $qual = <$F>;
     chomp($qual);
     my @qual = split /\t/,$qual;
     $self->qual(\@qual);
     #print STDERR "QUAL = ".Dumper(\@qual);
-    
+
     my $filter = <$F>;
     chomp($filter);
     my @filter = split /\t/, $filter;
     $self->filter(\@filter);
     #print STDERR "FILTER = ".Dumper(\@filter);
-    
+
     my $info = <$F>;
     chomp($info);
     my @info = split /\t/, $info;
     $self->info(\@info);
     #print STDERR "INFO = ".Dumper(\@info);
-    
+
     my $format = <$F>;
     chomp($format);
     my @format = split /\t/, $format;
@@ -187,13 +187,13 @@ sub _validate_with_plugin {
 	$lines++;
 	if ($lines % 100 == 0) { print STDERR "Reading line $lines...        \r"; }
     }
-    
+
     #print STDERR "\n";
     close($F);
-    
+
     my $number_observation_units = scalar(@observation_unit_names);
     #print STDERR "Number of observation units: $number_observation_units\n";
-    
+
     my @observation_units_names_trim;
     if ($self->get_igd_numbers_included){
         foreach (@observation_unit_names) {
@@ -262,7 +262,7 @@ sub _validate_with_plugin {
 
     my $protocol_data = $self->extract_protocol_data();
     $self->protocol_data($protocol_data);
-   
+
     return 1; #returns true if validation is passed
 }
 
@@ -280,8 +280,8 @@ sub _parse_with_plugin {
 
     foreach (1..9) { my $trash = <$F>; } # remove first 9 lines
     $self->_fh($F);
-    
-    
+
+
 }
 
 sub extract_protocol_data {
@@ -290,7 +290,7 @@ sub extract_protocol_data {
     my $marker_name;
     my %protocolprop_info;
     my $marker_info_p8;
-    
+
 #    open(my $F, '<', $self->get_filename()) || die "Can't open file ".$self->get_filename()."\n";
 
     for (my $i=1; $i<@{$self->ids()}; $i++) {
@@ -329,20 +329,20 @@ sub extract_protocol_data {
 
 sub next_genotype {
     my $self = shift;
-    
+
     #print STDERR "Processing next genotype...\n";
     my @fields;
 
     my $genotypeprop = {}; # hashref
     my $observation_unit_name;
-    
+
     my $line;
 
     my $F = $self->_fh();
-    
-    if (! ($line = <$F>)) { 
-        print STDERR "No next genotype... Done!\n"; 
-        close($F); 
+
+    if (! ($line = <$F>)) {
+        print STDERR "No next genotype... Done!\n";
+        close($F);
         return ( [$observation_unit_name], $genotypeprop );
     }
     else {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
When uploading genotyping data, uncallable or missing data will be coded as './.' instead of 'NA'. Dosage still coded as 'NA'.

<!-- If there are relevant issues, link them here: -->
Resolves #3769 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
