### PR TITLE
another npm fix. Numeric user ids require a leading # sign 

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@solgenomics/brapijs": "github:solgenomics/brapi-js#develop",
     "BrAPI-BoxPlotter": "git+https://github.com/solgenomics/BrAPI-BoxPlotter.git",
-    "d3": "^5.9.2",
+    "d3": "^7.3.0",
     "d3-sankey": "^0.12.3",
     "d3-array": "^2.11.0",
     "d3-path": "^1.0.9",

--- a/lib/SGN.pm
+++ b/lib/SGN.pm
@@ -156,7 +156,7 @@ after 'setup_finalize' => sub {
 	}
 
 	print STDERR "\n\nUSING USER ID $uid FOR npm...\n\n\n";
-        system("cd js && sudo -u $uid npm run build && cd -");
+        system("cd js && sudo -u \\#$uid npm run build && cd -");
     }
 };
 

--- a/lib/SGN/Script/Server.pm
+++ b/lib/SGN/Script/Server.pm
@@ -14,7 +14,7 @@ if (@ARGV && "-r" ~~ @ARGV) {
 	`useradd -u $uid -d /home/devel devel`;
     }
     print STDERR "\n\nSGN_WEBPACK_WATCH: USING USER ID $uid FOR npm...\n\n\n";
-    system("cd js && sudo -u $uid npm run build-watch &");
+    system("cd js && sudo -u \\#$uid npm run build-watch &");
 } 
 
 1;


### PR DESCRIPTION
with appropriate backslashing (two in this case).


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
