### PR TITLE
delete plate-trial linkage

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/GenotypingTrial.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/GenotypingTrial.js
@@ -365,7 +365,7 @@ jQuery(document).ready(function ($) {
                 url: '/ajax/breeders/trial/'+trial_id+'/delete/layout',
                 beforeSend: function(){
                     jQuery('#working_modal').modal("show");
-                    jQuery('#working_msg').html("Deleting genotyping experiment...<br />");
+                    jQuery('#working_msg').html("Deleting genotyping plate...<br />");
                 },
                 success: function(response) {
                     if (response.error) {

--- a/lib/CXGN/Project.pm
+++ b/lib/CXGN/Project.pm
@@ -5135,7 +5135,7 @@ sub cross_count {
 
 
 
-=head2 delete_linkage_genotyping_plate_from_field
+=head2 delete_linkage_genotyping_plate_from_field_trial
 
  Usage:
  Desc:
@@ -5146,7 +5146,7 @@ sub cross_count {
 
 =cut
 
-sub delete_linkage_genotyping_plate_from_field {
+sub delete_linkage_genotyping_plate_from_field_trial {
     my $self = shift;
     my $field_trial_id = shift;
     my $role = shift;
@@ -5154,6 +5154,7 @@ sub delete_linkage_genotyping_plate_from_field {
 
     my @errors;
 
+    #Make sure to have the right access to delete
     if ($role ne "curator") {
         push @errors, "Only a curator can delete this file.";
         return { errors => \@errors };
@@ -5171,9 +5172,8 @@ sub delete_linkage_genotyping_plate_from_field {
     if ($h->rows() == 1){
         if (my ($project_relationship_id) = $h->fetchrow_array()) {
             my $uq = "DELETE from project_relationship where project_relationship_id = ? and type_id = ? ";
-            # my $uh = $dbh->prepare($uq);
-            # $uh->execute($project_relationship_id,$genotyping_trial_from_field_trial_cvterm_id);
-            push @errors, $uq . $plate_id."-". $field_trial_id."-".$genotyping_trial_from_field_trial_cvterm_id . "PR:". $project_relationship_id;
+            my $uh = $dbh->prepare($uq);
+            $uh->execute($project_relationship_id,$genotyping_trial_from_field_trial_cvterm_id);
         }
         else {
             push @errors, "An error occurred during deletion.";

--- a/lib/CXGN/Project.pm
+++ b/lib/CXGN/Project.pm
@@ -5135,7 +5135,7 @@ sub cross_count {
 
 
 
-=head2 delete_linkage_genotyping_plate_from_field_trial
+=head2 delete_genotyping_plate_and_field_trial_linkage
 
  Usage:
  Desc:
@@ -5146,7 +5146,7 @@ sub cross_count {
 
 =cut
 
-sub delete_linkage_genotyping_plate_from_field_trial {
+sub delete_genotyping_plate_from_field_trial_linkage {
     my $self = shift;
     my $field_trial_id = shift;
     my $role = shift;
@@ -5156,7 +5156,7 @@ sub delete_linkage_genotyping_plate_from_field_trial {
 
     #Make sure to have the right access to delete
     if ($role ne "curator") {
-        push @errors, "Only a curator can delete this file.";
+        push @errors, "Only a curator can delete this linkage.";
         return { errors => \@errors };
     }
 

--- a/lib/CXGN/Project.pm
+++ b/lib/CXGN/Project.pm
@@ -5134,6 +5134,63 @@ sub cross_count {
 }
 
 
+
+=head2 delete_linkage_genotyping_plate_from_field
+
+ Usage:
+ Desc:
+ Ret:
+ Args:
+ Side Effects:
+ Example:
+
+=cut
+
+sub delete_linkage_genotyping_plate_from_field {
+    my $self = shift;
+    my $field_trial_id = shift;
+    my $role = shift;
+    my $plate_id = $self->get_trial_id();
+
+    my @errors;
+
+    if ($role ne "curator") {
+        push @errors, "Only a curator can delete this file.";
+        return { errors => \@errors };
+    }
+
+    my $genotyping_trial_from_field_trial_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'genotyping_trial_from_field_trial', 'project_relationship')->cvterm_id();
+    # check ownership of that image
+    my $q = "SELECT project_relationship.project_relationship_id from project  join project_relationship on(project_id= subject_project_id)  join project as genotypeproject on (genotypeproject.project_id= project_relationship.object_project_id) where genotypeproject.project_id=? and project.project_id=? and project_relationship.type_id=?;";
+
+    my $dbh = $self->bcs_schema->storage()->dbh();
+    my $h = $dbh->prepare($q);
+
+    $h->execute($plate_id, $field_trial_id,$genotyping_trial_from_field_trial_cvterm_id);
+
+    if ($h->rows() == 1){
+        if (my ($project_relationship_id) = $h->fetchrow_array()) {
+            my $uq = "DELETE from project_relationship where project_relationship_id = ? and type_id = ? ";
+            # my $uh = $dbh->prepare($uq);
+            # $uh->execute($project_relationship_id,$genotyping_trial_from_field_trial_cvterm_id);
+            push @errors, $uq . $plate_id."-". $field_trial_id."-".$genotyping_trial_from_field_trial_cvterm_id . "PR:". $project_relationship_id;
+        }
+        else {
+            push @errors, "An error occurred during deletion.";
+        }
+    } else {
+        push @errors, "Project relationship does not exists or has more than 1 occurrence.";
+    }
+ 
+    if (@errors >0) {
+    return { errors => \@errors };
+    }
+
+    return { success => 1 };
+        
+
+}
+
 1;
 
 ##__PACKAGE__->meta->make_immutable;

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -3620,6 +3620,29 @@ sub genotyping_trial_from_field_trial : Chained('trial') PathPart('genotyping_tr
     $c->stash->{rest} = {success => 1, genotyping_trials_from_field_trial => $genotyping_trials_from_field_trial, field_trials_source_of_genotyping_trial => $field_trials_source_of_genotyping_trial};
 }
 
+sub delete_linkage_genotyping_plate_from_field_trial : Chained('trial') PathPart('delete_linkage_genotyping_plate_from_field_trial') Args(1) {
+    my $self = shift;
+    my $c = shift;
+    my $field_trial_id = shift;
+    my $schema = $c->dbic_schema("Bio::Chado::Schema");
+
+    if (!$c->user) {
+        $c->stash->{rest} = { error => "You must be logged in to remove genotyping plate and field trial linkage!" };
+        $c->detach();
+    }
+
+    my @roles = $c->user->roles();
+    my $result = $c->stash->{trial}->delete_linkage_genotyping_plate_from_field_trial($field_trial_id, $roles[0]);
+
+    if (exists($result->{errors})) {
+        $c->stash->{rest} = { error => $result->{errors} };
+    }
+    else {
+        $c->stash->{rest} = { success => 1 };
+    }
+
+}
+
 sub crossing_trial_from_field_trial : Chained('trial') PathPart('crossing_trial_from_field_trial') Args(0) {
     my $self = shift;
     my $c = shift;

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -3620,7 +3620,7 @@ sub genotyping_trial_from_field_trial : Chained('trial') PathPart('genotyping_tr
     $c->stash->{rest} = {success => 1, genotyping_trials_from_field_trial => $genotyping_trials_from_field_trial, field_trials_source_of_genotyping_trial => $field_trials_source_of_genotyping_trial};
 }
 
-sub delete_linkage_genotyping_plate_from_field_trial : Chained('trial') PathPart('delete_linkage_genotyping_plate_from_field_trial') Args(1) {
+sub delete_genotyping_plate_from_field_trial_linkage : Chained('trial') PathPart('delete_genotyping_plate_from_field_trial_linkage') Args(1) {
     my $self = shift;
     my $c = shift;
     my $field_trial_id = shift;
@@ -3632,7 +3632,7 @@ sub delete_linkage_genotyping_plate_from_field_trial : Chained('trial') PathPart
     }
 
     my @roles = $c->user->roles();
-    my $result = $c->stash->{trial}->delete_linkage_genotyping_plate_from_field_trial($field_trial_id, $roles[0]);
+    my $result = $c->stash->{trial}->delete_genotyping_plate_from_field_trial_linkage($field_trial_id, $roles[0]);
 
     if (exists($result->{errors})) {
         $c->stash->{rest} = { error => $result->{errors} };

--- a/mason/breeders_toolbox/trial/genotyping_trial_from_field_trial_linkage.mas
+++ b/mason/breeders_toolbox/trial/genotyping_trial_from_field_trial_linkage.mas
@@ -48,7 +48,7 @@ jQuery(document).ready(function () {
 });
 
 function remove_linkage(plate_id, trial_id) {
-   var yes = confirm('Are you sure you want to remove the genotyping plate and field trial linkage? <br>This operation cannot be undone.');
+   var yes = confirm('Are you sure you want to remove the genotyping plate and field trial linkage? This operation cannot be undone.');
    if (yes) {
       jQuery.ajax({
           url: '/ajax/breeders/trial/'+plate_id+'/delete_genotyping_plate_from_field_trial_linkage/'+trial_id,

--- a/mason/breeders_toolbox/trial/genotyping_trial_from_field_trial_linkage.mas
+++ b/mason/breeders_toolbox/trial/genotyping_trial_from_field_trial_linkage.mas
@@ -32,7 +32,7 @@ jQuery(document).ready(function () {
 % if ($trial_type eq 'genotyping_trial'){
                 html1 = '<table class="table table-hover table-bordered"><thead><tr><th>Field Trial(s) That Are Source of This Genotyping Plate</th></tr></thead><tbody>';
                 for (var i=0; i<response.field_trials_source_of_genotyping_trial.length; i++){
-                    html1 = html1 + '<tr><td><a href="/breeders/trial/'+response.field_trials_source_of_genotyping_trial[i][0]+'">'+response.field_trials_source_of_genotyping_trial[i][1]+'</a></td></tr>';
+                    html1 = html1 + '<tr><td><a href="/breeders/trial/'+response.field_trials_source_of_genotyping_trial[i][0]+'">'+response.field_trials_source_of_genotyping_trial[i][1]+'</a></td><td> <a href="javascript:remove_linkage('+<% $trial_id %>+', '+response.field_trials_source_of_genotyping_trial[i][0]+')">Remove linkage</a></td></tr>';
                 }
 % }
                 html1 = html1 + '</tbody></table>';
@@ -46,5 +46,21 @@ jQuery(document).ready(function () {
     });
 
 });
+
+function remove_linkage(plate_id, trial_id) {
+   var yes = confirm('Are you sure you want to remove the linkage between this genotyping plate and the field trial? This operation cannot be undone.');
+   if (yes) {
+      jQuery.ajax({
+          url: '/ajax/breeders/trial/'+plate_id+'/delete_linkage_genotyping_plate_from_field_trial/'+trial_id,
+          success: function(r) {
+              if (r.error) { alert(r.error); }
+              else {
+                  alert("The genotyping plate link has been removed from the field trial.");
+              }
+           },
+           error: function(r) {  alert("An error occurred!") }
+      });
+    }
+}
 
 </script>

--- a/mason/breeders_toolbox/trial/genotyping_trial_from_field_trial_linkage.mas
+++ b/mason/breeders_toolbox/trial/genotyping_trial_from_field_trial_linkage.mas
@@ -48,7 +48,7 @@ jQuery(document).ready(function () {
 });
 
 function remove_linkage(plate_id, trial_id) {
-   var yes = confirm('Are you sure you want to remove the linkage between this genotyping plate and the field trial? This operation cannot be undone.');
+   var yes = confirm('Are you sure you want to remove the genotyping plate and field trial linkage? <br>This operation cannot be undone.');
    if (yes) {
       jQuery.ajax({
           url: '/ajax/breeders/trial/'+plate_id+'/delete_genotyping_plate_from_field_trial_linkage/'+trial_id,

--- a/mason/breeders_toolbox/trial/genotyping_trial_from_field_trial_linkage.mas
+++ b/mason/breeders_toolbox/trial/genotyping_trial_from_field_trial_linkage.mas
@@ -26,7 +26,7 @@ jQuery(document).ready(function () {
 % if ($trial_type eq 'field_trial'){
                 html1 = '<table class="table table-hover table-bordered"><thead><tr><th>Genotyping Plates(s) From This Field Trial</th></tr></thead><tbody>';
                 for (var i=0; i<response.genotyping_trials_from_field_trial.length; i++){
-                    html1 = html1 + '<tr><td><a href="/breeders/trial/'+response.genotyping_trials_from_field_trial[i][0]+'">'+response.genotyping_trials_from_field_trial[i][1]+'</a></td></tr>';
+                    html1 = html1 + '<tr><td><a href="/breeders/trial/'+response.genotyping_trials_from_field_trial[i][0]+'">'+response.genotyping_trials_from_field_trial[i][1]+'</a></td><td><a href="javascript:remove_linkage('+response.genotyping_trials_from_field_trial[i][0]+','+<% $trial_id %>+')">Remove linkage</a></td></tr>';
                 }
 % }
 % if ($trial_type eq 'genotyping_trial'){
@@ -51,7 +51,7 @@ function remove_linkage(plate_id, trial_id) {
    var yes = confirm('Are you sure you want to remove the linkage between this genotyping plate and the field trial? This operation cannot be undone.');
    if (yes) {
       jQuery.ajax({
-          url: '/ajax/breeders/trial/'+plate_id+'/delete_linkage_genotyping_plate_from_field_trial/'+trial_id,
+          url: '/ajax/breeders/trial/'+plate_id+'/delete_genotyping_plate_from_field_trial_linkage/'+trial_id,
           success: function(r) {
               if (r.error) { alert(r.error); }
               else {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Removing a plate was not possible when plate-trial linkage exists.
This PR creates a new option 'delete linkage' in both trial page and genotyping plate page. And it removes field trial and genotyping plates linkage.

Closes #3981

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
