### PR TITLE
fixed cache generation upon changes to fieldmap submission

### DIFF
--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -2460,6 +2460,21 @@ sub replace_trial_stock : Chained('trial') PathPart('replace_stock') Args(0) {
   $c->stash->{rest} = { success => 1};
 }
 
+sub refresh_cache : Chained('trial') PathPart('refresh_cache') Args(0) {
+    my $self = shift;
+    my $c = shift;
+    my $trial_id = $c->stash->{trial_id};
+    my $schema = $c->dbic_schema('Bio::Chado::Schema');
+
+    my $refresh_fieldmap_cache = CXGN::Trial::FieldMap->new({
+        trial_id => $trial_id,
+        bcs_schema => $schema,
+    });
+
+    $refresh_fieldmap_cache->_regenerate_trial_layout_cache();
+    $c->stash->{rest} = { success => 1};
+}
+
 sub replace_plot_accession : Chained('trial') PathPart('replace_plot_accessions') Args(0) {
     my $self = shift;
     my $c = shift;

--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -898,6 +898,28 @@ jQuery(document).ready( function() {
       hm_replace_plotAccession_fieldMap('override');
     });
 
+    function refresh_cache() {
+        new jQuery.ajax({
+            type: 'POST',
+            url: '/ajax/breeders/trial/<% $trial_id %>/refresh_cache',
+            dataType: "json",
+            data: {
+                'trial_id': trial_id,
+            },
+
+            success: function(response) {},
+            error: function(response) {
+                alert('Error refreshing cache');
+            },
+        })
+        .then(
+            function() {
+                jQuery('#working_modal').modal("hide");
+                jQuery('#fieldplot_layout_success_dialog').modal("show");
+            }
+        )
+    };
+
     function submit_fieldmap_metadata() {
         jQuery('#working_modal').modal("show");  
         let filler_plot_object = FieldMap.format_brapi_post_object();
@@ -932,9 +954,7 @@ jQuery(document).ready( function() {
             url: '/brapi/v2/observationunits/',
             data: stringifiedData,
             success: function(response) {
-                jQuery('#working_modal').modal("hide");
-                jQuery('#fieldplot_layout_success_dialog').modal("show");
-                
+                refresh_cache();
             },
             error: function(response) {
                 jQuery('#working_modal').modal("hide");


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Realized the main issue was not the matview refreshing, but the cache regeneration. Added a refresh cache function to trialmetadata and made submit fieldmap layout invoke it.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
