### PR TITLE
Topic/fix npm user devel env

### DIFF
--- a/lib/SGN.pm
+++ b/lib/SGN.pm
@@ -150,10 +150,10 @@ after 'setup_finalize' => sub {
     if(! $ENV{SGN_WEBPACK_WATCH}){
 	my $uid = (lstat("js/package.json"))[4];
 
-	my $user_exists = `id $uid`;
-	if ($user_exists =~ /no such user/) {
-	    `useradd -u $uid -d /home/devel devel`;
-	}
+	my $user_exists = `id $uid 2>&1`;            
+    if ($user_exists =~ /no such user/) {
+	    `useradd -u $uid -m devel`;
+	} 
 
 	print STDERR "\n\nUSING USER ID $uid FOR npm...\n\n\n";
         system("cd js && sudo -u $uid npm run build && cd -");

--- a/lib/SGN.pm
+++ b/lib/SGN.pm
@@ -151,7 +151,7 @@ after 'setup_finalize' => sub {
 	my $uid = (lstat("js/package.json"))[4];
 
 	my $user_exists = `id $uid`;
-	if ($user_exists !~ /no such user/) {
+	if ($user_exists =~ /no such user/) {
 	    `useradd -u $uid -d /home/devel devel`;
 	}
 

--- a/lib/SGN/Script/Server.pm
+++ b/lib/SGN/Script/Server.pm
@@ -9,10 +9,10 @@ extends 'Catalyst::Script::Server';
 if (@ARGV && "-r" ~~ @ARGV) {
     $ENV{SGN_WEBPACK_WATCH} = 1;
     my $uid = (lstat("js/package.json"))[4];
-    my $user_exists = `id $uid`;
+   my $user_exists = `id $uid 2>&1`;    
     if ($user_exists =~ /no such user/) {
-	`useradd -u $uid -d /home/devel devel`;
-    }
+        `useradd -u $uid -m devel`;        
+    }    
     print STDERR "\n\nSGN_WEBPACK_WATCH: USING USER ID $uid FOR npm...\n\n\n";
     system("cd js && sudo -u $uid npm run build-watch &");
 } 

--- a/lib/SGN/Script/Server.pm
+++ b/lib/SGN/Script/Server.pm
@@ -10,7 +10,7 @@ if (@ARGV && "-r" ~~ @ARGV) {
     $ENV{SGN_WEBPACK_WATCH} = 1;
     my $uid = (lstat("js/package.json"))[4];
     my $user_exists = `id $uid`;
-    if ($user_exists !~ /no such user/) {
+    if ($user_exists =~ /no such user/) {
 	`useradd -u $uid -d /home/devel devel`;
     }
     print STDERR "\n\nSGN_WEBPACK_WATCH: USING USER ID $uid FOR npm...\n\n\n";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->

For some reason, the backticks operator on a docker container build does not work correctly when the folder is mapped / mounted as a volume to the container. A code gives the result to STDERR, not STDOUT - that is why a variable is empty, and "if" test doesn't work correctly.

A `useradd` also has a problem with the home folder - after some tests - the only working version seems o be `-m` option instead of the full path of the folder.

Does someone have a similar problem on dokcer-compose / build? 


-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
