### PR TITLE
Changed matview refresh to phenotypes and added refresh cache to dele…

### DIFF
--- a/js/source/entries/fieldmap.js
+++ b/js/source/entries/fieldmap.js
@@ -619,7 +619,7 @@ export function init() {
                     d3.select(this).style('fill', 'green').style('cursor', 'pointer');
                     tooltip.style('opacity', .9)
                     .style('left', (window.event.pageX - 420)+"px")
-                    .style('top', (window.event.pageY - 1000)+"px")
+                    .style('top', (window.event.pageY - 1200)+"px")
                     .text(get_plot_message(d))
                 }})
                 .on("mouseout", function(d) { 

--- a/js/source/legacy/CXGN/Trial.js
+++ b/js/source/legacy/CXGN/Trial.js
@@ -461,8 +461,8 @@ jQuery("#delete_field_map_dialog").dialog({
 autoOpen: false,
 modal: true,
 autoResize:true,
-    width: 500,
-    position: ['top', 75],
+    // width: 500,
+    // position: ['top', 75],
 buttons: {
         "Cancel": function () {
             jQuery('#delete_field_map_dialog').dialog("close");

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -2412,7 +2412,7 @@ sub delete_field_coord : Path('/ajax/phenotype/delete_field_coords') Args(0) {
 
     my $dbh = $c->dbc->dbh();
     my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
-    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath});
+    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath});
     my $trial_layout = CXGN::Trial::TrialLayout->new({ schema => $schema, trial_id => $trial_id, experiment_type => 'field_layout' });
     $trial_layout->generate_and_cache_layout();
 
@@ -3012,9 +3012,6 @@ sub upload_trial_coordinates : Path('/ajax/breeders/trial/coordsupload') Args(0)
       }
     }
 
-    my $trial_layout = CXGN::Trial::TrialLayout->new({ schema => $c->dbic_schema("Bio::Chado::Schema"), trial_id => $trial_id, experiment_type => 'field_layout' });
-    $trial_layout->generate_and_cache_layout();
-
     if ($error_string){
         $c->stash->{rest} = {error_string => $error_string};
         $c->detach();
@@ -3022,8 +3019,10 @@ sub upload_trial_coordinates : Path('/ajax/breeders/trial/coordsupload') Args(0)
 
     my $dbh = $c->dbc->dbh();
     my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
-    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath});
-
+    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath});
+    my $trial_layout = CXGN::Trial::TrialLayout->new({ schema => $c->dbic_schema("Bio::Chado::Schema"), trial_id => $trial_id, experiment_type => 'field_layout' });
+    $trial_layout->generate_and_cache_layout();
+    
     $c->stash->{rest} = {success => 1};
 }
 


### PR DESCRIPTION
…trial coords and upload trial coords

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Changed the matview from stockprop to phenotypes in upload spatial layout function and delete layout function, and added cache refresh. 

<!-- If there are relevant issues, link them here: -->
Should fix #4061

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
