### PR TITLE
fix how matview info is updated.

### DIFF
--- a/bin/refresh_matviews.pl
+++ b/bin/refresh_matviews.pl
@@ -57,9 +57,12 @@ if ($mode eq 'stockprop'){
     $cur_refreshing_q .= " WHERE mv_name = 'materialized_stockprop'";
 }
 if ($mode eq 'phenotypes') {
-    $cur_refreshing_q .= " WHERE mv_name = 'materialized_phenotype_jsonb_table'";
+    $cur_refreshing_q .= " WHERE mv_name = 'materialized_phenotype_jsonb_table' or mv_name = 'materialized_phenoview' ";
 }
-
+if ($mode eq 'all_but_genoview') {
+    $cur_refreshing_q .= " WHERE mv_name = 'materialized_stockprop' or mv_name = 'materialized_phenoview' or mv_name= 'materialized_phenotype_jsonb_table' ";
+}
+    
 #set TRUE before the transaction begins
 my $state = 'TRUE';
 print STDERR "*Setting currently_refreshing = TRUE\n";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The update_in_progress info is not correctly updated for materialized_phenoview when 'phentoypes' is selected. Similar issues with 'all_but_genoview'.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
