### PR TITLE
add IF EXISTS to handle dbs that are missing fkey constraints

### DIFF
--- a/db/00158/AddCascadeDeletes.pm
+++ b/db/00158/AddCascadeDeletes.pm
@@ -60,9 +60,9 @@ sub patch {
 
 BEGIN;
 
-ALTER TABLE phenome.stock_image DROP CONSTRAINT stock_image_image_id_fkey;
-ALTER TABLE phenome.stock_image DROP CONSTRAINT stock_image_metadata_id_fkey;
-ALTER TABLE phenome.stock_image DROP CONSTRAINT stock_image_stock_id_fkey;
+ALTER TABLE phenome.stock_image DROP CONSTRAINT IF EXISTS stock_image_image_id_fkey;
+ALTER TABLE phenome.stock_image DROP CONSTRAINT IF EXISTS stock_image_metadata_id_fkey;
+ALTER TABLE phenome.stock_image DROP CONSTRAINT IF EXISTS stock_image_stock_id_fkey;
 ALTER TABLE phenome.stock_image ADD CONSTRAINT stock_image_image_id_fkey
     FOREIGN KEY (image_id)
     REFERENCES metadata.md_image(image_id)
@@ -76,9 +76,9 @@ ALTER TABLE phenome.stock_image ADD CONSTRAINT stock_image_stock_id_fkey
     REFERENCES stock(stock_id)
     ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-ALTER TABLE phenome.locus_owner DROP CONSTRAINT locus_owner_granted_by_fkey;
-ALTER TABLE phenome.locus_owner DROP CONSTRAINT locus_owner_locus_id_fkey;
-ALTER TABLE phenome.locus_owner DROP CONSTRAINT locus_owner_sp_person_id_fkey;
+ALTER TABLE phenome.locus_owner DROP CONSTRAINT IF EXISTS locus_owner_granted_by_fkey;
+ALTER TABLE phenome.locus_owner DROP CONSTRAINT IF EXISTS locus_owner_locus_id_fkey;
+ALTER TABLE phenome.locus_owner DROP CONSTRAINT IF EXISTS locus_owner_sp_person_id_fkey;
 ALTER TABLE phenome.locus_owner ADD CONSTRAINT locus_owner_granted_by_fkey
     FOREIGN KEY (granted_by)
     REFERENCES sgn_people.sp_person(sp_person_id)
@@ -92,8 +92,8 @@ ALTER TABLE phenome.locus_owner ADD CONSTRAINT locus_owner_sp_person_id_fkey
     REFERENCES sgn_people.sp_person(sp_person_id)
     ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-ALTER TABLE phenome.nd_experiment_md_files DROP CONSTRAINT nd_experiment_md_files_file_id_fkey;
-ALTER TABLE phenome.nd_experiment_md_files DROP CONSTRAINT nd_experiment_md_files_nd_experiment_id_fkey;
+ALTER TABLE phenome.nd_experiment_md_files DROP CONSTRAINT IF EXISTS nd_experiment_md_files_file_id_fkey;
+ALTER TABLE phenome.nd_experiment_md_files DROP CONSTRAINT IF EXISTS nd_experiment_md_files_nd_experiment_id_fkey;
 ALTER TABLE phenome.nd_experiment_md_files ADD CONSTRAINT nd_experiment_md_files_file_id_fkey
     FOREIGN KEY (file_id)
     REFERENCES metadata.md_files(file_id)
@@ -103,8 +103,8 @@ ALTER TABLE phenome.nd_experiment_md_files ADD CONSTRAINT nd_experiment_md_files
     REFERENCES nd_experiment(nd_experiment_id)
     ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-ALTER TABLE phenome.nd_experiment_md_json DROP CONSTRAINT nd_experiment_md_json_json_id_fkey;
-ALTER TABLE phenome.nd_experiment_md_json DROP CONSTRAINT nd_experiment_md_json_nd_experiment_id_fkey;
+ALTER TABLE phenome.nd_experiment_md_json DROP CONSTRAINT IF EXISTS nd_experiment_md_json_json_id_fkey;
+ALTER TABLE phenome.nd_experiment_md_json DROP CONSTRAINT IF EXISTS nd_experiment_md_json_nd_experiment_id_fkey;
 ALTER TABLE phenome.nd_experiment_md_json ADD CONSTRAINT nd_experiment_md_json_json_id_fkey
     FOREIGN KEY (json_id)
     REFERENCES metadata.md_json(json_id)
@@ -114,8 +114,8 @@ ALTER TABLE phenome.nd_experiment_md_json ADD CONSTRAINT nd_experiment_md_json_n
     REFERENCES nd_experiment(nd_experiment_id)
     ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-ALTER TABLE phenome.nd_experiment_md_images DROP CONSTRAINT nd_experiment_md_images_image_id_fkey;
-ALTER TABLE phenome.nd_experiment_md_images DROP CONSTRAINT nd_experiment_md_images_nd_experiment_id_fkey;
+ALTER TABLE phenome.nd_experiment_md_images DROP CONSTRAINT IF EXISTS nd_experiment_md_images_image_id_fkey;
+ALTER TABLE phenome.nd_experiment_md_images DROP CONSTRAINT IF EXISTS nd_experiment_md_images_nd_experiment_id_fkey;
 ALTER TABLE phenome.nd_experiment_md_images ADD CONSTRAINT nd_experiment_md_images_image_id_fkey
     FOREIGN KEY (image_id)
     REFERENCES metadata.md_image(image_id)
@@ -125,9 +125,9 @@ ALTER TABLE phenome.nd_experiment_md_images ADD CONSTRAINT nd_experiment_md_imag
     REFERENCES nd_experiment(nd_experiment_id)
     ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-ALTER TABLE phenome.project_md_image DROP CONSTRAINT project_md_image_image_id_fkey;
-ALTER TABLE phenome.project_md_image DROP CONSTRAINT project_md_image_project_id_fkey;
-ALTER TABLE phenome.project_md_image DROP CONSTRAINT project_md_image_type_id_fkey;
+ALTER TABLE phenome.project_md_image DROP CONSTRAINT IF EXISTS project_md_image_image_id_fkey;
+ALTER TABLE phenome.project_md_image DROP CONSTRAINT IF EXISTS project_md_image_project_id_fkey;
+ALTER TABLE phenome.project_md_image DROP CONSTRAINT IF EXISTS project_md_image_type_id_fkey;
 ALTER TABLE phenome.project_md_image ADD CONSTRAINT project_md_image_image_id_fkey
     FOREIGN KEY (image_id)
     REFERENCES metadata.md_image(image_id)
@@ -141,8 +141,8 @@ ALTER TABLE phenome.project_md_image ADD CONSTRAINT project_md_image_type_id_fke
     REFERENCES cvterm(cvterm_id)
     ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-ALTER TABLE phenome.project_owner DROP CONSTRAINT project_owner_project_id_fkey;
-ALTER TABLE phenome.project_owner DROP CONSTRAINT project_owner_sp_person_id_fkey;
+ALTER TABLE phenome.project_owner DROP CONSTRAINT IF EXISTS project_owner_project_id_fkey;
+ALTER TABLE phenome.project_owner DROP CONSTRAINT IF EXISTS project_owner_sp_person_id_fkey;
 ALTER TABLE phenome.project_owner ADD CONSTRAINT project_owner_project_id_fkey
     FOREIGN KEY (project_id)
     REFERENCES project(project_id)
@@ -152,9 +152,9 @@ ALTER TABLE phenome.project_owner ADD CONSTRAINT project_owner_sp_person_id_fkey
     REFERENCES sgn_people.sp_person(sp_person_id)
     ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-ALTER TABLE phenome.stock_owner DROP CONSTRAINT stock_owner_metadata_id_fkey;
-ALTER TABLE phenome.stock_owner DROP CONSTRAINT stock_owner_sp_person_id_fkey;
-ALTER TABLE phenome.stock_owner DROP CONSTRAINT stock_owner_stock_id_fkey;
+ALTER TABLE phenome.stock_owner DROP CONSTRAINT IF EXISTS stock_owner_metadata_id_fkey;
+ALTER TABLE phenome.stock_owner DROP CONSTRAINT IF EXISTS stock_owner_sp_person_id_fkey;
+ALTER TABLE phenome.stock_owner DROP CONSTRAINT IF EXISTS stock_owner_stock_id_fkey;
 ALTER TABLE phenome.stock_owner ADD CONSTRAINT stock_owner_metadata_id_fkey
     FOREIGN KEY (metadata_id)
     REFERENCES metadata.md_metadata(metadata_id)
@@ -168,9 +168,9 @@ ALTER TABLE phenome.stock_owner ADD CONSTRAINT stock_owner_stock_id_fkey
     REFERENCES stock(stock_id)
     ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-ALTER TABLE metadata.md_image_cvterm DROP CONSTRAINT md_image_cvterm_cvterm_id_fkey;
-ALTER TABLE metadata.md_image_cvterm DROP CONSTRAINT md_image_cvterm_image_id_fkey;
-ALTER TABLE metadata.md_image_cvterm DROP CONSTRAINT md_image_cvterm_sp_person_id_fkey;
+ALTER TABLE metadata.md_image_cvterm DROP CONSTRAINT IF EXISTS md_image_cvterm_cvterm_id_fkey;
+ALTER TABLE metadata.md_image_cvterm DROP CONSTRAINT IF EXISTS md_image_cvterm_image_id_fkey;
+ALTER TABLE metadata.md_image_cvterm DROP CONSTRAINT IF EXISTS md_image_cvterm_sp_person_id_fkey;
 ALTER TABLE metadata.md_image_cvterm ADD CONSTRAINT md_image_cvterm_cvterm_id_fkey
     FOREIGN KEY (cvterm_id)
     REFERENCES cvterm(cvterm_id)


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Edits cascade delete patch to handle databases that do not have the altered foreign keys in the first place.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
