### PR TITLE
The accession attribute download repeats certain entries

### DIFF
--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -780,7 +780,7 @@ sub build_accession_properties_info {
     push(@accession_rows, \@accession_headers);
 
     # Start query blocks
-    my $select = "SELECT stock.uniquename AS accession_name, organism.species AS species_name, string_agg(rs.uniquename, ', ') AS population_name";
+    my $select = "SELECT stock.uniquename AS accession_name, organism.species AS species_name, string_agg(distinct(rs.uniquename), ', ') AS population_name";
     my $from = "FROM public.stock";
     my $joins = "LEFT JOIN public.organism USING (organism_id)";
     $joins .= " LEFT JOIN public.stock_relationship ON (stock.stock_id = stock_relationship.subject_id)";

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -794,7 +794,7 @@ sub build_accession_properties_info {
     foreach my $sp (@stock_props) {
         $count++;
         my $table = "sp" . $count;
-        $select .= ", string_agg($table.value, ', ') AS \"$sp\"";
+        $select .= ", string_agg(distinct($table.value), ', ') AS \"$sp\"";
         $joins .= " LEFT JOIN public.stockprop AS $table ON (stock.stock_id = $table.stock_id AND $table.type_id = (SELECT cvterm_id FROM cvterm WHERE name = '$sp' AND cv_id = (SELECT cv_id FROM cv WHERE name = 'stock_property')))";
     }
 
@@ -805,10 +805,13 @@ sub build_accession_properties_info {
     # Put query together
     my $q = "$select $from $joins $where $group $order";
 
+    print STDERR "QUERY = $q\n";
+    
     # Execute the query and add results to accession rows
     my $h = $dbh->prepare($q);
     $h->execute(@params);
     while (my @results = $h->fetchrow_array()) {
+	print STDERR "RETRIEVED: ".join(",", @results)."\n";
         push(@accession_rows, \@results);
     }
 

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -811,7 +811,7 @@ sub build_accession_properties_info {
     my $h = $dbh->prepare($q);
     $h->execute(@params);
     while (my @results = $h->fetchrow_array()) {
-	print STDERR "RETRIEVED: ".join(",", @results)."\n";
+	# print STDERR "RETRIEVED: ".join(",", @results)."\n";
         push(@accession_rows, \@results);
     }
 

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -805,7 +805,7 @@ sub build_accession_properties_info {
     # Put query together
     my $q = "$select $from $joins $where $group $order";
 
-    print STDERR "QUERY = $q\n";
+    #print STDERR "QUERY = $q\n";
     
     # Execute the query and add results to accession rows
     my $h = $dbh->prepare($q);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Symptom: Certain values are repeated in the columns, such as in the organization column, IITA is repeated n times when there are n populations present (similar with other keys), when a download is made from the ```/breeders/download``` page, "Download Accession Properties" section.

Solution: report only distinct values for the string aggregation function.

<!-- If there are relevant issues, link them here: -->
Closes #4086.

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
