### PR TITLE
The shm_size option is not supported on github service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
     services:
       breedbase_db:
         image: postgres:12.9
-        shm_size: 2gb
         env:
           POSTGRES_PASSWORD: postgres
         # Set health checks to wait until postgres has started


### PR DESCRIPTION
Unfortunately, github service does not support all the options of docker-compose. See https://github.com/moby/moby/issues/25303


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
