### PR TITLE
P-rep Trial Design Plugin: fix replicated/unreplicated accessors

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/AddTrial.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/AddTrial.js
@@ -524,8 +524,12 @@ jQuery(document).ready(function ($) {
             unreplicated_stock_list_id = $('#list_of_unrep_family_name_list_select').val();
         }
 
-        var stock_list_array = list.getList(stock_list_id);
-        var stock_list = JSON.stringify(stock_list_array);
+        var stock_list;
+        var stock_list_array;
+        if (stock_list_id) {
+            stock_list_array = list.getList(stock_list_id);
+            stock_list = JSON.stringify(stock_list_array);
+        }
 
         var control_list;
         var control_list_array;
@@ -536,7 +540,6 @@ jQuery(document).ready(function ($) {
 
         var control_list_crbd;
         var control_list_crbd_array;
-
         if (control_stock_list_id_crbd) {
             control_list_crbd_array = list.getList(control_stock_list_id_crbd);
             control_list_crbd = JSON.stringify(control_list_crbd_array);

--- a/lib/CXGN/Trial/TrialDesign/Plugin/Prep.pm
+++ b/lib/CXGN/Trial/TrialDesign/Plugin/Prep.pm
@@ -31,11 +31,11 @@ sub create_design {
     } else {
       die "No stock list specified\n";
     }
-    if ($self->has_replicated_accession_no()) {
-      $number_of_replicated_accession = $self->get_replicated_accession_no();
+    if ($self->has_replicated_stock_no()) {
+      $number_of_replicated_accession = $self->get_replicated_stock_no();
     } 
-    if ($self->has_unreplicated_accession_no()) {
-      $number_of_unreplicated_accession = $self->set_unreplicated_accession_no();
+    if ($self->has_unreplicated_stock_no()) {
+      $number_of_unreplicated_accession = $self->get_unreplicated_stock_no();
     } 
     if ($self->has_num_of_replicated_times()) {
       $num_of_replicated_times = $self->get_num_of_replicated_times();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes the accessor error when creating a p-rep trial (first reported 2+ years ago!)

It also confirms that the p-rep trial design code still works with the latest version of DiGGer (v1.0.5), which requires R v4+.

Fixes #2834
Fixes #3822 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
