### PR TITLE
Topic/migrate barcode design to options on label design page

### DIFF
--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -55,6 +55,16 @@ page_formats["US Letter PDF"] = {
                 vertical_gap:0,
                 number_of_columns:1,
                 number_of_rows:1
+            },
+            'CASS': {
+                label_width: 378,
+                label_height: 72,
+                left_margin: 224,
+                top_margin: 30,
+                horizontal_gap: 10,
+                vertical_gap: 1.5,
+                number_of_columns: 1,
+                number_of_rows: 10
             }
         }
 };

--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -95,6 +95,16 @@ page_formats["US Letter PDF"] = {
                 vertical_gap: 20,
                 number_of_columns: 4,
                 number_of_rows: 8
+            },
+            '20 Label Size Sticker': {
+                label_width: 260,
+                label_height: 60,
+                left_margin: 30,
+                top_margin: 36.7,
+                horizontal_gap: 30,
+                vertical_gap: 12,
+                number_of_columns: 2,
+                number_of_rows: 10
             }
         }
 };

--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -56,7 +56,7 @@ page_formats["US Letter PDF"] = {
                 number_of_columns:1,
                 number_of_rows:1
             },
-            'CASS': {
+            'CASS [1" x 5 1/4"]': {
                 label_width: 378,
                 label_height: 72,
                 left_margin: 224,
@@ -66,7 +66,7 @@ page_formats["US Letter PDF"] = {
                 number_of_columns: 1,
                 number_of_rows: 10
             },
-            'MUSA': {
+            'MUSA [1" x 5 1/4"]': {
                 label_width: 378,
                 label_height: 72,
                 left_margin: 224,
@@ -76,7 +76,7 @@ page_formats["US Letter PDF"] = {
                 number_of_columns: 1,
                 number_of_rows: 10
             },
-            'IITA-3 | IITA-2': {
+            'IITA-3 | IITA-2 [2/5" x 5 1/4"]': {
                 label_width: 378,
                 label_height: 32,
                 left_margin: 224,
@@ -86,7 +86,7 @@ page_formats["US Letter PDF"] = {
                 number_of_columns: 1,
                 number_of_rows: 20
             },
-            '32 Label Size Sticker': {
+            '32 Label Size Sticker [1" x 1 1/3"]': {
                 label_width: 94.5,
                 label_height: 72,
                 left_margin: 45,
@@ -96,7 +96,7 @@ page_formats["US Letter PDF"] = {
                 number_of_columns: 4,
                 number_of_rows: 8
             },
-            '20 Label Size Sticker': {
+            '20 Label Size Sticker [5/6" x 3 3/5"]': {
                 label_width: 260,
                 label_height: 60,
                 left_margin: 30,

--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -65,6 +65,16 @@ page_formats["US Letter PDF"] = {
                 vertical_gap: 1.5,
                 number_of_columns: 1,
                 number_of_rows: 10
+            },
+            'MUSA': {
+                label_width: 378,
+                label_height: 72,
+                left_margin: 224,
+                top_margin: 30,
+                horizontal_gap: 10,
+                vertical_gap: 1.5,
+                number_of_columns: 1,
+                number_of_rows: 10
             }
         }
 };

--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -75,6 +75,16 @@ page_formats["US Letter PDF"] = {
                 vertical_gap: 1.5,
                 number_of_columns: 1,
                 number_of_rows: 10
+            },
+            'IITA-3': {
+                label_width: 378,
+                label_height: 32,
+                left_margin: 224,
+                top_margin: 39,
+                horizontal_gap: 5,
+                vertical_gap: 4,
+                number_of_columns: 1,
+                number_of_rows: 20
             }
         }
 };

--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -76,7 +76,7 @@ page_formats["US Letter PDF"] = {
                 number_of_columns: 1,
                 number_of_rows: 10
             },
-            'IITA-3': {
+            'IITA-3 | IITA-2': {
                 label_width: 378,
                 label_height: 32,
                 left_margin: 224,

--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -85,6 +85,16 @@ page_formats["US Letter PDF"] = {
                 vertical_gap: 4,
                 number_of_columns: 1,
                 number_of_rows: 20
+            },
+            '32 Label Size Sticker': {
+                label_width: 94.5,
+                label_height: 72,
+                left_margin: 45,
+                top_margin: 39,
+                horizontal_gap: 45,
+                vertical_gap: 20,
+                number_of_columns: 4,
+                number_of_rows: 8
             }
         }
 };

--- a/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
+++ b/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
@@ -127,7 +127,8 @@ sub check_label_format {
         '1 1/4" x 2"' => 1,
         'Custom' => 1,
         'CASS' => 1,
-        'MUSA' => 1
+        'MUSA' => 1,
+        'IITA-3' => 1
     );
     return $valid_formats{$format};
 }

--- a/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
+++ b/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
@@ -126,7 +126,8 @@ sub check_label_format {
         '2" x 2 5/8"' => 1,
         '1 1/4" x 2"' => 1,
         'Custom' => 1,
-        'CASS' => 1
+        'CASS' => 1,
+        'MUSA' => 1
     );
     return $valid_formats{$format};
 }

--- a/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
+++ b/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
@@ -128,7 +128,7 @@ sub check_label_format {
         'Custom' => 1,
         'CASS' => 1,
         'MUSA' => 1,
-        'IITA-3' => 1
+        'IITA-3 | IITA-2' => 1
     );
     return $valid_formats{$format};
 }

--- a/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
+++ b/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
@@ -126,6 +126,7 @@ sub check_label_format {
         '2" x 2 5/8"' => 1,
         '1 1/4" x 2"' => 1,
         'Custom' => 1,
+        'CASS' => 1
     );
     return $valid_formats{$format};
 }

--- a/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
+++ b/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
@@ -126,11 +126,11 @@ sub check_label_format {
         '2" x 2 5/8"' => 1,
         '1 1/4" x 2"' => 1,
         'Custom' => 1,
-        'CASS' => 1,
-        'MUSA' => 1,
-        'IITA-3 | IITA-2' => 1,
-        '32 Label Size Sticker' => 1,
-        '20 Label Size Sticker' => 1
+        'CASS [1" x 5 1/4"]' => 1,
+        'MUSA [1" x 5 1/4"]' => 1,
+        'IITA-3 | IITA-2 [2/5" x 5 1/4"]' => 1,
+        '32 Label Size Sticker [1" x 1 1/3"]' => 1,
+        '20 Label Size Sticker [5/6" x 3 3/5"]' => 1
     );
     return $valid_formats{$format};
 }

--- a/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
+++ b/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
@@ -129,7 +129,8 @@ sub check_label_format {
         'CASS' => 1,
         'MUSA' => 1,
         'IITA-3 | IITA-2' => 1,
-        '32 Label Size Sticker' => 1
+        '32 Label Size Sticker' => 1,
+        '20 Label Size Sticker' => 1
     );
     return $valid_formats{$format};
 }

--- a/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
+++ b/lib/CXGN/List/Validate/Plugin/LabelDesign.pm
@@ -128,7 +128,8 @@ sub check_label_format {
         'Custom' => 1,
         'CASS' => 1,
         'MUSA' => 1,
-        'IITA-3 | IITA-2' => 1
+        'IITA-3 | IITA-2' => 1,
+        '32 Label Size Sticker' => 1
     );
     return $valid_formats{$format};
 }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
This PR migrates preset barcode design formats to label design page.
The implementation is in three steps:
- migrating the barcode designs as label formats in label designer page.
- Testing the new formats with contact persons for Breeding stations of interest. In the alternative, we can buy the printing materials and ensures the label width and height matches the current implementations.
- Write a patch that save the formats as a public list and allow users to select saved design from a drop-down and print barcode.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [x] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
