### PR TITLE
add seed and fruit as options for tissue samples.

### DIFF
--- a/mason/breeders_toolbox/create_tissue_samples_dialogs.mas
+++ b/mason/breeders_toolbox/create_tissue_samples_dialogs.mas
@@ -234,7 +234,7 @@ jQuery(document).ready(function(){
         var num_tissues = jQuery(this).val();
         var html = '';
         for (var i=1; i<=num_tissues; i++){
-            html = html + '<div class="form-group"><label class="col-sm-3 control-label"><span title="The sample names will be a combination of the plant name, the tissue name you give here, and the tissue number."><span class="glyphicon glyphicon-info-sign"></span>&nbsp;&nbsp;Tissue Name '+i+': </span></label><div class="col-sm-9" ><input name="create_tissue_samples_tissue_name" id="create_tissue_samples_tissue_name_'+i+'" class="form-control" type="text" placeholder="examples: leaf or root or stem" /></div></div>';
+            html = html + '<div class="form-group"><label class="col-sm-3 control-label"><span title="The sample names will be a combination of the plant name, the tissue name you give here, and the tissue number."><span class="glyphicon glyphicon-info-sign"></span>&nbsp;&nbsp;Tissue Name '+i+': </span></label><div class="col-sm-9" ><input name="create_tissue_samples_tissue_name" id="create_tissue_samples_tissue_name_'+i+'" class="form-control" type="text" placeholder="examples: leaf or root or stem or seed or fruit" /></div></div>';
         }
         jQuery('#create_tissue_samples_names_div').html(html);
     });

--- a/mason/breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas
+++ b/mason/breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas
@@ -175,6 +175,8 @@ $sampling_facilities => ();
                                                 <option value="leaf">Leaf</option>
                                                 <option value="root">Root</option>
                                                 <option value="stem">Stem</option>
+                                                <option value="seed">Seed</option>
+                                                <option value="fruit">Fruit</option>
                                             </select>
                                         </div>
                                     </div>
@@ -300,7 +302,7 @@ $sampling_facilities => ();
                     <li>source_observation_unit_name (must exist in the database. the identifier of the origin material. in order of most desirable identifier to least desirable identifier that can be used here: tissue sample name, plant name, plot name, accession name. For blank wells, you can write BLANK here and place a 1 in the is_blank column also.)</li>
                     <li>sample_number (the sample number for the sample. Must be unique within this sampling trial)</li>
                     <li>replicate (the replicate number for the sample)</li>
-                    <li>tissue_type (must be either leaf, root, or stem)</li>
+                    <li>tissue_type (must be either leaf, root, or stem, or seed, or fruit)</li>
                     </ul>
 
                     <b>Optional fields:</b>

--- a/mason/breeders_toolbox/trial/add_tissue_sample_per_plant.mas
+++ b/mason/breeders_toolbox/trial/add_tissue_sample_per_plant.mas
@@ -65,7 +65,7 @@ jQuery(document).ready(function() {
         var num_tissues = jQuery(this).val();
         var html = '';
         for (var i=1; i<=num_tissues; i++){
-            html = html + '<div class="form-group"><label class="col-sm-3 control-label"><span title="The sample names will be a combination of the plant name, the tissue name you give here, and the tissue number."><span class="glyphicon glyphicon-info-sign"></span>&nbsp;&nbsp;Tissue Name '+i+': </span></label><div class="col-sm-9" ><input name="add_tissue_samples_tissue_name" id="add_tissue_samples_tissue_name_'+i+'" class="form-control" type="text" placeholder="examples: leaf or root or stem" /></div></div>';
+            html = html + '<div class="form-group"><label class="col-sm-3 control-label"><span title="The sample names will be a combination of the plant name, the tissue name you give here, and the tissue number."><span class="glyphicon glyphicon-info-sign"></span>&nbsp;&nbsp;Tissue Name '+i+': </span></label><div class="col-sm-9" ><input name="add_tissue_samples_tissue_name" id="add_tissue_samples_tissue_name_'+i+'" class="form-control" type="text" placeholder="examples: leaf or root or stem or seed or fruit" /></div></div>';
         }
         jQuery('#add_tissue_samples_names_div').html(html);
     });

--- a/mason/help/workflow_guided/tissue_sample_help.mas
+++ b/mason/help/workflow_guided/tissue_sample_help.mas
@@ -32,7 +32,7 @@
 
                         <&| /util/workflow.mas:step, title=> "Sampling Level" &>
                             <& /page/page_title.mas, title=>"At which level do you plan to keep track of your sampling?" &>
-                            
+
                             <input type="radio" name="tissue_sample_help_select_level" value="accession">&nbsp;&nbsp;&nbsp;Accession Level: The sample is not from a field trial entity and only the accession name is known.<br/>
                             <input type="radio" name="tissue_sample_help_select_level" value="plot">&nbsp;&nbsp;&nbsp;Plot Level: Each plot in the field has a unique identifier, ideally with a barcode label.<br/>
                             <input type="radio" name="tissue_sample_help_select_level" value="plant">&nbsp;&nbsp;&nbsp;Plant Level: Each plant in the field has a unique identifier, ideally with a barcode label.<br/>
@@ -401,7 +401,7 @@ jQuery(document).ready(function(){
         var num_tissues = jQuery(this).val();
         var html = '';
         for (var i=1; i<=num_tissues; i++){
-            html = html + '<div class="form-group"><label class="col-sm-3 control-label"><span title="The sample names will be a combination of the plant name, the tissue name you give here, and the tissue number."><span class="glyphicon glyphicon-info-sign"></span>&nbsp;&nbsp;Tissue Name '+i+': </span></label><div class="col-sm-9" ><input name="tissue_sample_help_tissue_name" id="tissue_samples_help_tissue_name_'+i+'" class="form-control" type="text" placeholder="examples: leaf or root or stem" /></div></div>';
+            html = html + '<div class="form-group"><label class="col-sm-3 control-label"><span title="The sample names will be a combination of the plant name, the tissue name you give here, and the tissue number."><span class="glyphicon glyphicon-info-sign"></span>&nbsp;&nbsp;Tissue Name '+i+': </span></label><div class="col-sm-9" ><input name="tissue_sample_help_tissue_name" id="tissue_samples_help_tissue_name_'+i+'" class="form-control" type="text" placeholder="examples: leaf or root or stem or seed or fruit" /></div></div>';
         }
         jQuery('#tissue_sample_help_tissue_samples_names_div').html(html);
     });


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The PR provide info to users that seed and fruit can also be used as tissue types during tissue sampling trial creation and adding of tissue samples to field trials. 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
