### PR TITLE
Allow seed and fruit to pass xls file check

### DIFF
--- a/lib/CXGN/Trial/ParseUpload/Plugin/SamplingTrialXLS.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/SamplingTrialXLS.pm
@@ -234,8 +234,8 @@ sub _validate_with_plugin {
         }
 
         #tissue_type must not be blank and must be either leaf, root, or step
-        if (!$tissue_type || $tissue_type eq '' || ($tissue_type ne 'leaf' && $tissue_type ne 'root' && $tissue_type ne 'stem')) {
-            push @error_messages, "Cell F$row_name: column tissue type and must be either stem, leaf, or root";
+        if (!$tissue_type || $tissue_type eq '' || ($tissue_type ne 'leaf' && $tissue_type ne 'root' && $tissue_type ne 'stem' && $tissue_type ne 'fruit' && $tissue_type ne 'seed')) {
+            push @error_messages, "Cell F$row_name: column tissue type and must be either stem, leaf, seed, fruit, or root";
         }
 
     }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Added seed and fruit as valid tissue types that pass the .xls file checks on upload of sampling trial.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
