### PR TITLE
Trial Phenotype Download: escape quotes in CSV files

### DIFF
--- a/lib/CXGN/Trial/Download/Plugin/TrialPhenotypeCSV.pm
+++ b/lib/CXGN/Trial/Download/Plugin/TrialPhenotypeCSV.pm
@@ -160,7 +160,7 @@ sub download {
         my $num_col = scalar(@$header);
         for (my $line =0; $line< @data; $line++) {
             my $columns = $data[$line];
-            print $F join ',', map { qq!"$_"! } @$columns;
+            print $F join ',', map { $_ =~ s/"/""/g; qq!"$_"! } @$columns;
             print $F "\n";
         }
     close($F);

--- a/lib/CXGN/Trial/Download/Plugin/TrialPhenotypeCSVEntryNumbers.pm
+++ b/lib/CXGN/Trial/Download/Plugin/TrialPhenotypeCSVEntryNumbers.pm
@@ -193,7 +193,7 @@ sub download {
                 my $entry_number = $trial_entry_numbers{$trial_id}{$stock_id};
                 splice(@$columns, $ENTRY_NUMBER_COLUMN, 0, $entry_number);
             }
-            print $F join ',', map { qq!"$_"! } @$columns;
+            print $F join ',', map { $_ =~ s/"/""/g; qq!"$_"! } @$columns;
             print $F "\n";
         }
     close($F);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This escapes double quotes (`"` --> `""`) in the CSV phenotype downloads


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
