### PR TITLE
change phenotype data search_type to Native

### DIFF
--- a/lib/SGN/Model/solGS/solGS.pm
+++ b/lib/SGN/Model/solGS/solGS.pm
@@ -1533,7 +1533,7 @@ sub phenotype_data {
 
     my $phenotypes_search = CXGN::Phenotypes::PhenotypeMatrix->new(
         bcs_schema  => $self->schema,
-        search_type => 'MaterializedViewTable',
+        search_type => 'Native',
         trial_list  => [$project_id],
         data_level  => 'plot',
     );


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Change phenotype data search type to 'Native' from 'MaterializedViewTable'. This allows users to analyze data immediately after upload, with out having to wait for the matviews to be updated.
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
