### PR TITLE
Fieldmap.js: remove optional chaining syntax

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -15,8 +15,8 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.3.3",
-    "@babel/preset-env": "^7.3.1",
     "@babel/polyfill": "^7.2.5",
+    "@babel/preset-env": "^7.3.1",
     "babel-loader": "^8.0.5",
     "deepmerge": "^2.2.1",
     "del": "^3.0.0",
@@ -34,9 +34,9 @@
     "@solgenomics/brapijs": "github:solgenomics/brapi-js#develop",
     "BrAPI-BoxPlotter": "git+https://github.com/solgenomics/BrAPI-BoxPlotter.git",
     "d3": "^7.3.0",
-    "d3-sankey": "^0.12.3",
     "d3-array": "^2.11.0",
     "d3-path": "^1.0.9",
+    "d3-sankey": "^0.12.3",
     "d3-shape": "^1.3.7",
     "internmap": "^1.0.0"
   },

--- a/js/source/entries/fieldmap.js
+++ b/js/source/entries/fieldmap.js
@@ -536,8 +536,11 @@ export function init() {
             }
 
             var is_plot_overlapping = function(plot) {
-                let k = `${plot.observationUnitPosition?.positionCoordinateX}-${plot.observationUnitPosition?.positionCoordinateY}`;
-                return Object.keys(local_this.meta_data.overlapping_plots).includes(k);
+                if ( plot.observationUnitPosition ) {
+                    let k = `${plot.observationUnitPosition.positionCoordinateX}-${plot.observationUnitPosition.positionCoordinateY}`;
+                    return Object.keys(local_this.meta_data.overlapping_plots).includes(k);
+                }
+                return false;
             }
 
             var get_fieldmap_plot_color = function(plot) {
@@ -590,7 +593,7 @@ export function init() {
             var get_plot_message = function(plot) {
                 let html = '';
                 if ( is_plot_overlapping(plot) ) {
-                    let k = `${plot.observationUnitPosition?.positionCoordinateX}-${plot.observationUnitPosition?.positionCoordinateY}`;
+                    let k = `${plot.observationUnitPosition.positionCoordinateX}-${plot.observationUnitPosition.positionCoordinateY}`;
                     let plots = local_this.meta_data.overlapping_plots[k];
                     html += `<strong>Overlapping Plots:</strong> ${plots.join(', ')}`;
                 }
@@ -679,16 +682,18 @@ export function init() {
             this.meta_data.overlapping_plots = {};
             let plot_positions = {};
             this.plot_arr.forEach((plot) => {
-                let x = plot.observationUnitPosition?.positionCoordinateX;
-                let y = plot.observationUnitPosition?.positionCoordinateY;
-                let p = plot.observationUnitPosition?.observationLevel?.levelCode;
-                let t = plot.studyName;
-                if ( x && y ) {
-                    let k = `${x}-${y}`;
-                    if ( !plot_positions.hasOwnProperty(k) ) plot_positions[k] = [];
-                    plot_positions[k].push(jQuery("#include_linked_trials_checkmark").is(":checked") ? `${p} (${t})` : p);
-                    if ( plot_positions[k].length > 1 ) {
-                        this.meta_data.overlapping_plots[k] = plot_positions[k];
+                if ( plot.observationUnitPosition ) {
+                    let x = plot.observationUnitPosition.positionCoordinateX;
+                    let y = plot.observationUnitPosition.positionCoordinateY;
+                    let p = plot.observationUnitPosition.observationLevel ? plot.observationUnitPosition.observationLevel.levelCode : '';
+                    let t = plot.studyName;
+                    if ( x && y ) {
+                        let k = `${x}-${y}`;
+                        if ( !plot_positions.hasOwnProperty(k) ) plot_positions[k] = [];
+                        plot_positions[k].push(jQuery("#include_linked_trials_checkmark").is(":checked") ? `${p} (${t})` : p);
+                        if ( plot_positions[k].length > 1 ) {
+                            this.meta_data.overlapping_plots[k] = plot_positions[k];
+                        }
                     }
                 }
             });


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This removes the optional chaining JS syntax from the fieldmap.js file


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
