### PR TITLE
Heritability: Return error messages to website

### DIFF
--- a/lib/SGN/Controller/AJAX/Heritability.pm
+++ b/lib/SGN/Controller/AJAX/Heritability.pm
@@ -142,6 +142,8 @@ sub generate_results: Path('/ajax/heritability/generate_results') : {
     my $h2File = $tempfile . "_" . "h2File.png";
     my $figure3file = $tempfile . "_" . "figure3.png";
     my $figure4file = $tempfile . "_" . "figure4.png";
+    my $errorFile = $tempfile . "_" . "error.txt";
+
 
     $trait_id =~ tr/ /./;
     $trait_id =~ tr/\//./;
@@ -166,7 +168,8 @@ sub generate_results: Path('/ajax/heritability/generate_results') : {
             $trait_id,
             $figure3file,
             $figure4file,
-            $h2File
+            $h2File,
+            $errorFile
     );
     $cmd->alive;
     $cmd->is_cluster(1);
@@ -191,6 +194,12 @@ sub generate_results: Path('/ajax/heritability/generate_results') : {
     my $figure4basename = basename($figure4file);
     my $figure4_response = "/documents/tempfiles/heritability_files/" . $figure4basename;
 
+    my $errors;
+    if ( -e $errorFile ) {
+        open my $fh, '<', $errorFile or die "Can't open error file $!";
+        $errors = do { local $/; <$fh> };
+    }
+
 
     #print STDERR $h2File_response;
         
@@ -198,7 +207,8 @@ sub generate_results: Path('/ajax/heritability/generate_results') : {
         h2Table => $h2File_response,
         figure3 => $figure3_response,
         figure4 => $figure4_response,
-        dummy_response => $dataset_id
+        dummy_response => $dataset_id,
+        error => $errors
         # dummy_response2 => $trait_id,
     };
 }

--- a/mason/tools/heritability/index.mas
+++ b/mason/tools/heritability/index.mas
@@ -222,15 +222,13 @@ jQuery(document).ready(function() {
             if (response.error) {
               alert(response.error);
             }
-            else {
-              var fig1_response = response.h2Table;
-              var fig2_response = response.figure3;
-        //alert("Response ID: "+temp_response);
-            //alert("Response ID: "+fig1_response);
+            var fig1_response = response.h2Table;
+            var fig2_response = response.figure3;
+      //alert("Response ID: "+temp_response);
+          //alert("Response ID: "+fig1_response);
 
-              $('#heritability_output').append("<img id='h2_Table' src='"+ fig1_response + "'/>");
-              $('#heritability_output').append("<img id='h2_Figure4' src='"+ fig2_response + "'/>");
-            }
+            $('#heritability_output').append("<img id='h2_Table' src='"+ fig1_response + "'/>");
+            $('#heritability_output').append("<img id='h2_Figure4' src='"+ fig2_response + "'/>");
           },
           error: function(xhr, status, error) {
             var err = eval("(" + xhr.responseText + ")");


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes a small typo in the heritability R script:
https://github.com/solgenomics/sgn/blob/86c31e7fdf3fa280497c97ba72b69ffba58dc43c/R/heritability/h2_blup_rscript.R#L85

It also adds a few more try/catch blocks and writes all of the error messages encountered in the R script to a file which is used to return the error messages to the website.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
