### PR TITLE
Topic/plot map fixes

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/UploadTrial.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/UploadTrial.js
@@ -276,7 +276,11 @@ jQuery(document).ready(function ($) {
                 $("#upload_trial_error_display_second_try").show();
             }
             if (response.warnings) {
-                alert(response.warnings);
+                warnings = response.warnings;
+                warning_html = "<li>"+warnings.join("</li><li>")+"</li>"
+                $("#upload_trial_warning_messages").show();
+                $("#upload_trial_warning_messages").html('<b>Warnings. Fix or ignore the following warnings and try again.</b><br><br>'+warning_html);
+                return;
             }
             if (response.success) {
                 refreshTrailJsTree(0);

--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
@@ -582,11 +582,6 @@ sub _validate_with_plugin {
       push @error_messages, "Cell M".$seen_plot_names{$r->uniquename}.": plot name <b>".$r->uniquename."</b> already exists.";
   }
 
-  if (scalar(@warning_messages) >= 1) {
-      $warnings{'warning_messages'} = \@warning_messages;
-      $self->_set_parse_warnings(\%warnings);
-  }
-
   ## PLOT POSITION OVERALL VALIDATION
   foreach my $tk (keys %seen_plot_keys) {
       foreach my $pk (keys %{$seen_plot_keys{$tk}} ) {
@@ -594,9 +589,14 @@ sub _validate_with_plugin {
           my $count = scalar(@{$plots});
           if ( $count > 1 ) {
               my @pos = split('-', $pk);
-              push @error_messages, "More than 1 plot is assigned to the position row=" . $pos[0] . " col=" . $pos[1] . " trial=" . $tk . " plots=" . join(',', @$plots);
+              push @warning_messages, "More than 1 plot is assigned to the position row=" . $pos[0] . " col=" . $pos[1] . " trial=" . $tk . " plots=" . join(',', @$plots);
           }
       }
+  }
+
+  if (scalar(@warning_messages) >= 1) {
+      $warnings{'warning_messages'} = \@warning_messages;
+      $self->_set_parse_warnings(\%warnings);
   }
 
   #store any errors found in the parsed file to parse_errors accessor

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
@@ -374,7 +374,7 @@ sub _validate_with_plugin {
         my $count = scalar(@{$plots});
         if ( $count > 1 ) {
             my @pos = split('-', $key);
-            push @error_messages, "More than 1 plot is assigned to the position row=" . $pos[0] . " col=" . $pos[1] . " plots=" . join(',', @$plots);
+            push @warning_messages, "More than 1 plot is assigned to the position row=" . $pos[0] . " col=" . $pos[1] . " plots=" . join(',', @$plots);
         }
     }
 

--- a/lib/SGN/Controller/AJAX/Trial.pm
+++ b/lib/SGN/Controller/AJAX/Trial.pm
@@ -905,6 +905,7 @@ sub upload_trial_file_POST : Args(0) {
     my $add_project_trial_genotype_trial_select = [$add_project_trial_genotype_trial];
     my $add_project_trial_crossing_trial_select = [$add_project_trial_crossing_trial];
     my $trial_stock_type = $c->req->param('trial_upload_trial_stock_type');
+    my $ignore_warnings = $c->req->param('upload_trial_ignore_warnings');
 
     my $upload = $c->req->upload('trial_uploaded_file');
     my $parser;
@@ -997,11 +998,11 @@ sub upload_trial_file_POST : Args(0) {
         return;
     }
 
-    my $return_warnings;
     if ($parser->has_parse_warnings()) {
-        my $warnings = $parser->get_parse_warnings();
-        foreach my $warning_string (@{$warnings->{'warning_messages'}}){
-            $return_warnings=$return_warnings.$warning_string."<br>";
+        unless ($ignore_warnings) {
+            my $warnings = $parser->get_parse_warnings();
+            $c->stash->{rest} = {warnings => $warnings->{'warning_messages'}};
+            return;
         }
     }
 
@@ -1081,7 +1082,7 @@ sub upload_trial_file_POST : Args(0) {
     #print STDERR "Check 5: ".localtime()."\n";
     if ($save->{'error'}) {
         print STDERR "Error saving trial: ".$save->{'error'};
-        $c->stash->{rest} = {warnings => $return_warnings, error => $save->{'error'}};
+        $c->stash->{rest} = {error => $save->{'error'}};
         return;
     } elsif ($save->{'trial_id'}) {
 
@@ -1089,7 +1090,7 @@ sub upload_trial_file_POST : Args(0) {
         my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
         my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'all_but_genoview', 'concurrent', $c->config->{basepath});
 
-        $c->stash->{rest} = {warnings => $return_warnings, success => "1", trial_id => $save->{'trial_id'}};
+        $c->stash->{rest} = {success => "1", trial_id => $save->{'trial_id'}};
         return;
     }
 

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -381,7 +381,22 @@ $design_types => ()
                                     </div>
                                 </div>
 
-                                <br/>
+                                <br />
+
+                                <div class="form-horizontal">
+                                    <p>Check this box to ignore any possible warning messages and save the trial to the database.</p>
+                                    <div class="form-group">
+                                        <label class="col-sm-5 control-label">Ignore Warnings?: </label>
+                                        <div class="col-sm-7">
+                                            <input id="upload_trial_ignore_warnings" name="upload_trial_ignore_warnings" type="checkbox">
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div style="display:none; padding: 5px; text-align: center" id="upload_trial_warning_messages" class="alert-warning" role="alert"></div>
+
+                                <br />
+
                                 <center>
                                     <button type="button" class="btn btn-lg btn-primary" name="upload_trial_validate_form_button" id="upload_trial_validate_form_button">First validate the form</button>
                                     <button type="button" class="btn btn-lg btn-primary" disabled name="upload_trial_submit_first" onclick="Workflow.complete(this, false); return false;" >Upload Trial</button>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This makes a couple of small changes to the single and multi-trial uploads:

- It changes the plot row/col checks to warnings instead of errors (added in PR #4236)
- It changes the single-trial upload to handle warnings like the multi-trial upload
    - if warnings are encountered, the trial is not automatically saved
    - warning messages are displayed in the upload dialog
    - the user can override the warnings with an "ignore warnings" checkbox

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
