### PR TITLE
db_id parameter in blast url not working correctly

### DIFF
--- a/lib/SGN/Controller/Blast.pm
+++ b/lib/SGN/Controller/Blast.pm
@@ -44,7 +44,7 @@ sub index :Path('/tools/blast/') :Args(0) {
   # $preselected_database = 224;
   
   if ($db_id) { 
-    my $rs = $schema->resultset("BlastDb")->search( { blast_db_id => $db_id }, { join => 'blast_db_group' });
+    my $rs = $schema->resultset("BlastDb")->search( { blast_db_id => $db_id }, { join => 'blast_db_blast_db_group' });
     
     if ($rs == 0) {
       $c->throw( is_error => 0, message => "The blast database with id $db_id could not be found.");


### PR DESCRIPTION

The db_id parameter query joined to the group table, instead of the linking table, not retrieving datasets if the blast_db_group_id was not set in sgn.blast_db. This should now go through the linking table and that column in sgn.blast_db should be removed. This PR only changes the query.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
