### PR TITLE
allow missing values to be specified with dot '.' for VCF input

### DIFF
--- a/bin/transpose_matrix.pl
+++ b/bin/transpose_matrix.pl
@@ -2,6 +2,14 @@
 # 'transpose' swaps rows and columns in the given tab-delimited table.
 # syntax perl transpose.pl input.txt > output.txt
 
+use strict;
+use warnings;
+
+my @line;
+my @outline;
+my $lastcol;
+my $oldlastcol;
+
 while (<>) {
   chomp;
   @line = split /\t/;
@@ -11,7 +19,7 @@ while (<>) {
     $outline[$i] = "\t" x $oldlastcol;
   }
   for (my $i=0; $i <=$lastcol; $i++) {
-    if ($outline[$i] =~ /\w/) {
+    if ($outline[$i] =~ /[\w.]/) {
         $outline[$i] .= "\t$line[$i]";
     } else {
 	$outline[$i] = $line[$i];

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -1678,14 +1678,14 @@ sub get_cached_file_VCF {
                 $genotype_string .= "POS\t";
                 foreach my $m (@all_marker_objects) {
 		    my $pos = $geno->{selected_protocol_hash}->{markers}->{$m->{name}}->{pos};
-		    if (! $pos) {
+		    if ($pos eq "") {
 			(undef, $pos) = split /\_/, $m->{name};
-			if ($pos) {
-			    #print STDERR "Warning! No position data, using $pos extracted from $m->{name}\n";
-		        } else {
+			if (! $pos) {
 			    $pos = 0;
 			    print STDERR "Warning! No position data, using 0\n";
 			}
+		    } elsif ($pos eq ".") { # pos must be an integer
+			$pos = 0;
 		    }
                     #$genotype_string .= $geno->{selected_protocol_hash}->{markers}->{$m->{name}}->{pos} . "\t";
 		    $genotype_string .= $pos ."\t";


### PR DESCRIPTION
replace missing values in POS field of VCF output with 0


when values in VCF were specified as missing with dot '.' the transform_matrix.pl would remove those columns. This patch fixes that problem. The VCF specification also say that the POS column must be an integer and the TASSEL program will fail if POS is not an integer. To fix this case, the VCF output converts the dot '.' entry to a 0

fixes #4328

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
