### PR TITLE
Topic/new account verification

### DIFF
--- a/lib/SGN/Controller/User.pm
+++ b/lib/SGN/Controller/User.pm
@@ -75,6 +75,29 @@ sub confirm_user :Path('/user/confirm') Args(0) {
 
     $sp->store();
 
+    # Send confirmation to user, if manual confirmation is enabled
+    if ( $c->config->{user_registration_admin_confirmation} && $c->config->{user_registration_admin_confirmation_email} ) {
+        my $host = $c->config->{main_production_site_url};
+        my $project_name = $c->config->{project_name};
+        my $subject="[$project_name] New Account Confirmed";
+        my $body=<<END_HEREDOC;
+
+Your new account on $project_name with the username \"$username\" has been confirmed.
+
+You can now login using your account credentials:
+$host
+
+Thank you,
+$project_name Team
+
+Please do *NOT* reply to this message. If you have any trouble logging into your 
+account or have any other questions, please use the contact form instead:
+$host/contact/form
+
+END_HEREDOC
+        CXGN::Contact::send_email($subject,$body,$sp->get_pending_email());
+    }
+
     $c->stash->{template} = '/generic_message.mas';
     $c->stash->{message} = "Confirmation successful for username <b>$username</b>";
 }

--- a/mason/site/login_dialog.mas
+++ b/mason/site/login_dialog.mas
@@ -291,7 +291,8 @@ jQuery(document).ready( function() {
                 console.log(r);
                 if (r.error) { alert(r.error); }
                 else {
-                    alert('New account added. Check your email for the confirmation link - you must confirm your account before you can login.');
+                    let message = r.message || 'New account added. Check your email for the confirmation link - you must confirm your account before you can login.';
+                    alert(message);
                     jQuery('#site_login_new_user_dialog').modal('hide');
                     jQuery('#site_login_dialog').modal('hide');
                 }

--- a/sgn.conf
+++ b/sgn.conf
@@ -44,6 +44,8 @@ seedlot_maintenance_info_cvterms
 project_name SGN
 
 user_registration_join_breeding_programs 0  # when enabled, a new user can choose which breeding programs to join during registration
+user_registration_admin_confirmation 0      # when enabled, the new user confirmation message will be sent to the address(es) below instead of the user
+user_registration_admin_confirmation_email  # a comma-separated list of email addresses to send new user confirmation messages to, when the above is enabled
 disable_login 0
 default_login_janedoe 0
 require_login 0

--- a/t/unit_mech/AJAX/Login.t
+++ b/t/unit_mech/AJAX/Login.t
@@ -26,11 +26,11 @@ is($response->{message}, 'Login successful');
 $mech->get_ok('http://localhost:3010/ajax/user/new?first_name=testfirst&last_name=testlast&username=testusername&password=testpass&confirm_password=testpass&email_address=test@testcassavabase.com');
 $response = decode_json $mech->content;
 print STDERR Dumper $response;
-is_deeply($response, {'message' => ' <table summary="" width="80%" align="center">
-<tr><td><p>Account was created with username "testusername". To continue, you must confirm that SGN staff can reach you via email address "test@testcassavabase.com". An email has been sent with a URL to confirm this address. Please check your email for this message and use the link to confirm your email address.</p></td></tr>
-<tr><td><br /></td></tr>
-</table>
-'});
+is_deeply($response, {'message' => 'Account was created with username "testusername".
+
+To continue, you must confirm that we can reach you via email address "test@testcassavabase.com". An email has been sent with a URL to confirm this address. Please check your email for this message and use the link to confirm your email address.
+
+You will be able to login once your account has been confirmed.'});
 
 $mech->get_ok('http://localhost:3010/ajax/user/new?first_name=testfirst&last_name=testlast&username=testusername&password=testpass&confirm_password=testpass&email_address=test@testcassavabase.com&organization=testorg');
 $response = decode_json $mech->content;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds a simple account verification feature.  If enabled in the `sgn_local.conf`, when a new user creates an account:

1) The new user's account is disabled (unable to login) until confirmed by an admin
2) A confirmation email will be sent to the admin email(s) given in the `sgn_local.conf` file
3) An admin needs to click the verification link in the email to enable the account
4) When the new user's account is verified, they will receive an email saying their account is active and they can now login

To enable this feature, add these conf keys to `sgn_local.conf`:

```
user_registration_admin_confirmation 1
user_registration_admin_confirmation_email admin1@cornell.edu, admin2@cornell.edu
```

Fixes #4433 



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
