### PR TITLE
Fix the datatable on cvterm detail page that shows associated accessions

### DIFF
--- a/lib/SGN/Controller/AJAX/Cvterm.pm
+++ b/lib/SGN/Controller/AJAX/Cvterm.pm
@@ -258,18 +258,17 @@ sub get_phenotyped_stocks :Chained('/cvterm/get_cvterm') :PathPart('datatables/p
     my $cvterm =  $c->stash->{cvterm};
     my $cvterm_id  = $cvterm->cvterm_id;
 
-    my $q = "SELECT DISTINCT stock_id,  stock.uniquename, stock.description, type.name
+    my $q = "SELECT DISTINCT acc.stock_id,  pathdistance, acc.uniquename, acc.description, type.name
              FROM cvtermpath
-              JOIN cvterm ON (cvtermpath.object_id = cvterm.cvterm_id
-                            OR cvtermpath.subject_id = cvterm.cvterm_id )
-               JOIN phenotype on cvterm.cvterm_id = phenotype.observable_id
-               JOIN nd_experiment_phenotype USING (phenotype_id)
-               JOIN nd_experiment_stock USING (nd_experiment_id)
-               JOIN stock USING (stock_id)
-               JOIN cvterm as type on type.cvterm_id = stock.type_id
-
-             WHERE pathdistance > 0
-             AND cvtermpath.object_id = ? ORDER BY stock_id " ;
+             JOIN cvterm ON (cvtermpath.object_id = cvterm.cvterm_id
+                         OR cvtermpath.subject_id = cvterm.cvterm_id )
+             JOIN phenotype on cvterm.cvterm_id = phenotype.observable_id
+             JOIN nd_experiment_phenotype USING (phenotype_id)
+             JOIN nd_experiment_stock USING (nd_experiment_id)
+             JOIN stock USING (stock_id)
+             JOIN stock_relationship on(plot.stock_id=stock_relationship.subject_id) join stock as acc on(stock_relationship.object_id=acc.stock_id)
+             JOIN cvterm as type on type.cvterm_id = stock.type_id      
+             WHERE cvtermpath.object_id = ? ORDER BY stock_id " ;
 
 
     my $sth = $c->dbc->dbh->prepare($q);

--- a/lib/SGN/Controller/AJAX/Cvterm.pm
+++ b/lib/SGN/Controller/AJAX/Cvterm.pm
@@ -265,17 +265,17 @@ sub get_phenotyped_stocks :Chained('/cvterm/get_cvterm') :PathPart('datatables/p
              JOIN phenotype on cvterm.cvterm_id = phenotype.observable_id
              JOIN nd_experiment_phenotype USING (phenotype_id)
              JOIN nd_experiment_stock USING (nd_experiment_id)
-             JOIN stock USING (stock_id)
+             JOIN stock as plot USING (stock_id)
              JOIN stock_relationship on(plot.stock_id=stock_relationship.subject_id) join stock as acc on(stock_relationship.object_id=acc.stock_id)
-             JOIN cvterm as type on type.cvterm_id = stock.type_id      
-             WHERE cvtermpath.object_id = ? ORDER BY stock_id " ;
+             JOIN cvterm as type on type.cvterm_id = acc.type_id      
+             WHERE cvtermpath.object_id = ? ORDER BY acc.stock_id " ;
 
 
     my $sth = $c->dbc->dbh->prepare($q);
     $sth->execute($cvterm_id) ;
     #$c->stash->{rest}{count} = 0 + $sth->execute($cvterm_id);
     my @data;
-    while ( my ($stock_id, $stock_name, $description, $type) = $sth->fetchrow_array ) {
+    while ( my ($stock_id, $pathdistance, $stock_name, $description, $type) = $sth->fetchrow_array ) {
         my $link = qq|<a href="/stock/$stock_id/view">$stock_name</a> |;
         push @data, [
 	    $type,


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Topic/fix accession query on trait detail page

The section "Phentoyped accessions" does not work on most Breedbases because the query is based on an outdated data storage scheme. With this PR the accessions should be shown correctly on most instances.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
