### PR TITLE
BrAPI: Search Observations Units - includeObservations param

### DIFF
--- a/lib/CXGN/BrAPI/v2/ObservationUnits.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationUnits.pm
@@ -40,6 +40,7 @@ sub search {
     my $observation_unit_db_id = $params->{observationUnitDbId} || ($params->{observationUnitDbIds} || ());
     my $observation_unit_names_list = $params->{observationUnitName} || ($params->{observationUnitNames} || ());
     my $include_observations = $params->{includeObservations} || "False";
+    $include_observations = ref($include_observations) eq 'ARRAY' ? ${$include_observations}[0] : $include_observations;
     my $level_order_arrayref = $params->{observationUnitLevelOrder} || ($params->{observationUnitLevelOrders} || ());
     my $level_code_arrayref = $params->{observationUnitLevelCode} || ($params->{observationUnitLevelCodes} || ());
     my $levels_relation_arrayref = $params->{observationLevelRelationships} || ();


### PR DESCRIPTION
BrAPI Search Observations Units:

when the `includeObservations` parameter is included, it is being converted to an array somewhere, but the search function is expecting a "true"/"false" value.  This checks to see if the param is an array and uses the first value if it is.

This was causing the Compare Trials tool to fail since no observations were being returned from the BrAPI call.


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
