### PR TITLE
Fix searching seedlots with accession names

### DIFF
--- a/lib/CXGN/Stock/Seedlot.pm
+++ b/lib/CXGN/Stock/Seedlot.pm
@@ -318,6 +318,7 @@ sub list_seedlots {
     my $offset = shift;
     my $limit = shift;
     my $seedlot_name = shift;
+    my $description = shift;
     my $breeding_program = shift;
     my $location = shift;
     my $minimum_count = shift;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fix searching seedlots with accession names by  adding a description variable to CXGN::Stock::Seedlot.

<!-- If there are relevant issues, link them here: -->
Closes #4295 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x ] Bug fix
  - [ x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
