### PR TITLE
Location Validation: Check for code/abbreviation matches

### DIFF
--- a/lib/CXGN/List/Validate/Plugin/Locations.pm
+++ b/lib/CXGN/List/Validate/Plugin/Locations.pm
@@ -15,16 +15,66 @@ sub validate {
 
 #    print STDERR "LIST: ".Data::Dumper::Dumper($list);
 
-    my @missing = ();
-    foreach my $term (@$list) { 
+   my $location_code_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'abbreviation', 'geolocation_property')->cvterm_id();
 
-	my $rs = $schema->resultset("NaturalDiversity::NdGeolocation")->search( { description => $term } );
+   my @missing;
+   my @wrong_case;
+   my @multiple_wrong_case;
+   my @codes;
 
-	if ($rs->count == 0) { 
-	    push @missing, $term;
-	}
+    # First filter out exact matches
+    my $rs = $schema->resultset("NaturalDiversity::NdGeolocation")->search({
+        description => {
+            in => $list
+        }
+    });
+    my @exact = $rs->get_column('description')->all();
+    my %exact_map = map { $_=>1 } @exact;
+    my @missing = grep { !exists $exact_map{$_} } @$list;
+
+    # Now do more searches on the non-exact matches
+    foreach my $item (@missing) {
+
+        # find case-insensitive matches
+        my $rs = $schema->resultset("NaturalDiversity::NdGeolocation")->search({
+            'lower(description)' => lc($item)
+        });
+        if ( $rs->count() == 1 ) {
+            my $row = $rs->next();
+            if ($row->description ne $item) {
+                push @wrong_case, [ $item, $row->description() ];
+            }
+        }
+        elsif ($rs->count() > 1) {
+            while(my $row = $rs->next()) { 
+                push @multiple_wrong_case, [ $item, $row->description() ];
+            }
+        }
+
+        # find location codes
+        my $rs = $schema->resultset("NaturalDiversity::NdGeolocationprop")->search(
+            {
+                type_id => $location_code_type_id,
+                value => $item
+            },
+            {
+                join => "nd_geolocation",
+                '+select' => [ "nd_geolocation.description" ],
+                '+as' => "description"
+            });
+        if ( $rs->count() == 1 ) {
+            my $row = $rs->next();
+            push @codes, [ $item, $row->get_column('description') ];
+        }
+
     }
-    return { missing => \@missing };
+
+    return { 
+        missing => \@missing,
+        wrong_case => \@wrong_case,
+        multiple_wrong_case => \@multiple_wrong_case,
+        codes => \@codes
+    };
 
 }
 

--- a/lib/CXGN/Trial/ParseUpload.pm
+++ b/lib/CXGN/Trial/ParseUpload.pm
@@ -49,6 +49,15 @@ has '_parsed_data' => (
     predicate => '_has_parsed_data'
 );
 
+has '_location_code_map' => (
+    is => 'ro',
+    isa => 'HashRef',
+    writer => '_set_location_code_map',
+    reader => '_get_location_code_map',
+    predicate => '_has_location_code_map',
+    required => 0
+);
+
 has 'trial_stock_type' => (
     isa => 'Str',
     is => 'rw',

--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
@@ -484,10 +484,24 @@ sub _validate_with_plugin {
 
   ## LOCATIONS OVERALL VALIDATION
   my @locations = keys %seen_locations;
-  my @locations_missing = @{$validator->validate($schema,'locations',\@locations)->{'missing'}};
-  if (scalar(@locations_missing) > 0) {
-      # $errors{'missing_locations'} = \@locations_missing;
-      push @error_messages, "Location(s) <b>".join(',',@locations_missing)."</b> are not in the database.";
+  my $locations_hashref = $validator->validate($schema,'locations',\@locations);
+
+  # Find valid location codes
+  my @codes = @{$locations_hashref->{'codes'}};
+  my %location_code_map;
+  foreach my $code (@codes) {
+    my $location_code = $code->[0];
+    my $found_location_name = $code->[1];
+    $location_code_map{$location_code} = $found_location_name;
+    push @warning_messages, "File Location '$location_code' matches the code for the location named '$found_location_name' and will be substituted if you ignore warnings.";
+  }
+  $self->_set_location_code_map(\%location_code_map);
+
+  # Check the missing locations, ignoring matched codes
+  my @locations_missing = @{$locations_hashref->{'missing'}};
+  my @locations_missing_no_codes = grep { !exists $location_code_map{$_} } @locations_missing;
+  if (scalar(@locations_missing_no_codes) > 0) {
+      push @error_messages, "Location(s) <b>".join(',',@locations_missing_no_codes)."</b> are not in the database.";
   }
 
   ## DESIGN TYPES OVERALL VALIDATION
@@ -738,8 +752,18 @@ sub _parse_with_plugin {
         %single_design = ();
         $all_designs{$trial_name} = \%final_single_design;
       }
+
+      # Get location and replace codes with names
+      my $location = $worksheet->get_cell($row,2)->value();
+      if ( $self->_has_location_code_map() ) {
+        my $location_code_map = $self->_get_location_code_map();
+        if ( exists $location_code_map->{$location} ) {
+          $location = $location_code_map->{$location};
+        }
+      }
+
       $single_design{'breeding_program'} = $worksheet->get_cell($row,1)->value();
-      $single_design{'location'} = $worksheet->get_cell($row,2)->value();
+      $single_design{'location'} = $location;
       $single_design{'year'} = $worksheet->get_cell($row,3)->value();
       $single_design{'design_type'} = $worksheet->get_cell($row,4)->value();
       $single_design{'description'} = $worksheet->get_cell($row,5)->value();

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -719,7 +719,7 @@ $design_types => ()
                     <ul>
                     <li>trial_name (Must be unique across entire database. It is often a concatenation of the year, purpose, unique number, and location.)</li>
                     <li>breeding_program (The name of breeding program that managed the trial, must exist in the database.)</li>
-                    <li>location (The name of the location where the trial was held, must exist in the database.)</li>
+                    <li>location (The <strong>name</strong> or <strong>abbreviation</strong> of the location where the trial was held, must exist in the database.)</li>
                     <li>year (The year the trial was held.)</li>                    
                     <li>design_type (The shorthand for the design type, must exist in the database. Possible values include CRD (Completely Randomized Design), RCBD (Randomized Complete Block Design), RRC (Resolvable Row-Column), DRRC (Doubly-Resolvable Row-Column), ARC (Augmented Row-Column), Alpha (Alpha Lattice Design), Lattice (Lattice Design), Augmented (Augmented Design), MAD (Modified Augmented Design), greenhouse (undesigned Nursery/Greenhouse), splitplot (Split Plot), p-rep (Partially Replicated), Westcott (Westcott Design))</li>
                     <li>description (Additional text with any other relevant information about the trial.)</li>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This allows the multi-trial upload template to use location codes/abbreviations, in addition to the full location name.

- List Validation: 
    - adds a `codes` key returned with the list validation that matches valid location codes with full location names
    - a code match is still considered 'missing' so this doesn't change the behavior of other code using the location list validation

- Multi-Trial Excel Upload Plugin:
    - returns a warning if a location code is going to be substituted with a location name, so the user has to approve the substitution
    - the parsed trial design will have the location code replaced with the full location name


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
