### PR TITLE
Trait Validation: Check trait name for COMP traits

### DIFF
--- a/lib/CXGN/BrAPI/v1/Observations.pm
+++ b/lib/CXGN/BrAPI/v1/Observations.pm
@@ -134,6 +134,7 @@ sub observations_store {
         has_timestamps=>1,
         metadata_hash=>\%phenotype_metadata,
         #image_zipfile_path=>$image_zip,
+        composable_validation_check_name=>$params->{composable_validation_check_name}
     );
 
     my ($stored_observation_error, $stored_observation_success, $stored_observation_details) = $store_observations->store();

--- a/lib/CXGN/BrAPI/v2/Observations.pm
+++ b/lib/CXGN/BrAPI/v2/Observations.pm
@@ -337,6 +337,7 @@ sub observations_store {
         metadata_hash=>\%phenotype_metadata,
         overwrite_values=>$overwrite_values,
         #image_zipfile_path=>$image_zip,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     );
     my ($verified_warning, $verified_error) = $store_observations->verify();
 

--- a/lib/CXGN/List/Validate.pm
+++ b/lib/CXGN/List/Validate.pm
@@ -5,6 +5,12 @@ use Moose;
 
 use Module::Pluggable require => 1;
 
+has 'composable_validation_check_name' => (
+    isa => "Bool",
+    is => 'rw',
+    default => 0
+);
+
 sub validate {
     my $self = shift;
     my $schema = shift;

--- a/lib/CXGN/List/Validate/Plugin/Traits.pm
+++ b/lib/CXGN/List/Validate/Plugin/Traits.pm
@@ -30,6 +30,8 @@ sub validate {
         $accession =~ s/^\s+//;
         $db_name =~ s/\s+$//;
         $db_name =~ s/^\s+//;
+        $trait_name =~ s/\s+$//;
+        $trait_name =~ s/^\s+//;
 
         my $db_rs = $schema->resultset("General::Db")->search( { 'me.name' => $db_name });
         if ($db_rs->count() == 0) {

--- a/lib/CXGN/List/Validate/Plugin/Traits.pm
+++ b/lib/CXGN/List/Validate/Plugin/Traits.pm
@@ -12,6 +12,7 @@ sub validate {
     my $self = shift;
     my $schema = shift;
     my $list = shift;
+    my $validator = shift;
     my @missing;
 
 #    print STDERR "LIST: ".Data::Dumper::Dumper($list);
@@ -43,7 +44,7 @@ sub validate {
                 'dbxref.db_id' => $db->db_id(),
                 'dbxref.accession' => $accession,
             };
-            if ( $db_name eq 'COMP' ) {
+            if ( $db_name eq 'COMP' && $validator->{composable_validation_check_name} ) {
                 $query->{'me.name'} = $trait_name;
             }
             my $rs = $schema->resultset("Cv::Cvterm")->search($query, {'join' => 'dbxref'});

--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -192,6 +192,12 @@ has 'unique_trait_stock_timestamp' => (
     is => 'rw',
 );
 
+has 'composable_validation_check_name' => (
+    isa => "Bool",
+    is => 'rw',
+    default => 0
+);
+
 #build is used for creating hash lookups in this case
 sub create_hash_lookups {
     my $self = shift;
@@ -268,7 +274,9 @@ sub verify {
     # print STDERR Dumper \@plot_list;
     # print STDERR Dumper \%plot_trait_value;
     my $plot_validator = CXGN::List::Validate->new();
-    my $trait_validator = CXGN::List::Validate->new();
+    my $trait_validator = CXGN::List::Validate->new(
+        composable_validation_check_name => $self->{composable_validation_check_name}
+    );
     my @plots_missing = @{$plot_validator->validate($schema,'plots_or_subplots_or_plants_or_tissue_samples_or_analysis_instances',\@plot_list)->{'missing'}};
     my @traits_missing = @{$trait_validator->validate($schema,'traits',\@trait_list)->{'missing'}};
     my $error_message = '';

--- a/lib/SGN/Controller/AJAX/DeriveTrait.pm
+++ b/lib/SGN/Controller/AJAX/DeriveTrait.pm
@@ -297,6 +297,7 @@ project.project_id=? ) );");
         has_timestamps=>1,
         overwrite_values=>0,
         metadata_hash=>\%phenotype_metadata,
+				composable_validation_check_name=>$c->config->{composable_validation_check_name}
     );
 
     my ($store_error, $store_success) = $store_phenotypes->store();
@@ -424,6 +425,7 @@ sub store_generated_plot_phenotypes : Path('/ajax/breeders/trial/store_generated
             has_timestamps=>0,
             overwrite_values=>$overwrite,
             metadata_hash=>\%phenotype_metadata,
+						composable_validation_check_name=>$c->config->{composable_validation_check_name}
         );
         my ($store_error, $store_success) = $store_phenotypes->store();
         if ($store_error) {

--- a/lib/SGN/Controller/AJAX/DroneImagery/DroneImagery.pm
+++ b/lib/SGN/Controller/AJAX/DroneImagery/DroneImagery.pm
@@ -10784,7 +10784,8 @@ sub _perform_phenotype_calculation {
                 trait_list=>\@traits_seen,
                 values_hash=>\%zonal_stat_phenotype_data,
                 has_timestamps=>1,
-                metadata_hash=>\%phenotype_metadata
+                metadata_hash=>\%phenotype_metadata,
+                composable_validation_check_name=>$c->config->{composable_validation_check_name}
             };
 
             if ($overwrite_phenotype_values) {
@@ -12186,7 +12187,8 @@ sub _perform_keras_cnn_predict {
             has_timestamps=>1,
             metadata_hash=>\%phenotype_metadata,
             ignore_new_values=>undef,
-            overwrite_values=>1
+            overwrite_values=>1,
+            composable_validation_check_name=>$c->config->{composable_validation_check_name}
         });
         my ($verified_warning, $verified_error) = $store_phenotypes->verify();
         my ($stored_phenotype_error, $stored_phenotype_success) = $store_phenotypes->store();
@@ -12700,7 +12702,8 @@ sub _perform_autoencoder_keras_cnn_vi {
             has_timestamps=>1,
             metadata_hash=>\%phenotype_metadata,
             overwrite_values=>1,
-            #ignore_new_values=>1
+            #ignore_new_values=>1,
+            composable_validation_check_name=>$c->config->{composable_validation_check_name}
         };
 
         my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(

--- a/lib/SGN/Controller/AJAX/HighDimensionalPhenotypes.pm
+++ b/lib/SGN/Controller/AJAX/HighDimensionalPhenotypes.pm
@@ -228,7 +228,8 @@ sub high_dimensional_phenotypes_nirs_upload_verify_POST : Args(0) {
         trait_list=>[],
         values_hash=>\%parsed_data_agg,
         has_timestamps=>0,
-        metadata_hash=>\%phenotype_metadata
+        metadata_hash=>\%phenotype_metadata,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     });
 
     my $warning_status;
@@ -511,7 +512,8 @@ sub high_dimensional_phenotypes_nirs_upload_store_POST : Args(0) {
         trait_list=>[],
         values_hash=>\%parsed_data_agg_coalesced,
         has_timestamps=>0,
-        metadata_hash=>\%phenotype_metadata
+        metadata_hash=>\%phenotype_metadata,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     });
 
     my $warning_status;
@@ -701,7 +703,8 @@ sub high_dimensional_phenotypes_transcriptomics_upload_verify_POST : Args(0) {
         trait_list=>[],
         values_hash=>\%parsed_data,
         has_timestamps=>0,
-        metadata_hash=>\%phenotype_metadata
+        metadata_hash=>\%phenotype_metadata,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     });
 
     my $warning_status;
@@ -911,8 +914,8 @@ sub high_dimensional_phenotypes_transcriptomics_upload_store_POST : Args(0) {
         trait_list=>[],
         values_hash=>\%parsed_data_agg_coalesced,
         has_timestamps=>0,
-        metadata_hash=>\%phenotype_metadata
-
+        metadata_hash=>\%phenotype_metadata,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     });
 
     my $warning_status;
@@ -1131,7 +1134,8 @@ sub high_dimensional_phenotypes_metabolomics_upload_verify_POST : Args(0) {
         trait_list=>[],
         values_hash=>\%parsed_data,
         has_timestamps=>0,
-        metadata_hash=>\%phenotype_metadata
+        metadata_hash=>\%phenotype_metadata,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     });
 
     my $warning_status;
@@ -1399,7 +1403,8 @@ sub high_dimensional_phenotypes_metabolomics_upload_store_POST : Args(0) {
         trait_list=>[],
         values_hash=>\%parsed_data_agg,
         has_timestamps=>0,
-        metadata_hash=>\%phenotype_metadata
+        metadata_hash=>\%phenotype_metadata,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     });
 
     my $warning_status;

--- a/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
+++ b/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
@@ -78,6 +78,7 @@ sub upload_phenotype_verify_POST : Args(1) {
         has_timestamps=>$timestamp,
         metadata_hash=>$phenotype_metadata,
         image_zipfile_path=>$image_zip,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     );
 
     my $warning_status;
@@ -137,6 +138,7 @@ sub upload_phenotype_store_POST : Args(1) {
         overwrite_values=>$overwrite,
         metadata_hash=>$phenotype_metadata,
         image_zipfile_path=>$image_zip,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     );
 
     #upload_phenotype_store function redoes the same verification that upload_phenotype_verify does before actually uploading. maybe this should be commented out.
@@ -418,6 +420,7 @@ sub update_plot_phenotype_POST : Args(0) {
       has_timestamps=> 1,
       overwrite_values=> 1,
       metadata_hash=>\%phenotype_metadata,
+      composable_validation_check_name=>$c->config->{composable_validation_check_name}
   );
 
   my ($verified_warning, $verified_error) = $store_phenotypes->verify();

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -4611,6 +4611,7 @@ sub trial_calculate_numerical_derivative : Chained('trial') PathPart('calculate_
         overwrite_values=>1,
         ignore_new_values=>0,
         metadata_hash=>\%phenotype_metadata,
+        composable_validation_check_name=>$c->config->{composable_validation_check_name}
     );
     my ($verified_warning, $verified_error) = $store_phenotypes->verify();
     my ($stored_phenotype_error, $stored_Phenotype_success) = $store_phenotypes->store();

--- a/sgn.conf
+++ b/sgn.conf
@@ -24,6 +24,7 @@ composable_tod_root_cvterm "time of day|TIME:0000001"
 composable_toy_root_cvterm "time of year|TIME:0000005"
 composable_gen_root_cvterm "generation|TIME:0000072"
 composable_evt_root_cvterm "event|TIME:0000477"
+composable_validation_check_name 0
 allow_observation_variable_submission_interface 0
 trait_ontology_db_name SP
 # For displaying ontologies in Ontology Browser

--- a/t/unit_fixture/CXGN/Trial.t
+++ b/t/unit_fixture/CXGN/Trial.t
@@ -581,6 +581,7 @@ my $lp = CXGN::Phenotypes::StorePhenotypes->new(
     has_timestamps=>0,
     overwrite_values=>0,
     metadata_hash=>\%metadata,
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 );
 
 $lp->store();
@@ -755,6 +756,7 @@ my $lp = CXGN::Phenotypes::StorePhenotypes->new({
     has_timestamps=>0,
     overwrite_values=>0,
     metadata_hash=>\%metadata,
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 });
 $lp->store();
 

--- a/t/unit_fixture/CXGN/Trial/DeriveTrait.t
+++ b/t/unit_fixture/CXGN/Trial/DeriveTrait.t
@@ -145,7 +145,8 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     values_hash=>$parsed_data,
     has_timestamps=>1,
     overwrite_values=>0,
-    metadata_hash=>\%phenotype_metadata
+    metadata_hash=>\%phenotype_metadata,
+    composable_validation_check_name=>$fix->config->{composable_validation_check_name}
 );
 
 my ($stored_phenotype_error_msg, $stored_phenotype_success) = $store_phenotypes->store();
@@ -203,7 +204,8 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     values_hash=>$store_hash,
     has_timestamps=>0,
     overwrite_values=>1,
-    metadata_hash=>\%phenotype_metadata
+    metadata_hash=>\%phenotype_metadata,
+    composable_validation_check_name=>$fix->config->{composable_validation_check_name}
 );
 
 my ($store_error, $store_success) = $store_phenotypes->store();

--- a/t/unit_fixture/CXGN/Uploading/Phenotype.t
+++ b/t/unit_fixture/CXGN/Uploading/Phenotype.t
@@ -138,7 +138,8 @@ for my $extension ("xls", "xlsx") {
 		values_hash=>\%parsed_data,
 		has_timestamps=>1,
 		overwrite_values=>0,
-		metadata_hash=>\%phenotype_metadata
+		metadata_hash=>\%phenotype_metadata,
+		composable_validation_check_name=>$f->config->{composable_validation_check_name}
 	);
 	my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 	ok(!$verified_error);
@@ -268,7 +269,8 @@ for my $extension ("xls", "xlsx") {
 		values_hash=>\%parsed_data,
 		has_timestamps=>0,
 		overwrite_values=>0,
-		metadata_hash=>\%phenotype_metadata
+		metadata_hash=>\%phenotype_metadata,
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 	);
 	my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 	#print STDERR Dumper $verified_error;
@@ -437,6 +439,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     overwrite_values=>0,
     metadata_hash=>\%phenotype_metadata,
     image_zipfile_path=>'t/data/fieldbook/photos.zip',
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 );
 my $validate_phenotype_error_msg = $store_phenotypes->verify();
 #print STDERR Dumper $validate_phenotype_error_msg;
@@ -896,6 +899,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     has_timestamps=>0,
     overwrite_values=>0,
     metadata_hash=>\%phenotype_metadata,
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 print STDERR Dumper $verified_error;
@@ -1592,6 +1596,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     has_timestamps=>0,
     overwrite_values=>0,
     metadata_hash=>\%phenotype_metadata,
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 ok(!$verified_error);
@@ -2193,6 +2198,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     has_timestamps=>0,
     overwrite_values=>0,
     metadata_hash=>\%phenotype_metadata,
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 ok(!$verified_error);
@@ -2517,6 +2523,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     has_timestamps=>1,
     overwrite_values=>0,
     metadata_hash=>\%phenotype_metadata,
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 ok(!$verified_error);
@@ -5596,6 +5603,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     has_timestamps=>1,
     overwrite_values=>1,
     metadata_hash=>\%phenotype_metadata,
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 ok(!$verified_error);
@@ -5685,6 +5693,7 @@ my $store_phenotypes = CXGN::Phenotypes::StorePhenotypes->new(
     has_timestamps=>1,
     overwrite_values=>1,
     metadata_hash=>\%phenotype_metadata,
+    composable_validation_check_name=>$f->config->{composable_validation_check_name}
 );
 my ($verified_warning, $verified_error) = $store_phenotypes->verify();
 ok(!$verified_error);

--- a/t/unit_fixture/CXGN/Uploading/ValidateNIRS.t
+++ b/t/unit_fixture/CXGN/Uploading/ValidateNIRS.t
@@ -73,6 +73,7 @@ for my $extension ("xls", "xlsx") {
         has_timestamps             => 0,
         overwrite_values           => 0,
         metadata_hash              => \%phenotype_metadata,
+        composable_validation_check_name => $f->config->{composable_validation_check_name}
     );
     my ($verified_warning, $verified_error) = $store_phenotypes->verify();
     ok(!$verified_error);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

### The Problem

When uploading trait observations, the column header uses the format of `trait_name|trait_id` (such as `Grain yield - kg/ha|CO_321:0001218`).  The trait validation just checks to make sure the DB and Accession (`CO_321:0001218`) are valid and ignores the trait name (this allows users to use different trait names, such as just `yield|CO_321:0001218`).

This isn't a problem for traits in the official trait ontology, since all of the traits share the same DB and Accession for all of the instances using the same crop trait ontology.

However, problems can arise for the composed traits.  If we add the same composed trait to two different databases, they will most likely have a different accession in each database (`COMP:0000043` = `Canopy Cover - UASHub - %|day 101` on DB 1 and `Canopy NDVI - UASHub - index|day 300` on DB 2).  If the user doesn't know the COMP Accessions are different in the different databases, the observation upload will be successful, but the data will be associated with a different trait.

### The Fix

This adds an additional check to the trait validation.  If the trait is in the COMP trait ontology, the validator will also check to make sure the trait name matches the name in the database.   All other traits still don't need to have their names match.

The error message displayed in the observation upload will include any matching traits (by trait name) that are potential replacements for missing traits (that don't have a valid ID for regular traits or matching trait name and ID for COMP traits).

![image](https://user-images.githubusercontent.com/7526014/226637212-deff147d-4c45-4c5c-ba70-a1922e5dd5f4.png)

### Configuration

By default, the trait validation will not include the additional name check.  To enable the name check for composable traits, set the `composable_validation_check_name` key to `1` in the `sgn_local.conf` file.

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
