### PR TITLE
Change default trait_phenotypes retrieval search type to Native

### DIFF
--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -323,7 +323,7 @@ sub trait_phenotypes : Chained('trial') PathPart('trait_phenotypes') Args(0) {
     my $trait = $c->req->param('trait');
     my $phenotypes_search = CXGN::Phenotypes::PhenotypeMatrix->new(
         bcs_schema=> $schema,
-        search_type => "MaterializedViewTable",
+        search_type => "Native",
         data_level => $display,
         trait_list=> [$trait],
         trial_list => [$c->stash->{trial_id}]


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes problem where uploaded or computed phenotypes are not visible in the trial detail page histogram until matviews refresh.

<!-- If there are relevant issues, link them here: -->
closes #4349

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
