### PR TITLE
Fix accession phenotype download

### DIFF
--- a/lib/CXGN/BreedersToolbox/Projects.pm
+++ b/lib/CXGN/BreedersToolbox/Projects.pm
@@ -710,6 +710,14 @@ sub get_related_treatments {
     my $trial_ids = shift;
     my $relevant_obsunits = shift;
 
+    if (ref($trial_ids) && @$trial_ids == 0) {
+	return {
+	    treatment_names => [],
+	    treatment_details => {},
+	};
+
+	
+    }
     my $trial_treatment_relationship_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->schema, 'trial_treatment_relationship', 'project_relationship')->cvterm_id();
 
     my $q = "SELECT treatment.name, nds.stock_id

--- a/lib/CXGN/Phenotypes/Search/Native.pm
+++ b/lib/CXGN/Phenotypes/Search/Native.pm
@@ -194,7 +194,9 @@ sub search {
     my %design_layout_hash;
     my $using_layout_hash;
     #For performance reasons the number of joins to stock can be reduced if a trial is given. If trial(s) given, use the cached layout from TrialLayout instead.
+
     if ($self->trial_list && scalar(@{$self->trial_list})>0) {
+
         $using_layout_hash = 1;
         foreach (@{$self->trial_list}){
             my $trial_layout = CXGN::Trial::TrialLayout->new({schema => $schema, trial_id => $_, experiment_type=>$self->experiment_type()});
@@ -397,7 +399,7 @@ sub search {
 
     my  $q = $select_clause . $from_clause . $where_clause . $group_by . $order_clause . $limit_clause . $offset_clause;
 
-    print STDERR "QUERY: $q\n\n";
+    #print STDERR "QUERY: $q\n\n";
 
     my $location_rs = $schema->resultset('NaturalDiversity::NdGeolocation')->search();
     my %location_id_lookup;

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -183,7 +183,7 @@ sub breeder_download : Path('/breeders/download/') Args(0) {
 
 sub _parse_list_from_json {
     my $list_json = shift;
-    #print STDERR Dumper $list_json;
+#    print STDERR "LIST JSON: ". Dumper $list_json;
     my $json = new JSON;
     if ($list_json) {
        # my $decoded_list = $json->allow_nonref->relaxed->escape_slash->loose->allow_singlequote->allow_barekey->decode($list_json);
@@ -236,23 +236,50 @@ sub download_phenotypes_action : Path('/breeders/trials/phenotype/download') Arg
     my $phenotype_max_value = $c->req->param("phenotype_max_value") && $c->req->param("phenotype_max_value") ne 'null' ? $c->req->param("phenotype_max_value") : "";
 
     my @trait_list;
-    if ($trait_list && $trait_list ne 'null') { print STDERR "trait_list: ".Dumper $trait_list."\n"; @trait_list = @{_parse_list_from_json($trait_list)}; }
+    if ($trait_list && $trait_list ne 'null') {
+	print STDERR "trait_list: ".Dumper $trait_list."\n";
+	@trait_list = @{_parse_list_from_json($trait_list)};
+    }
     my @trait_component_list;
-    if ($trait_component_list && $trait_component_list ne 'null') { print STDERR "trait_component_list: ".Dumper $trait_component_list."\n"; @trait_component_list = @{_parse_list_from_json($trait_component_list)}; }
+    if ($trait_component_list && $trait_component_list ne 'null') {
+	print STDERR "trait_component_list: ".Dumper $trait_component_list."\n";
+	@trait_component_list = @{_parse_list_from_json($trait_component_list)};
+    }
     my @trait_contains_list;
-    if ($trait_contains && $trait_contains ne 'null') { print STDERR "trait_contains: ".Dumper $trait_contains."\n"; @trait_contains_list = @{_parse_list_from_json($trait_contains)}; }
+    if ($trait_contains && $trait_contains ne 'null') {
+	print STDERR "trait_contains: ".Dumper $trait_contains."\n";
+	@trait_contains_list = @{_parse_list_from_json($trait_contains)};
+    }
     my @year_list;
-    if ($year_list && $year_list ne 'null') { print STDERR "year list: ".Dumper $year_list."\n"; @year_list = @{_parse_list_from_json($year_list)}; }
+    if ($year_list && $year_list ne 'null') {
+	print STDERR "year list: ".Dumper $year_list."\n";
+	@year_list = @{_parse_list_from_json($year_list)};
+    }
     my @location_list;
-    if ($location_list && $location_list ne 'null') { print STDERR "location list: ".Dumper $location_list."\n"; @location_list = @{_parse_list_from_json($location_list)}; }
+    if ($location_list && $location_list ne 'null') {
+	print STDERR "location list: ".Dumper $location_list."\n";
+	@location_list = @{_parse_list_from_json($location_list)};
+    }
     my @trial_list;
-    if ($trial_list && $trial_list ne 'null') { print STDERR "trial list: ".Dumper $trial_list."\n"; @trial_list = @{_parse_list_from_json($trial_list)}; }
+    if ($trial_list && $trial_list ne 'null') {
+	print STDERR "trial list: ".Dumper $trial_list."\n";
+	@trial_list = @{_parse_list_from_json($trial_list)};
+    }
     my @accession_list;
-    if ($accession_list && $accession_list ne 'null') { print STDERR "accession list: ".Dumper $accession_list."\n";@accession_list = @{_parse_list_from_json($accession_list)}; }
+    if ($accession_list && $accession_list ne 'null') {
+	print STDERR "accession list: ".Dumper $accession_list."\n";
+	@accession_list = @{_parse_list_from_json($accession_list)};
+    }
     my @plot_list;
-    if ($plot_list && $plot_list ne 'null') { print STDERR "plot list: ".Dumper $plot_list."\n"; @plot_list = @{_parse_list_from_json($plot_list)}; }
+    if ($plot_list && $plot_list ne 'null') {
+	print STDERR "plot list: ".Dumper $plot_list."\n";
+	@plot_list = @{_parse_list_from_json($plot_list)};
+    }
     my @plant_list;
-    if ($plant_list && $plant_list ne 'null') { print STDERR "plant list: ".Dumper $plant_list."\n"; @plant_list = @{_parse_list_from_json($plant_list)}; }
+    if ($plant_list && $plant_list ne 'null') {
+	print STDERR "plant list: ".Dumper $plant_list."\n";
+	@plant_list = @{_parse_list_from_json($plant_list)};
+    }
 
     #Input list arguments can be arrays of integer ids or strings; however, when fed to CXGN::Trial::Download, they must be arrayrefs of integer ids
     my @trait_list_int;

--- a/mason/stock/download_stock_phenotypes_dialog.mas
+++ b/mason/stock/download_stock_phenotypes_dialog.mas
@@ -98,6 +98,10 @@ jQuery(document).ready(function() {
     var format = jQuery("#download_stock_phenotypes_format").val();
     var timestamp = jQuery("#download_stock_phenotypes_timestamp_option").val();
     var traits = jQuery("#download_stock_phenotypes_traits_select").val();
+    if (! Array.isArray(traits) ) {
+       traits = [ traits ];
+    }
+       
     var datalevel = jQuery("#download_stock_phenotypes_level_option").val();
     var exclude_phenotype_outlier = jQuery("#download_stock_phenotypes_exclude_outliers").val();
     window.open("/breeders/trials/phenotype/download?"+stock_type+"_list="+JSON.stringify(stock_id)+"&dataLevel="+datalevel+"&format="+format+"&timestamp="+timestamp+"&trait_list="+JSON.stringify(traits)+"&exclude_phenotype_outlier="+exclude_phenotype_outlier);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
On the accession detail page, the accession phenotype download crashes. Turns out that some code in the process relies on trial ids, which are not always provided. In that case, that part of the query is ignored.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
