### PR TITLE
allow self pedigrees to be specified with an empty male parent field.

### DIFF
--- a/lib/SGN/Controller/AJAX/Pedigrees.pm
+++ b/lib/SGN/Controller/AJAX/Pedigrees.pm
@@ -261,8 +261,8 @@ sub _get_pedigrees_from_file {
                 $c->detach();
             }
         }
-        if (($female && !$male) && ($cross_type ne 'open')) {
-            $c->stash->{rest} = { error => "For $progeny on line number $line_num no male parent specified and cross_type is not open..." };
+        if (($female && !$male) && (($cross_type ne 'open') && ($cross_type ne 'self') && ($cross_type eq 'reselected') && ($cross_type eq 'sib'))) {
+            $c->stash->{rest} = { error => "For $progeny on line number $line_num no male parent specified and cross_type is not open, self, reselected or sib..." };
             $c->detach();
         }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
closes #4519 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
