### PR TITLE
Don't show login dialog on password reset page

### DIFF
--- a/mason/site/toolbar/login.mas
+++ b/mason/site/toolbar/login.mas
@@ -5,7 +5,7 @@
 <script>
 
   // Add URL paths to this array that should not have the login dialog shown
-  // when the config `require_login` is
+  // when the config `require_login` is set
   const PATHS_TO_NOT_REQUIRE_LOGIN = ["/user/reset_password_form"];
 
   function update_login_button() { 

--- a/mason/site/toolbar/login.mas
+++ b/mason/site/toolbar/login.mas
@@ -4,6 +4,9 @@
 
 <script>
 
+  // Add URL paths to this array that should not have the login dialog shown
+  // when the config `require_login` is
+  const PATHS_TO_NOT_REQUIRE_LOGIN = ["/user/reset_password_form"];
 
   function update_login_button() { 
 
@@ -16,7 +19,9 @@
           jQuery('#login_button_html_div').html(r.html);
 
           if (<% $c->config->{require_login} %> == 1 && !r.logged_in) {
-            jQuery('#site_login_dialog').modal({backdrop: 'static', keyboard: false});
+            if ( !PATHS_TO_NOT_REQUIRE_LOGIN.includes(window.location.pathname) ) {
+              jQuery('#site_login_dialog').modal({backdrop: 'static', keyboard: false});
+            }
           }
         }
       }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

When the `require_login` conf key is set, the login dialog is shown on the password reset page, preventing the user from entering their new password.

This PR stops the login dialog from being shown on the password reset page.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
