### PR TITLE
download all traits from phenotype dialog box fixed

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/HTMLSelect.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/HTMLSelect.js
@@ -26,6 +26,10 @@ function get_select_box(type, div_id, options) {
             // console.log(JSON.stringify(response.select));
             var select = jQuery("#"+options.id).attr('onChange', 'Workflow.complete(this);');
         }
+        if (options.full_dropdown) {
+            var select_collection = document.getElementById(options.id).options;
+            document.getElementById(options.id).setAttribute("size", select_collection.length);
+        }
 	},
 	error: function(response) {
 	    alert("An error occurred");

--- a/mason/stock/download_stock_phenotypes_dialog.mas
+++ b/mason/stock/download_stock_phenotypes_dialog.mas
@@ -60,20 +60,24 @@ $stock_name => undef
             </div>
 
             <div class="form-group">
-                <label class="col-sm-3 control-label">Traits:<br/><small>(Select none for all traits)</small></label>
+                <label class="col-sm-3 control-label">Traits:</label>
                 <div class="col-sm-9" >
                     <div id="download_stock_phenotypes_traits">
                     </div>
                 </div>
             </div>
+           <div class="row">
+               <div id="download_stock_phenotypes_select_all" class="btn btn-sm btn-primary" style="margin:3px">Select all traits</div>
+               <div id="download_stock_phenotypes_select_reset" class="btn btn-sm btn-default" style="margin:3px">Unselect all traits</div>
+           </div>
 </&>
         </form><br/>
 
         </div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" name="download_stock_phenotypes_cancel_button" id="download_stock_phenotypes_cancel_button" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary" name="download_stock_phenotypes_submit_button" id="download_stock_phenotypes_submit_button" title="Submit">Submit</button>
+        <button class="btn btn-default" name="download_stock_phenotypes_cancel_button" id="download_stock_phenotypes_cancel_button" data-dismiss="modal">Close</button>
+        <button class="btn btn-primary" name="download_stock_phenotypes_submit_button" id="download_stock_phenotypes_submit_button" title="Submit">Submit</button>
       </div>
     </div>
   </div>
@@ -92,6 +96,20 @@ jQuery(document).ready(function() {
     data_level_change_traits();
   });
 
+  jQuery(document).on('click', "#download_stock_phenotypes_select_all", function() {
+    var trait_collection = document.getElementById('download_stock_phenotypes_traits_select').options;
+    for (var index = 0; index < trait_collection.length; index += 1) {
+      trait_collection[index].selected = true;
+    };
+  });
+
+  jQuery(document).on('click', "#download_stock_phenotypes_select_reset", function() {
+    var trait_collection = document.getElementById('download_stock_phenotypes_traits_select').options;
+    for (var index = 0; index < trait_collection.length; index += 1) {
+      trait_collection[index].selected = false;
+    };
+  });
+
   jQuery('#download_stock_phenotypes_submit_button').click( function () {
     var stock_type = "<% $stock_type %>";
     var stock_id = ["<% $stock_id %>"];
@@ -101,7 +119,7 @@ jQuery(document).ready(function() {
     if (! Array.isArray(traits) ) {
        traits = [ traits ];
     }
-       
+
     var datalevel = jQuery("#download_stock_phenotypes_level_option").val();
     var exclude_phenotype_outlier = jQuery("#download_stock_phenotypes_exclude_outliers").val();
     window.open("/breeders/trials/phenotype/download?"+stock_type+"_list="+JSON.stringify(stock_id)+"&dataLevel="+datalevel+"&format="+format+"&timestamp="+timestamp+"&trait_list="+JSON.stringify(traits)+"&exclude_phenotype_outlier="+exclude_phenotype_outlier);
@@ -111,6 +129,6 @@ jQuery(document).ready(function() {
 
 function data_level_change_traits() {
     var stock_type = "<% $stock_type %>";
-    get_select_box('traits', 'download_stock_phenotypes_traits', { 'name' : 'download_stock_phenotypes_traits_select', 'id' : 'download_stock_phenotypes_traits_select', 'stock_id':<% $stock_id %>, 'stock_type': stock_type });
+    get_select_box('traits', 'download_stock_phenotypes_traits', { 'name' : 'download_stock_phenotypes_traits_select', 'id' : 'download_stock_phenotypes_traits_select', 'stock_id':<% $stock_id %>, 'stock_type': stock_type , 'multiple': true});
 }
 </script>

--- a/mason/stock/download_stock_phenotypes_dialog.mas
+++ b/mason/stock/download_stock_phenotypes_dialog.mas
@@ -83,8 +83,8 @@ $stock_name => undef
         </div>
       </div>
       <div class="modal-footer">
-        <button class="btn btn-default" name="download_stock_phenotypes_cancel_button" id="download_stock_phenotypes_cancel_button" data-dismiss="modal">Close</button>
-        <button class="btn btn-primary" name="download_stock_phenotypes_submit_button" id="download_stock_phenotypes_submit_button" title="Submit">Submit</button>
+        <button type="button" class="btn btn-default" name="download_stock_phenotypes_cancel_button" id="download_stock_phenotypes_cancel_button" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary" name="download_stock_phenotypes_submit_button" id="download_stock_phenotypes_submit_button" title="Submit">Submit</button>
       </div>
     </div>
   </div>

--- a/mason/stock/download_stock_phenotypes_dialog.mas
+++ b/mason/stock/download_stock_phenotypes_dialog.mas
@@ -70,6 +70,13 @@ $stock_name => undef
                <div id="download_stock_phenotypes_select_all" class="btn btn-sm btn-primary" style="margin:3px">Select all traits</div>
                <div id="download_stock_phenotypes_select_reset" class="btn btn-sm btn-default" style="margin:3px">Unselect all traits</div>
            </div>
+
+            <style>
+              #download_stock_phenotypes_traits_select:hover {
+                width:auto;
+                margin-left: -140px;
+              }
+            </style>
 </&>
         </form><br/>
 
@@ -129,6 +136,15 @@ jQuery(document).ready(function() {
 
 function data_level_change_traits() {
     var stock_type = "<% $stock_type %>";
-    get_select_box('traits', 'download_stock_phenotypes_traits', { 'name' : 'download_stock_phenotypes_traits_select', 'id' : 'download_stock_phenotypes_traits_select', 'stock_id':<% $stock_id %>, 'stock_type': stock_type , 'multiple': true});
+    get_select_box(
+        'traits',
+        'download_stock_phenotypes_traits',
+        { 'name' : 'download_stock_phenotypes_traits_select',
+        'id' : 'download_stock_phenotypes_traits_select',
+        'stock_id':<% $stock_id %>,
+        'stock_type': stock_type ,
+        'multiple': true,
+        'full_dropdown':true}
+        );
 }
 </script>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixed selection of all traits from the dialog box.

functionality is here:

Manage/Accessions  
-> Accession detail page   
-> Traits Assayed ( panel ) 
-> Download Phenotypes ( button ) 
-> Additional Search Options

[Screencast from 05-11-2023 08:24:33 PM.webm](https://github.com/solgenomics/sgn/assets/7416921/f74b5cc2-7a5b-4820-9355-92664a66e1a7)

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
