### PR TITLE
Pedigree Download: Helium Format

### DIFF
--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -1167,7 +1167,7 @@ sub get_descendant_hash {
  Usage:
  Desc:          get an array of pedigree rows from an array of stock ids, conatining female parent, male parent, and cross type if defined
  Ret:
- Args: $accession_ids, $format (either 'parents_only' or 'full')
+ Args: $accession_ids, $format (either 'parents_only' or 'full'), $include_descendants (when defined, the response will include children of the accessions)
  Side Effects:
  Example:
 

--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -1234,10 +1234,11 @@ sub get_pedigree_rows {
                 WHERE c.stock_id IN (included_rows.mother_id, included_rows.father_id) AND NOT cycle
                 GROUP BY 1,2,3,4,5,6,7,8,9,10
         )
-        SELECT child, mother, father, type, depth
+        SELECT child, mother, father, type
         FROM included_rows
-        GROUP BY 1,2,3,4,5
-        ORDER BY 5,1;";
+        GROUP BY 1,2,3,4
+        ORDER BY 1;";
+        # depth was removed from this query since including it was creating a lot of duplicate rows
     }
 
     my $sth = $self->schema()->storage()->dbh()->prepare($query);

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -937,7 +937,7 @@ sub download_pedigree_action : Path('/breeders/download_pedigree_action') {
       value => $dl_token,
       expires => '+1m',
     };
-
+    $c->res->header("Filename", $filename);
     $c->res->header("Content-Disposition", qq[attachment; filename="$filename"]);
 
 

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -880,9 +880,9 @@ sub download_pedigree_action : Path('/breeders/download_pedigree_action') {
         $source_description = "Pedigrees of Accessions in List: $list_name";
     }
 
-    my $ped_format = $c->req->param("ped_format");
-    my $include_descendants = $c->req->param("include_descendants");
-    my $file_format = $c->req->param("file_format");
+    my $ped_format = $c->req->param("ped_format") || "parents_only";
+    my $ped_include = $c->req->param("ped_include") || "ancestors";
+    my $file_format = $c->req->param("file_format") || ".txt";
     my $dl_token = $c->req->param("pedigree_download_token") || "no_token";
     my $dl_cookie = "download".$dl_token;
 
@@ -892,13 +892,13 @@ sub download_pedigree_action : Path('/breeders/download_pedigree_action') {
 
     # Get the pedigrees
     my $stock = CXGN::Stock->new ( schema => $schema);
-    my $pedigree_rows = $stock->get_pedigree_rows(\@accession_ids, $ped_format, defined $include_descendants);
+    my $pedigree_rows = $stock->get_pedigree_rows(\@accession_ids, $ped_format, $ped_include);
 
     # HELIUM FORMAT
     if ( $file_format eq ".helium" ) {
         print $FILE "# $source_description\n";
         print $FILE "# Pedigree Format: $ped_format\n";
-        print $FILE "# Include Descendants: " . ( defined $include_descendants ? 'true' : 'false' ) . "\n";
+        print $FILE "# Include: " . join(' and ', split(/_/, $ped_include))  . "\n";
         if (scalar(@$pedigree_rows) == 0) {
             print $FILE "# No pedigrees found for the provided source\n";
         }

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -20,6 +20,7 @@ use File::Temp 'tempfile';
 use File::Basename;
 use File::Copy;
 use URI::FromHash 'uri';
+use CXGN::List;
 use CXGN::List::Transform;
 use Excel::Writer::XLSX;
 use CXGN::Trial::Download;
@@ -854,14 +855,18 @@ sub download_pedigree_action : Path('/breeders/download_pedigree_action') {
     my $self = shift;
     my $c = shift;
     my $schema = $c->dbic_schema("Bio::Chado::Schema", "sgn_chado");
+    my $dbh = $schema->storage->dbh;
+
     my $input_format = $c->req->param("input_format") || 'list_id';
     my @accession_ids = [];
+    my $source_description;         # used as a comment in the helium output file
     if ($input_format eq 'accession_ids') {       #use accession ids supplied directly
-      my $id_string = $c->req->param("ids");
-      @accession_ids = split(',',$id_string);
+        my $id_string = $c->req->param("ids");
+        @accession_ids = split(',',$id_string);
+        $source_description = "Pedigrees of provided Accession IDs: $id_string";
     }
     elsif ($input_format eq 'list_id') {        #get accession names from list and tranform them to ids
-        my$accession_list_id = $c->req->param("pedigree_accession_list_list_select");
+        my $accession_list_id = $c->req->param("pedigree_accession_list_list_select");
         my $accession_data = SGN::Controller::AJAX::List->retrieve_list($c, $accession_list_id);
         my @accession_list = map { $_->[1] } @$accession_data;
 
@@ -869,33 +874,60 @@ sub download_pedigree_action : Path('/breeders/download_pedigree_action') {
         my $acc_t = $t->can_transform("accessions", "accession_ids");
         my $accession_id_hash = $t->transform($schema, $acc_t, \@accession_list);
         @accession_ids = @{$accession_id_hash->{transform}};
+
+        my $list = CXGN::List->new({ dbh => $dbh, list_id => $accession_list_id });
+        my $list_name = $list->name();
+        $source_description = "Pedigrees of Accessions in List: $list_name";
     }
 
     my $ped_format = $c->req->param("ped_format");
+    my $file_format = $c->req->param("file_format");
     my $dl_token = $c->req->param("pedigree_download_token") || "no_token";
     my $dl_cookie = "download".$dl_token;
-    print STDERR "Token is: $dl_token\n";
 
     my ($tempfile, $uri) = $c->tempfile(TEMPLATE => "pedigree_download_XXXXX", UNLINK=> 0);
-
     open(my $FILE, '> :encoding(UTF-8)', $tempfile) or die "Cannot open tempfile $tempfile: $!";
+    my $filename;
 
-    print $FILE "Accession\tFemale_Parent\tMale_Parent\tCross_Type\n";
-    my $pedigrees_found = 0;
+    # Get the pedigrees
     my $stock = CXGN::Stock->new ( schema => $schema);
     my $pedigree_rows = $stock->get_pedigree_rows(\@accession_ids, $ped_format);
 
-    foreach my $row (@$pedigree_rows) {
-        print $FILE $row;
-        $pedigrees_found++;
+    # HELIUM FORMAT
+    if ( $file_format eq ".helium" ) {
+        print $FILE "# $source_description\n";
+        if (scalar(@$pedigree_rows) == 0) {
+            print $FILE "# No pedigrees found for the provided source\n";
+        }
+
+        print $FILE "# heliumInput = PEDIGREE\n";
+        print $FILE "LineName\tFemaleParent\tMaleParent\n";
+        foreach my $row (@$pedigree_rows) {
+            my ($progeny, $female_parent, $male_parent, $cross_type) = split "\t", $row;
+            my $string = join ("\t", $progeny, $female_parent ? $female_parent : '', $male_parent ? $male_parent : '');
+            print $FILE "$string\n";
+        }
+
+        close $FILE;
+        $filename = "pedigree.helium";
     }
 
-    unless ($pedigrees_found > 0) {
-        print $FILE "$pedigrees_found pedigrees found in the database for the accessions searched. \n";
-    }
-    close $FILE;
+    # GENERAL TEXT FORMAT
+    else {
+        print $FILE "Accession\tFemale_Parent\tMale_Parent\tCross_Type\n";
+        my $pedigrees_found = 0;
+        foreach my $row (@$pedigree_rows) {
+            print $FILE $row;
+            $pedigrees_found++;
+        }
 
-    my $filename = "pedigree.txt";
+        unless ($pedigrees_found > 0) {
+            print $FILE "$pedigrees_found pedigrees found in the database for the accessions searched. \n";
+        }
+        close $FILE;
+
+        $filename = "pedigree.txt";
+    }
 
     $c->res->content_type("application/text");
     $c->res->cookies->{$dl_cookie} = {
@@ -912,7 +944,7 @@ sub download_pedigree_action : Path('/breeders/download_pedigree_action') {
     my $output = "";
     open(my $F, "< :encoding(UTF-8)", $tempfile) || die "Can't open file $tempfile for reading.";
     while (<$F>) {
-	$output .= $_;
+        $output .= $_;
     }
     close($F);
 

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -881,6 +881,7 @@ sub download_pedigree_action : Path('/breeders/download_pedigree_action') {
     }
 
     my $ped_format = $c->req->param("ped_format");
+    my $include_descendants = $c->req->param("include_descendants");
     my $file_format = $c->req->param("file_format");
     my $dl_token = $c->req->param("pedigree_download_token") || "no_token";
     my $dl_cookie = "download".$dl_token;
@@ -891,11 +892,13 @@ sub download_pedigree_action : Path('/breeders/download_pedigree_action') {
 
     # Get the pedigrees
     my $stock = CXGN::Stock->new ( schema => $schema);
-    my $pedigree_rows = $stock->get_pedigree_rows(\@accession_ids, $ped_format);
+    my $pedigree_rows = $stock->get_pedigree_rows(\@accession_ids, $ped_format, defined $include_descendants);
 
     # HELIUM FORMAT
     if ( $file_format eq ".helium" ) {
         print $FILE "# $source_description\n";
+        print $FILE "# Pedigree Format: $ped_format\n";
+        print $FILE "# Include Descendants: " . ( defined $include_descendants ? 'true' : 'false' ) . "\n";
         if (scalar(@$pedigree_rows) == 0) {
             print $FILE "# No pedigrees found for the provided source\n";
         }

--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -374,10 +374,10 @@ $(document).ready(function() {
     <td>
       <div style="width: 150px">
         <div class="radio">
-          <label><input type="radio" id="ped_format" name="ped_format" value="parents_only" checked>Direct parents (and descendants) only</label>
+          <label><input type="radio" id="ped_format_parents" name="ped_format" value="parents_only" checked>Direct parents (and descendants) only</label>
         </div>
         <div class="radio">
-          <label><input type="radio" id="ped_format" name="ped_format" value="full">Full pedigrees</label>
+          <label><input type="radio" id="ped_format_full" name="ped_format" value="full">Full pedigrees</label>
         </div>
         <div>
           <input type="checkbox" id="ped_descendants" name="include_descendants" value="true">
@@ -429,7 +429,24 @@ $(document).ready(function() {
                     //var token = new Date().getTime(); //use the current timestamp as the token name and value
                     //manage_dl_with_cookie(token, ladda);
                     //jQuery('#pedigree_download_token').val(token);
-                    jQuery('#download_pedigree').submit();
+                    jQuery('#working_modal').modal('show');
+                    var http = new XMLHttpRequest();
+                    http.open('POST', '/breeders/download_pedigree_action', true);
+                    http.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+                    http.onreadystatechange = () => {
+                      if( http.readyState == 4 ) {
+                        jQuery('#working_modal').modal('hide');
+                        if ( http.status == 200) {
+                          var blob = new Blob([http.response], { type : 'plain/text' });
+                          var fileName = http.getResponseHeader("FileName");
+                          var link = document.createElement('a');
+                          link.href = window.URL.createObjectURL(blob);
+                          link.download = fileName;
+                          link.click();
+                        }
+                      }
+                    }
+                    http.send(jQuery("#download_pedigree").serialize());
                  }
              });
         } });

--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -355,7 +355,7 @@ $(document).ready(function() {
       Accessions
     </th>
     <th>
-      Depth
+      Query
     </th>
     <th>
       Format
@@ -372,16 +372,20 @@ $(document).ready(function() {
       </div>
     </td>
     <td>
-      <div style="width: 150px">
+      <div style="width: 175px">
+        <p><strong>Depth:</strong></p>
         <div class="radio">
-          <label><input type="radio" id="ped_format_parents" name="ped_format" value="parents_only" checked>Direct parents (and descendants) only</label>
+          <label><input type="radio" id="ped_format_parents" name="ped_format" value="parents_only" checked>Only One Generation</label>
         </div>
         <div class="radio">
-          <label><input type="radio" id="ped_format_full" name="ped_format" value="full">Full pedigrees</label>
+          <label><input type="radio" id="ped_format_full" name="ped_format" value="full">All Generations</label>
         </div>
-        <div>
-          <input type="checkbox" id="ped_descendants" name="include_descendants" value="true">
-          <span>Include Descendants</span>
+        <p><strong>Include:</strong></p>
+        <div class="radio">
+          <label><input type="radio" id="include_ancestors" name="ped_include" value="ancestors" checked>Only Ancestors</label>
+        </div>
+        <div class="radio">
+          <label><input type="radio" id="include_ancestors_descendants" name="ped_include" value="ancestors_descendants">Ancestors and Descendants</label>
         </div>
       </div>
     </td>

--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -349,10 +349,13 @@ $(document).ready(function() {
 <form id="download_pedigree" action="/breeders/download_pedigree_action" method="POST">
 <table class="table"  cellpadding="10">
   <thead>
-  <tr><td colspan="2"><h4>Download Pedigree </h4><p>Select parameter:</p></tr>
+  <tr><td colspan="2"><h4>Download Pedigrees </h4><p>Select parameter:</p></tr>
   <tr>
     <th>
       Accessions
+    </th>
+    <th>
+      Include
     </th>
     <th>
       Format
@@ -369,13 +372,19 @@ $(document).ready(function() {
       </div>
     </td>
     <td>
- <div class="radio">
-  <label><input type="radio" id="ped_format" name="ped_format" value="parents_only" checked>Direct parents only</label>
- </div>
- <div class="radio">
-   <label><input type="radio" id="ped_format" name="ped_format" value="full">Full pedigrees</label>
- </div>
-     </td>
+      <div class="radio">
+        <label><input type="radio" id="ped_format" name="ped_format" value="parents_only" checked>Direct parents only</label>
+      </div>
+      <div class="radio">
+        <label><input type="radio" id="ped_format" name="ped_format" value="full">Full pedigrees</label>
+      </div>
+    </td>
+    <td>
+      <select class="form-control" id="pedigree_file_format" name="file_format">
+        <option value=".txt">Plain Text</option>
+        <option value=".helium">Helium Format</option>
+      </select>
+    </td>
     <td>
       <button class="btn btn-primary" type="button" id="pedigree">Download</button>
       <input type="hidden" id="pedigree_download_token" name="pedigree_download_token"/>

--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -355,7 +355,7 @@ $(document).ready(function() {
       Accessions
     </th>
     <th>
-      Include
+      Depth
     </th>
     <th>
       Format
@@ -372,11 +372,17 @@ $(document).ready(function() {
       </div>
     </td>
     <td>
-      <div class="radio">
-        <label><input type="radio" id="ped_format" name="ped_format" value="parents_only" checked>Direct parents only</label>
-      </div>
-      <div class="radio">
-        <label><input type="radio" id="ped_format" name="ped_format" value="full">Full pedigrees</label>
+      <div style="width: 150px">
+        <div class="radio">
+          <label><input type="radio" id="ped_format" name="ped_format" value="parents_only" checked>Direct parents (and descendants) only</label>
+        </div>
+        <div class="radio">
+          <label><input type="radio" id="ped_format" name="ped_format" value="full">Full pedigrees</label>
+        </div>
+        <div>
+          <input type="checkbox" id="ped_descendants" name="include_descendants" value="true">
+          <span>Include Descendants</span>
+        </div>
       </div>
     </td>
     <td>

--- a/t/unit_mech/AJAX/DownloadPedigrees.t
+++ b/t/unit_mech/AJAX/DownloadPedigrees.t
@@ -41,11 +41,11 @@ test5P002	test_accession4	test_accession5
 test5P003	test_accession4	test_accession5	
 test5P004	test_accession4	test_accession5	
 test5P005	test_accession4	test_accession5	
-test_accession4	test_accession1	test_accession2	biparental
-test_accession5	test_accession3		open
 test_accession1			
 test_accession2			
 test_accession3			
+test_accession4	test_accession1	test_accession2	biparental
+test_accession5	test_accession3		open
 ';
 
 # for identifying whitespace differences


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This modifies the Pedigree download from the "Download Using Lists" page:

- Adds a [helium](https://helium.hutton.ac.uk/#/) format for the web-based and desktop pedigree viewers (Fixes #2401)
- Adds an option to include descendants/children in the pedigree file
- Removes duplicate rows from the downloaded pedigree file (before: if an accession was found more than once in the pedigree tree, it would have a row in the file listing it and its parents for each occurrence)


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
