### PR TITLE
position html elements next to each other properly

### DIFF
--- a/mason/solgs/tools/anova/analysis.mas
+++ b/mason/solgs/tools/anova/analysis.mas
@@ -32,9 +32,10 @@ $training_pop_id   => undef,
 
   <div id="anova_canvas">
 
-    <div id="anova_select_a_trait_div" style="float:left; z-index:10; position:absolute; "></div>
-    <input  style="position:absolute;margin-left:300px;" id="run_anova" class="btn btn-success" type="button" value="Run ANOVA" />
-
+    <div>
+    <div id="anova_select_a_trait_div" style="display:inline-block;"></div>
+    <button style="display:inline-block;" id="run_anova" class="btn btn-success" type="button">Run ANOVA</button>
+  </div>
     <div id="anova_selected_trait_div" style="display:none">
 
       <input type="hidden" id="anova_selected_trait_name" value="" />

--- a/mason/solgs/tools/select_menu.mas
+++ b/mason/solgs/tools/select_menu.mas
@@ -14,13 +14,13 @@ Isaak Y Tecle (iyt2@cornell.edu)
 
 <%args>
 $analysis_type
-$wizard_link_txt =>'Create a new list or dataset',
+$wizard_link_txt => ''
 $breeder_search_params =>''
 </%args>
 <%perl>
 my $label = $analysis_type =~ s/_/ /gr;
 my $analysis_abbr = $analysis_type =~ /correlation/ ? 'corr' : $analysis_type;
-
+$wizard_link_txt = 'Create a new list or dataset' if !$wizard_link_txt;
 </%perl>
 
 <& /util/import_css.mas, paths => ['/static/css/solgs/solgs.css'] &>
@@ -28,7 +28,7 @@ my $analysis_abbr = $analysis_type =~ /correlation/ ? 'corr' : $analysis_type;
 
 <div id="select_menu">
   <div class="select_menu_block" id="<% $analysis_type %>_pops_label">
-    <label for="<% $analysis_abbr %>_pops_label">Select a <% $label %> population</label>
+    <label for="<% $analysis_abbr %>_pops_label">Select a population</label>
   </div>
   <div class="select_menu_block" id="<% $analysis_abbr %>_pops_list"></div>
   <div class="select_menu_block go_btn" id="<% $analysis_abbr %>_pop_go_btn">


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
fixes buttons positioning that was overflowing or overlapping with long list/dataset names in select menu

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
