### PR TITLE
Accession Upload: verify accessions file character encoding

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
@@ -381,7 +381,7 @@ jQuery(document).ready(function ($) {
         },
         complete: function (r) {
 	    //alert("DONE WITH UPLOAD "+r);
-	    var clean_r = r.replace('<pre>', '');
+	    var clean_r = r.replace(/^<pre[^>]*>/, '');
 	    clean_r = clean_r.replace('</pre>', '');
 	    response = JSON.parse(clean_r); //decodeURIComponent(clean_r));
             console.log(response);

--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -41,6 +41,7 @@ __PACKAGE__->config(
     default   => 'application/json',
     stash_key => 'rest',
     map       => { 'application/json' => 'JSON', 'text/html' => 'JSON'  },
+    json_options_encode => { 'utf8' => 0 }
    );
 
 sub verify_accession_list : Path('/ajax/accession_list/verify') : ActionClass('REST') { }

--- a/lib/SGN/Controller/AJAX/Accessions.pm
+++ b/lib/SGN/Controller/AJAX/Accessions.pm
@@ -40,9 +40,8 @@ BEGIN { extends 'Catalyst::Controller::REST' }
 __PACKAGE__->config(
     default   => 'application/json',
     stash_key => 'rest',
-    map       => { 'application/json' => 'JSON', 'text/html' => 'JSON'  },
-    json_options_encode => { 'utf8' => 0 }
-   );
+    map       => { 'application/json' => 'JSON' },
+);
 
 sub verify_accession_list : Path('/ajax/accession_list/verify') : ActionClass('REST') { }
 
@@ -63,7 +62,7 @@ sub verify_accession_list_POST : Args(0) {
         my $dbh = $c->dbc->dbh;
         my @user_info = CXGN::Login->new($dbh)->query_from_cookie($session_id);
         if (!$user_info[0]){
-            $c->stash->{rest} = {error=>'You must be logged in to upload this seedlot info!'};
+            $c->stash->{rest} = {error=>'You must be logged in to upload this info!'};
             $c->detach();
         }
         $user_id = $user_info[0];
@@ -72,7 +71,7 @@ sub verify_accession_list_POST : Args(0) {
         $user_name = $p->get_username;
     } else {
         if (!$c->user){
-            $c->stash->{rest} = {error=>'You must be logged in to upload this seedlot info!'};
+            $c->stash->{rest} = {error=>'You must be logged in to upload this info!'};
             $c->detach();
         }
         $user_id = $c->user()->get_object()->get_sp_person_id();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Accession Upload:

unicode characters (such as accented letters) were not being properly returned from the `verify_accessions_file` endpoint.

This prevents the JSON serializer from re-encoding text that is already utf-8 encoded


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
