### PR TITLE
Allow SSR genotyping data with less number of markers to be included in previously stored protocol

### DIFF
--- a/lib/CXGN/Genotype/ParseUpload/Plugin/SSRExcel.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/SSRExcel.pm
@@ -89,7 +89,7 @@ sub _validate_with_plugin {
             if ($worksheet->get_cell($row,$column)) {
                 my $ssr_data = $worksheet->get_cell($row,$column)->value();
                 $ssr_data =~ s/^\s+|\s+$//g;
-                if (($ssr_data ne '0') && ($ssr_data ne '1')) {
+                if (($ssr_data ne '0') && ($ssr_data ne '1') && ($ssr_data ne '?')) {
                     push @error_messages, "Row:$row_name Column:$column_name data missing or incorrect data type";
                 }
             }

--- a/lib/CXGN/Genotype/StoreVCFGenotypes.pm
+++ b/lib/CXGN/Genotype/StoreVCFGenotypes.pm
@@ -697,18 +697,16 @@ sub validate {
     if ($genotyping_data_type eq 'ssr') {
         my @stock_keys = keys %{$genotype_info};
         my @marker_keys = sort keys %{$genotype_info->{$stock_keys[0]}};
-#        print STDERR "MARKER KEYS =".Dumper(\@marker_keys)."\n";
 
         my $protocol_marker_names = $protocol_info->{'marker_names'};
         my @protocol_marker_array =  sort @$protocol_marker_names;
-#        print STDERR "PROTOCOL MARKER ARRAY =".Dumper(\@protocol_marker_array)."\n";
 
-        my @diff_markers = array_diff(@marker_keys, @protocol_marker_array);
-        print STDERR "DIFF MARKERS =".Dumper(\@diff_markers)."\n";
+        my %stored_marker_hash = map {$_=>1} @protocol_marker_array;
+        my @not_stored_markers = grep {!exists $stored_marker_hash{$_}} @marker_keys;
 
-        if (scalar(@diff_markers) > 0) {
-            my $mismatch_markers = join(",", @diff_markers);
-            push @error_messages, "Markers in SSR genotyping data and the selected protocol are not the same. Mismatch markers: $mismatch_markers";
+        if (scalar(@not_stored_markers) > 0) {
+            my $missing_markers = join(",", @not_stored_markers);
+            push @error_messages, "Error: some markers in SSR genotyping data are not in the selected protocol. Missing markers: $missing_markers";
         }
     }
 

--- a/lib/SGN/Controller/AJAX/Search/Genotype.pm
+++ b/lib/SGN/Controller/AJAX/Search/Genotype.pm
@@ -169,7 +169,6 @@ sub pcr_genotyping_data_search_GET : Args(0) {
         foreach my $marker (@marker_name_arrays) {
             my @positive_bands = ();
             my $product_sizes_ref = $marker_genotype_hash{$marker};
-
             if (!$product_sizes_ref) {
                 push @each_genotype, 'NA';
             } else {
@@ -178,6 +177,8 @@ sub pcr_genotyping_data_search_GET : Args(0) {
                     my $pcr_result = $product_sizes_hash{$product_size};
                     if ($pcr_result eq '1') {
                         push @positive_bands, $product_size;
+                    } elsif ($pcr_result eq '?') {
+                        push @positive_bands, $pcr_result;
                     }
                 }
                 if (scalar @positive_bands == 0) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
