### PR TITLE
Allowing the refresh_matviews script to be run synchronously.

### DIFF
--- a/lib/CXGN/BrAPI/v2/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v2/Germplasm.pm
@@ -801,7 +801,8 @@ sub store {
     }
 
     my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
-    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath});
+
+    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath}, 0);
 
     #retrieve saved items
     my @data = _simple_search($self,undef,$accession_list);
@@ -1017,7 +1018,7 @@ sub update {
 
     #update matviews
     my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
-    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath});
+    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath}, 0);
 
      #retrieve updated item
     my @result = _simple_search($self,[$germplasm_id]);

--- a/lib/CXGN/BreederSearch.pm
+++ b/lib/CXGN/BreederSearch.pm
@@ -340,6 +340,12 @@ sub refresh_matviews {
     my $materialized_view = shift || 'fullview'; #Can be 'fullview' or 'stockprop'
     my $refresh_type = shift || 'concurrent';
     my $basepath = shift;
+    my $async = shift;
+
+    if (!defined($async)) {
+        $async = 1;
+    }
+
     my $refresh_finished = 0;
     my $async_refresh;
 
@@ -354,14 +360,22 @@ sub refresh_matviews {
     }
     else {
         try {
+            my $refresh_command = "perl $basepath/bin/refresh_matviews.pl -H $dbhost -D $dbname -U $dbuser -P $dbpass -m $materialized_view";
+            $async_refresh = CXGN::Tools::Run->new();
             if ($refresh_type eq 'concurrent') {
-                print STDERR "Using CXGN::Tools::Run to run perl bin/refresh_matviews.pl -H $dbhost -D $dbname -U $dbuser -P $dbpass -m $materialized_view -c\n";
-                $async_refresh = CXGN::Tools::Run->new();
-                $async_refresh->run_async("perl $basepath/bin/refresh_matviews.pl -H $dbhost -D $dbname -U $dbuser -P $dbpass -m $materialized_view -c");
+                print STDERR "Using CXGN::Tools::Run to ".($async ? "asynchronously" : "synchronously")." run $refresh_command -c\n";
+                if ($async) {
+                    $async_refresh->run_async($refresh_command." -c");
+                } else {
+                    $async_refresh->run($refresh_command." -c");
+                }
             } else {
-                print STDERR "Using CXGN::Tools::Run to run perl bin/refresh_matviews.pl -H $dbhost -D $dbname -U $dbuser -P $dbpass -m $materialized_view\n";
-                $async_refresh = CXGN::Tools::Run->new();
-                $async_refresh->run_async("perl $basepath/bin/refresh_matviews.pl -H $dbhost -D $dbname -U $dbuser -P $dbpass -m $materialized_view");
+                print STDERR "Using CXGN::Tools::Run to ".($async ? "asynchronously" : "synchronously")." run $refresh_command\n";
+                if ($async) {
+                    $async_refresh->run_async($refresh_command);
+                } else {
+                    $async_refresh->run($refresh_command);
+                }
             }
 
             for (my $i = 1; $i < 10; $i++) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Allowing the refresh_matviews script to be run synchronously.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [x] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
