### PR TITLE
Added a config flag to control if the Field Book trait export file should use a trait's synonym or not

### DIFF
--- a/lib/SGN/Controller/AJAX/FieldBook.pm
+++ b/lib/SGN/Controller/AJAX/FieldBook.pm
@@ -238,7 +238,14 @@ sub create_trait_file_for_field_book_POST : Args(0) {
 
       my $cvterm = CXGN::Chado::Cvterm->new( $dbh, $trait_ids[$order] );
       my $synonym = $cvterm->get_uppercase_synonym();
-      my $name = $synonym || $trait_name; # use uppercase synonym if defined, otherwise use full trait name
+      my $name;
+      if($c->config->{fieldbook_trait_synonym}) {
+          print STDERR "synonym: $synonym, trait_name: $trait_name\n";
+          $name = $synonym || $trait_name; # use uppercase synonym if defined, otherwise use full trait name
+      } else {
+          print STDERR "trait_name: $trait_name\n";
+          $name = $trait_name;
+      }
       $order++;
 
       #get trait info

--- a/sgn.conf
+++ b/sgn.conf
@@ -74,6 +74,9 @@ brapi_ou_order_plot_num 0
 
 allow_repeat_measures 0
 
+#export trait names as synonyms (1) or the original trait name (0)
+fieldbook_trait_synonym 1
+
 # Cluster backend
 backend Slurm
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Original functionality would look for any synonym of a trait that was all caps, and use that synonym in the Field Book trait file.  Added a config flag to toggle the original functionality, or just using the trait name in the file.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
