### PR TITLE
Fixing observation unit sort order

### DIFF
--- a/lib/CXGN/BrAPI/v1/Studies.pm
+++ b/lib/CXGN/BrAPI/v1/Studies.pm
@@ -661,7 +661,7 @@ sub observation_units {
             limit=>$limit,
             offset=>$offset,
 			# Order by plot_number, account for non-numeric plot numbers
-			order_by=>'NULLIF(regexp_replace(plot_number, \'\D\', \'\', \'g\'), \'\')::int',
+			order_by=>'NULLIF(regexp_replace(plot_number, \'\D\', \'\', \'g\'), \'\')::numeric',
         }
     );
     my ($data, $unique_traits) = $phenotypes_search->search();

--- a/lib/CXGN/BrAPI/v2/ObservationUnits.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationUnits.pm
@@ -95,7 +95,7 @@ sub search {
             limit=>$limit,
             offset=>$offset,
             # Order by plot_number, account for non-numeric plot numbers
-            order_by=> ($c && $c->config->{brapi_ou_order_plot_num}) ? 'NULLIF(regexp_replace(plot_number, \'\D\', \'\', \'g\'), \'\')::int' : undef,
+            order_by=> ($c && $c->config->{brapi_ou_order_plot_num}) ? 'NULLIF(regexp_replace(plot_number, \'\D\', \'\', \'g\'), \'\')::numeric' : undef,
             observation_unit_names_list=>$observation_unit_names_list,
             xref_id_list=>$reference_ids_arrayref,
             xref_source_list=>$reference_sources_arrayref


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixed a SQL bug where sorting observation units was casting the order by field to an `int`.  Changed this to cast to `numeric` as it is more inclusive 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
