### PR TITLE
fix the extension for the new(er) version of BLAST.

### DIFF
--- a/lib/Bio/BLAST2/Database.pm
+++ b/lib/Bio/BLAST2/Database.pm
@@ -17,6 +17,7 @@ use IPC::Cmd qw/ can_run /;
 
 use Carp;
 use Memoize;
+use Data::Dumper;
 
 use File::Basename;
 use File::Copy;
@@ -74,8 +75,8 @@ sub open {
         # open succeeds if all the files are there
         return $self if $self->files_are_complete;
 
-        #carp "cannot open for reading, not a complete set of files:\n",
-        #    map "  - $_\n", $self->list_files;
+        carp "cannot open for reading, not a complete set of files:\n",
+           map "  - $_\n", $self->list_files;
         return;
     }
 }
@@ -361,7 +362,7 @@ sub files_are_complete {
   #assemble list of necessary extensions
   my @necessary_extensions = (qw/sq hr in/, #base database files
 			      #add seqid indexes if called for
-			      $self->indexed_seqs ? qw/sd si/ : (),
+			      $self->indexed_seqs ? qw/tf to/ : (),
 			     );
 
   #add protein/nucleotide prefix to extensions
@@ -406,8 +407,8 @@ sub _list_files {
   my ($ffbn,$type) = @_;
 
   #file extensions for each type of blast database
-  my %valid_extensions = ( protein     => [qw/.psq .phr .pin .psd .psi .pal .pnd .pni/],
-			   nucleotide  => [qw/.nsq .nhr .nin .nsd .nsi .nal .nnd .nni/],
+  my %valid_extensions = ( protein     => [qw/.psq .phr .pin .pog .pos .pot .ptf .pto .pdb /],
+			   nucleotide  => [qw/.nsq .nhr .nin .nog .nos .not .ntf .nto .ndb /],
 			 );
 
   #file extensions for _this_ database
@@ -438,7 +439,7 @@ sub get_sequence {
         unless $self->files_are_complete;
 
     croak "cannot call get_sequence on a database that has not been indexed for retrieval!"
-        unless $self->indexed_seqs;
+	unless $self->indexed_seqs;
 
     return Bio::BLAST2::Database::Seq->new(
         -bdb => $self,
@@ -477,8 +478,9 @@ sub _read_blastdbcmd_info {
                       )x
                           or die "could not parse output of blastdbcmd (2):\n$blastdbcmd";
 
-
-    my $indexed = (any {/sd$/} @files) && (any {/si$/} @files);
+    print STDERR "FILES = ".Dumper(\@files);
+    
+    my $indexed = (any {/tf$/} @files) && (any {/to$/} @files);
 
     ### set our data
     $self->type( $self->_guess_type )

--- a/lib/Bio/BLAST2/Database/Seq.pm
+++ b/lib/Bio/BLAST2/Database/Seq.pm
@@ -48,6 +48,7 @@ sub seq {
 
     return $self->whole_seq->seq;
 }
+
 sub length {
     my $self = shift;
     croak ref($self)." objects are immutable, cannot set length" if @_;
@@ -59,9 +60,14 @@ sub length {
 sub whole_seq {
     my ( $self ) = @_;
 
+    print STDERR "RETRIEVE SEQUENCE USING whole_seq().\n";
+    
     return $self->{seq_obj} ||= do {
         my $ffbn    = $self->_bdb->full_file_basename;
         my $seqname = $self->id;
+
+	print STDERR "DATABASE $ffbn. SEQNAME: $seqname\n";
+	
         CORE::open my $fc, "blastdbcmd -db '$ffbn' -entry '$seqname' 2>&1 |";
 
         # we can't know how big this sequence is.  blastdbcmd has no way (or
@@ -83,6 +89,9 @@ sub trunc {
 
     my $ffbn    = $self->_bdb->full_file_basename;
     my $seqname = $self->id;
+
+    print STDERR "DATABASE $ffbn. SEQNAME: $seqname\n";
+    
     open my $fc, "blastdbcmd -db '$ffbn' -entry '$seqname' -range $start-$end 2>&1 |";
 
     return $length > 4_000_000


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

The BLAST code checks extensions of BLAST databases, some of which are remnants of the BLAST 1 code. BLAST 2 has different extensions which interfered with the retrieval of sequences from the BLAST databases.

Note that all BLAST databases need to be re-indexed with makeblastdb to continue working!

makeblastdb example:
```
makeblastdb -in Nitabv6-assembly_Chrs+Ch0.fa -dbtype nucl -parse_seqids
```
(-parse_seqids is important for sequence retrieval with blastdbcmd)

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
