### PR TITLE
do not show users on manage users that have been censored

### DIFF
--- a/lib/CXGN/People/Roles.pm
+++ b/lib/CXGN/People/Roles.pm
@@ -82,17 +82,20 @@ sub get_breeding_program_roles {
 	my $ascii_chars = shift;
 	my $dbh = $self->bcs_schema->storage->dbh;
 	my @breeding_program_roles;
-	my $q="SELECT username, sp_person_id, name FROM sgn_people.sp_person_roles JOIN sgn_people.sp_person using(sp_person_id) JOIN sgn_people.sp_roles using(sp_role_id)";
+	my $q="SELECT username, sp_person_id, name, censor FROM sgn_people.sp_person
+	JOIN sgn_people.sp_person_roles using(sp_person_id) 
+	JOIN sgn_people.sp_roles using(sp_role_id) 
+	where  disabled IS NULL and sp_person.censor = 0";
 	my $sth = $dbh->prepare($q);
 	$sth->execute();
-	while (my ($username, $sp_person_id, $sp_role) = $sth->fetchrow_array ) {
+	while (my ($username, $sp_person_id, $sp_role, $censor) = $sth->fetchrow_array ) {
 	    if ($ascii_chars) {
 		$username = unidecode($username);
 	    }
-		push(@breeding_program_roles, [$username, $sp_person_id, $sp_role] );
+		push(@breeding_program_roles, [$username, $sp_person_id, $sp_role, $censor] );
 	}
 
-	#print STDERR Dumper \@breeding_program_roles;
+	print STDERR Dumper \@breeding_program_roles;
 	return \@breeding_program_roles;
 }
 
@@ -111,7 +114,7 @@ sub get_sp_persons {
 	my $self = shift;
 	my $dbh = $self->bcs_schema->storage->dbh;
 	my @sp_persons;
-	my $q="SELECT username, sp_person_id FROM sgn_people.sp_person ORDER BY username ASC;";
+	my $q="SELECT username, sp_person_id FROM sgn_people.sp_person WHERE disabled IS NULL and censor = 0 ORDER BY username ASC;";
 	my $sth = $dbh->prepare($q);
 	$sth->execute();
 	while (my ($username, $sp_person_id) = $sth->fetchrow_array ) {

--- a/lib/SGN/Controller/AJAX/People.pm
+++ b/lib/SGN/Controller/AJAX/People.pm
@@ -54,7 +54,7 @@ sub autocomplete_GET :Args(1) {
     $person =~ s/(^\s+|\s+)$//g;
     $person =~ s/\s+/ /g;
     my $q = "SELECT sp_person_id, first_name, last_name FROM sgn_people.sp_person
-             WHERE lower(first_name) like ? OR lower(last_name) like ?
+             WHERE lower(first_name) like ? OR lower(last_name) like ? and censor =0 and disable IS NULL
              LIMIT 20";
 
     my $sth = $c->dbc->dbh->prepare($q);
@@ -130,7 +130,7 @@ sub list_roles :Chained('roles') PathPart('list') Args(0) {
     }
     
     my $rs2 = $schema->resultset("SpPerson")->search(
-	{ },
+	{ censor => 0, disabled => undef },
 	{ join => 'sp_person_roles',
 	  '+select' => ['sp_person_roles.sp_role_id', 'sp_person_roles.sp_person_role_id' ],
 	  '+as'     => ['sp_role_id', 'sp_person_role_id' ],


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
if users have disabled='t' or censor=1 they should not be shown in the manage user page or the user search



<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
