### PR TITLE
Download Spatial Layout: fix offset plot positioning

### DIFF
--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -1196,7 +1196,7 @@ jQuery(document).ready( function() {
     for (let i = FieldMap.meta_data.min_col; i <= FieldMap.meta_data.max_col; i++) {
         cols_csv_header.push(i);
     }
-    let csv = '\n';
+    let csv = '';
     csv += ['Rows/Columns',cols_csv_header];
     csv += "\n";
     // if (FieldMap.meta_data.top_border_selection) {
@@ -1207,12 +1207,10 @@ jQuery(document).ready( function() {
     let col = "positionCoordinateX";
     let temp_plot_arr = [...FieldMap.plot_arr];
     for (let plot of temp_plot_arr.filter(plot => plot.type != "border")) {
-        if (!coord_matrix[plot.observationUnitPosition[row] - 1]) {
-            coord_matrix[plot.observationUnitPosition[row] - 1] = [];
-            coord_matrix[plot.observationUnitPosition[row] - 1][plot.observationUnitPosition[col] - 1] = plot.germplasmName;
-        } else {
-            coord_matrix[plot.observationUnitPosition[row] - 1][plot.observationUnitPosition[col] - 1] = plot.germplasmName;
+        if (!coord_matrix[plot.observationUnitPosition[row] - FieldMap.meta_data.min_row]) {
+            coord_matrix[plot.observationUnitPosition[row] - FieldMap.meta_data.min_row] = [];
         }
+        coord_matrix[plot.observationUnitPosition[row]-FieldMap.meta_data.min_row][plot.observationUnitPosition[col]-FieldMap.meta_data.min_col] = plot.germplasmName;
     }
     if (!FieldMap.meta_data.invert_row_checkmark) {
         coord_matrix.reverse();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes the "Download Spatial Layout" function on the Field Layout section of the Trial Detail page for trials that have offset plot positions (that do not start at row/col position 1/1).

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
