### PR TITLE
Seedlot Upload: check if name already exists as any stock

### DIFF
--- a/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotHarvestedXLS.pm
+++ b/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotHarvestedXLS.pm
@@ -197,15 +197,16 @@ sub _validate_with_plugin {
         $errors{'missing_crosses'} = \@crosses_missing;
     }
 
-    # Not checking if seedlot name already exists because the database will just update the seedlot entries
-    # my @seedlots = keys %seen_seedlot_names;
-    # my $rs = $schema->resultset("Stock::Stock")->search({
-    #     'is_obsolete' => { '!=' => 't' },
-    #     'uniquename' => { -in => \@seedlots }
-    # });
-    # while (my $r=$rs->next){
-    #     push @error_messages, "Cell A".$seen_seedlot_names{$r->uniquename}.": seedlot name already exists in database: ".$r->uniquename;
-    # }
+    # Check if Seedlot names already exist as other stock names
+    my @seedlots = keys %seen_seedlot_names;
+    my $rs = $schema->resultset("Stock::Stock")->search({
+        'uniquename' => { -in => \@seedlots }
+    });
+    while (my $r=$rs->next) {
+        if ( $r->type->name ne 'seedlot' ) {
+            push @error_messages, "Cell A".$seen_seedlot_names{$r->uniquename}.": stock name already exists in database: ".$r->uniquename.".  The seedlot name must be unique.";
+        }
+    }
 
     #store any errors found in the parsed file to parse_errors accessor
     if (scalar(@error_messages) >= 1) {

--- a/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotXLS.pm
+++ b/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotXLS.pm
@@ -237,15 +237,17 @@ sub _validate_with_plugin {
 	push @error_messages, "The following source seedlots could not be found in the database: ".join(',',@sources_missing);
 	$errors{'missing_sources'} = \@sources_missing;
     }
-    # Not checking if seedlot name already exists because the database will just update the seedlot entries
-    # my @seedlots = keys %seen_seedlot_names;
-    # my $rs = $schema->resultset("Stock::Stock")->search({
-    #     'is_obsolete' => { '!=' => 't' },
-    #     'uniquename' => { -in => \@seedlots }
-    # });
-    # while (my $r=$rs->next){
-    #     push @error_messages, "Cell A".$seen_seedlot_names{$r->uniquename}.": seedlot name already exists in database: ".$r->uniquename;
-    # }
+
+    # Check if Seedlot names already exist as other stock names
+    my @seedlots = keys %seen_seedlot_names;
+    my $rs = $schema->resultset("Stock::Stock")->search({
+        'uniquename' => { -in => \@seedlots }
+    });
+    while (my $r=$rs->next) {
+        if ( $r->type->name ne 'seedlot' ) {
+            push @error_messages, "Cell A".$seen_seedlot_names{$r->uniquename}.": stock name already exists in database: ".$r->uniquename.".  The seedlot name must be unique.";
+        }
+    }
 
     #store any errors found in the parsed file to parse_errors accessor
     if (scalar(@error_messages) >= 1) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds a check to the seedlot upload validation that returns an error if the seedlot name already exists as a stock name (excluding existing seedlots, which would be updated).

This addresses the immediate problem in Issue #4138

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
