### PR TITLE
Label Designer Sorting: support Public Lists

### DIFF
--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -1300,8 +1300,8 @@ function addSortOrders(add_fields, data_type, data_level) {
     // Set type-specific sorting options
     let data_type_fields = [];
     // Sort by trial layout for plot-level labels...
-    if ( (data_type === 'Field Trials' || data_type === 'Lists') && data_level === 'plots' ) {
-        data_type_fields = ['Trial Layout: Plot Order']
+    if ( ['Field Trials', 'Lists', 'Public Lists'].includes(data_type) && data_level === 'plots' ) {
+        data_type_fields = ['Trial Layout: Plot Order'];
     }
 
     //load options

--- a/lib/CXGN/List.pm
+++ b/lib/CXGN/List.pm
@@ -222,7 +222,7 @@ sub exists_list {
     my $name = shift;
     my $owner = shift;
 
-    my $q = "SELECT list_id, cvterm.name FROM sgn_people.list AS list LEFT JOIN cvterm ON (type_id=cvterm_id) WHERE list.name = ? AND list.owner=?";
+    my $q = "SELECT list_id, cvterm.name FROM sgn_people.list AS list LEFT JOIN cvterm ON (type_id=cvterm_id) WHERE list.name=? AND (list.owner=? OR list.is_public=TRUE)";
     my $h = $dbh->prepare($q);
     $h->execute($name, $owner);
     my ($list_id, $list_type) = $h->fetchrow_array();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Two small fixes to support Public Lists in the label designer when sorting labels by trial layout:

- recognize the data type of 'Public Lists' in addition to 'Lists'
- in `CXGN::List`, allow the `exists_list` function to return information for public lists

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
