### PR TITLE
Phenotype Upload: additional acceptable column headers

### DIFF
--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetSimple.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetSimple.pm
@@ -22,6 +22,9 @@ use Spreadsheet::ParseXLSX;
 use JSON;
 use Data::Dumper;
 
+my @oun_columns = ("observationunit_name", "plot_name", "observationUnitName", "plotName");
+my %oun_columns_map = map { $_ => 1 } @oun_columns;
+
 sub name {
     return "phenotype spreadsheet simple";
 }
@@ -67,17 +70,18 @@ sub validate {
     my ( $row_min, $row_max ) = $worksheet->row_range();
     my ( $col_min, $col_max ) = $worksheet->col_range();
     if (($col_max - $col_min)  < 1 || ($row_max - $row_min) < 1 ) { #must have header with at least observationunit_name and one trait, as well as one row of phenotypes
-        $parse_result{'error'} = "Spreadsheet is missing observationunit_name and atleast one trait in header.";
+        $parse_result{'error'} = "Spreadsheet is missing observationunit_name and at least one trait in header.";
         print STDERR "Spreadsheet is missing header\n";
         return \%parse_result;
     }
 
-    if ($worksheet->get_cell(0,0)->value() ne 'observationunit_name' ) {
-        $parse_result{'error'} = "First column must be 'observationunit_name'. It may help to recreate your spreadsheet from the website.";
+    # check if the first column is one of the supported variations of observationunit_name
+    if ( !exists($oun_columns_map{$worksheet->get_cell(0,0)->value()}) ) {
+        $parse_result{'error'} = "First column must be one of: '" . join("', '", @oun_columns) . "'. It may help to recreate your spreadsheet from the website.";
         print STDERR "Columns not correct\n";
         return \%parse_result;
     }
-    my @fixed_columns = qw | observationunit_name |;
+    my @fixed_columns = ( $worksheet->get_cell(0,0)->value() );
     my $num_fixed_col = scalar(@fixed_columns);
 
     for (my $row=1; $row<$row_max; $row++) {
@@ -155,7 +159,7 @@ sub parse {
     my ( $row_min, $row_max ) = $worksheet->row_range();
     my ( $col_min, $col_max ) = $worksheet->col_range();
 
-    my @fixed_columns = qw | observationunit_name |;
+    my @fixed_columns = ( $worksheet->get_cell(0,0)->value() );
     my $num_fixed_col = scalar(@fixed_columns);
 
     for my $row ( 1 .. $row_max ) {

--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetSimple.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetSimple.pm
@@ -22,7 +22,7 @@ use Spreadsheet::ParseXLSX;
 use JSON;
 use Data::Dumper;
 
-my @oun_columns = ("observationunit_name", "plot_name", "observationUnitName", "plotName");
+my @oun_columns = ("observationunit_name", "plot_name", "subplot_name", "plant_name", "observationUnitName", "plotName", "subplotName", "plantName");
 my %oun_columns_map = map { $_ => 1 } @oun_columns;
 
 sub name {

--- a/mason/breeders_toolbox/upload_phenotype_spreadsheet.mas
+++ b/mason/breeders_toolbox/upload_phenotype_spreadsheet.mas
@@ -105,7 +105,7 @@
 
             <h4>Simple and Detailed Spreadsheet Format:</h4>
             <ul>
-                <li>The "Simple" format requires only a column called 'observationunit_name' followed by your trait columns.</li>
+                <li>The "Simple" format requires only a column called 'observationunit_name' followed by your trait columns.  Other acceptable headers for the first column include: 'plot_name', 'subplot_name', 'plant_name', 'observationUnitName', 'plotName', 'sublotName', 'plantName'</li>
                 <li>The "Detailed" format includes a special header as well as additional columns for design information.</li>
                 <li>The "NIRS" format is built on top of the simple format - a column called 'observationunit_name' followed by trait columns derived from the NIR spectra, followed by columns of NIR spectra data themselves. Trait column names must come form the trait ontology but NIR spectra column names should simply be copied from whateve standard output file the NIR device produces.</li>
             </ul>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR allows the first column of the "simple" phenotype upload to be one of any:

- observationunit_name
- plot_name
- subplot_name
- plant_name
- observationUnitName
- plotName
- sublotName
- plantName

We frequently have some users trying to upload data with 'plot_name' or copying the column from some of the downloads on the website, which may use 'observationUnitName'.  The upload will accept any of these as a valid first column header.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
