### PR TITLE
bring back generic_message func, removed accidentally

### DIFF
--- a/lib/SGN/Controller/solGS/Utils.pm
+++ b/lib/SGN/Controller/solGS/Utils.pm
@@ -346,11 +346,19 @@ sub stash_json_args {
 
 }
 
+sub generic_message {
+    my ($self, $c, $msg) = @_;
+
+    $c->stash->{message} = $msg;
+    $c->stash->{template} = "/generic_message.mas";
+}
+
 sub require_login {
     my ($self, $c) = @_;
 
     my $page = "/" . $c->req->path;
     $c->res->redirect("/solgs/login/message?page=$page");
+
     $c->detach;
 
 }

--- a/mason/solgs/search/selection_populations.mas
+++ b/mason/solgs/search/selection_populations.mas
@@ -76,6 +76,5 @@ if ($c->req->path =~ /solgs\/traits\/all\/population/) {
   </div>
 
   <& /solgs/search/list_type_selection_population.mas &>
-
-</&>
 </div>
+</&>

--- a/mason/solgs/search/selection_populations.mas
+++ b/mason/solgs/search/selection_populations.mas
@@ -33,7 +33,6 @@ if ($c->req->path =~ /solgs\/traits\/all\/population/) {
 
 
 <& /util/import_javascript.mas, classes => ["solGS.solGS", "solGS.Dataset", "jquery.dataTables", "solGS.selectionPopulations",  "solGS.ajaxAutocomplete"] &>
-
 <& /util/import_css.mas, paths => ['/documents/inc/datatables/jquery.dataTables.css'] &>
 
 <&| /page/info_section.mas,
@@ -57,7 +56,6 @@ if ($c->req->path =~ /solgs\/traits\/all\/population/) {
     <div  id="form-feedback-search-trials" style="color:red"> </div>
   </div>
 
-
   <div id="selection_pops_message"  class="message"></div>
   <& /solgs/spinner/spinner.mas &>
   
@@ -68,7 +66,7 @@ if ($c->req->path =~ /solgs\/traits\/all\/population/) {
 	  <th>Selection population</th>
 	  <th>Description</th>
 	  <th>Year</th>
-    <th>More details</th>
+	  <th>More details</th>
 	  <th>View GEBVs</th>
 	</tr>
       </thead>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
-- bring back generic_message func, was removed accidentally.
-- fixes private analysis results display breakage when user is not logged in.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
