### PR TITLE
make get_genotypes_from_dataset return accession ids

### DIFF
--- a/lib/SGN/Model/solGS/solGS.pm
+++ b/lib/SGN/Model/solGS/solGS.pm
@@ -2067,10 +2067,10 @@ sub get_genotypes_from_dataset {
     my ( $self, $dataset_id ) = @_;
 
     my $data = $self->get_dataset_data($dataset_id);
+    my @accessions_ids;
 
-    my $genotypes_ids;
     if ( $data->{categories}->{accessions}->[0] ) {
-        $genotypes_ids = $data->{categories}->{accessions};
+        @accessions_ids = @{$data->{categories}->{accessions}};
     }
     else {
         my $dataset = CXGN::Dataset->new(
@@ -2081,13 +2081,17 @@ sub get_genotypes_from_dataset {
             }
         );
 
-        $genotypes_ids = $dataset->retrieve_accessions();
-        my @genotypes_ids = uniq(@$genotypes_ids) if $genotypes_ids;
-        $genotypes_ids = \@genotypes_ids;
-
+        my $accessions = $dataset->retrieve_accessions();
+        if ($accessions->[0]) {
+            for (my $i=0; $i < scalar(@$accessions); $i++) {
+                push @accessions_ids, $accessions->[$i][0];
+            }
+        }
     }
+    
+    @accessions_ids = uniq(@accessions_ids) if @accessions_ids;
 
-    return $genotypes_ids;
+    return \@accessions_ids;
 }
 
 sub get_dataset_data {

--- a/lib/solGS/queryJobs.pm
+++ b/lib/solGS/queryJobs.pm
@@ -238,8 +238,8 @@ sub dataset_genotype_data {
 	my $model = $self->get_model();
 
 	my $genotypes_ids = $model->get_genotypes_from_dataset ($dataset_id);
-    my $cnt = @$genotypes_ids;
-	if (@$genotypes_ids)
+    # my $cnt = @$genotypes_ids;
+	if (@{$genotypes_ids})
 	{
 		$self->genotypes_list_genotype_data($genotypes_ids);
 	}


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
-- extract accession ids from Dataset's retrieve_accessions query result
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
