### PR TITLE
In wizard downlod - require genotype protocol and warn if too many geno…

### DIFF
--- a/js/source/modules/wizard-downloads.js
+++ b/js/source/modules/wizard-downloads.js
@@ -54,13 +54,12 @@ export function WizardDownloads(main_id,wizard){
       selections["genotyping_protocols"]:
       [];
     main.select(".wizard-download-genotypes-info")
-      .attr("value",`${accessions.length||"Too few"} accessions, ${
-        protocols.length==1?"selected protocol":
-        protocols.length>1?"too many protocols selected":
-        "default protocol"
+      .attr("value",`${accessions.length||"Too few"} accessions ${
+        protocols.length<1?", select a protocol":
+        protocols.length>1?", too many protocols":""
       }`);
     main.selectAll(".wizard-download-genotypes")
-      .attr("disabled",!!accessions.length&&protocols.length<=1?null:true)
+      .attr("disabled",accessions.length<1||protocols.length<1?true:null)
       .on("click",()=>{
         event.preventDefault();
         var accession_ids = accessions.map(d=>d.id);

--- a/js/source/modules/wizard-downloads.js
+++ b/js/source/modules/wizard-downloads.js
@@ -53,18 +53,19 @@ export function WizardDownloads(main_id,wizard){
     var protocols = categories.indexOf("genotyping_protocols")!=-1?
       selections["genotyping_protocols"]:
       [];
+    var projects = categories.indexOf("genotyping_projects")!=-1?
+      selections["genotyping_projects"]:
+      [];
     main.select(".wizard-download-genotypes-info")
-      .attr("value",`${accessions.length||"Too few"} accessions ${
-        protocols.length<1?", select a protocol":
-        protocols.length>1?", too many protocols":""
-      }`);
+      .attr("value",`${accessions.length||"Too few"} accessions`);
     main.selectAll(".wizard-download-genotypes")
-      .attr("disabled",accessions.length<1||protocols.length<1?true:null)
+      .attr("disabled",accessions.length<1?true:null)
       .on("click",()=>{
         event.preventDefault();
         var accession_ids = accessions.map(d=>d.id);
         var trial_ids = (selections["trials"]||[]).map(d=>d.id);
         var protocol_id = protocols.length==1?protocols[0].id:'';
+	var project_id = projects.length==1?projects[0].id:'';
         var chromosome_number = d3.select(".wizard-download-genotypes-chromosome-number").node().value;
         var start_position = d3.select(".wizard-download-genotypes-start-position").node().value;
         var end_position = d3.select(".wizard-download-genotypes-end-position").node().value;
@@ -81,6 +82,7 @@ export function WizardDownloads(main_id,wizard){
         openWindowWithPost(url, {
             ids: accession_ids.join(","),
             protocol_id: protocol_id,
+	    project_id: project_id,
             format: 'accession_ids',
             chromosome_number: chromosome_number,
             start_position: start_position,
@@ -99,6 +101,7 @@ export function WizardDownloads(main_id,wizard){
         var accession_ids = accessions.map(d=>d.id);
         var trial_ids = (selections["trials"]||[]).map(d=>d.id);
         var protocol_id = protocols.length==1?protocols[0].id:'';
+	var project_id = projects.length==1?projects[0].id:'';
         var download_format = d3.select(".wizard-download-genotypes-grm-format").node().value;
         var maf = d3.select(".wizard-download-genotypes-grm-maf").node().value;
         var marker_filter = d3.select(".wizard-download-genotypes-grm-marker-filter").node().value;

--- a/lib/SGN/Controller/AJAX/Search/GenotypingProtocol.pm
+++ b/lib/SGN/Controller/AJAX/Search/GenotypingProtocol.pm
@@ -83,6 +83,32 @@ sub genotyping_protocol_search_GET : Args(0) {
     $c->stash->{rest} = { data => \@result };
 }
 
+sub genotyping_protocol_number : Path('/ajax/genotyping_protocol/num_markers') : ActionClass('REST') { }
+
+sub genotyping_protocol_number_GET : Args(0) {
+    my $self = shift;
+    my $c = shift;
+    my $bcs_schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
+    my @protocol_list = $c->req->param('protocol_ids') ? split ',', $c->req->param('protocol_ids') : ();
+    my @accession_list = $c->req->param('accession_ids') ? split ',', $c->req->param('accession_ids') : ();
+
+    my $protocol_search_result;
+    if (@protocol_list) {
+        $protocol_search_result = CXGN::Genotype::Protocol::list_simple($bcs_schema, \@protocol_list);
+    }
+
+    my @result;
+    my $num_markers;
+    foreach (@$protocol_search_result){
+        $num_markers = $_->{marker_count};
+        push @result,[$num_markers];
+	#print STDERR "PROTOCOL number of markers $num_markers\n";
+    }
+
+    $c->stash->{rest} = { data => $num_markers };
+
+}
+
 sub genotyping_protocol_markers_search : Path('/ajax/genotyping_protocol/markers_search') : ActionClass('REST') { }
 
 sub genotyping_protocol_markers_search_GET : Args(0) {

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -12,7 +12,6 @@ use warnings;
 use utf8;
 use JSON::XS;
 use Data::Dumper;
-use CGI;
 use CXGN::Trial;
 use CXGN::Trial::TrialLayout;
 use File::Slurp qw | read_file |;
@@ -1077,7 +1076,8 @@ sub download_gbs_action : Path('/breeders/download_gbs_action') {
     my $dl_token = $c->req->param("gbs_download_token") || "no_token";
     my $dl_cookie = "download".$dl_token;
     my $genotyping_project_id = $c->req->param("genotyping_project_id");
-    my (@accession_ids, @accession_list, @accession_genotypes, @unsorted_markers, $accession_data, $id_string, $protocol_id, $trial_id_string, @trial_ids);
+    my (@accession_ids, @accession_list, @accession_genotypes, @unsorted_markers, $accession_data, $id_string, $protocol_id, $project_id, $trial_id_string, @trial_ids);
+    my $associated_protocol;
 
     $trial_id_string = $c->req->param("trial_ids");
     if ($trial_id_string){
@@ -1088,9 +1088,21 @@ sub download_gbs_action : Path('/breeders/download_gbs_action') {
         $id_string = $c->req->param("ids");
         @accession_ids = split(',',$id_string);
         $protocol_id = $c->req->param("protocol_id");
-        if ((!defined $protocol_id) && (!defined $genotyping_project_id)){
+	$project_id = $c->req->param("project_id");
+        if ($protocol_id =~ /\d/) {
+	    print STDERR "found protocol_id $protocol_id\n";
+        } elsif ($project_id =~ /\d/) {
+	    my $protocol_info = CXGN::Genotype::GenotypingProject->new({
+	        bcs_schema => $schema,
+	        project_id => $project_id
+            });
+            $associated_protocol = $protocol_info->get_associated_protocol();
+	    $protocol_id = $associated_protocol->[0]->[0];
+	    print STDERR "using protocol_id from project = $protocol_id\n";
+        } else {
             my $default_genotyping_protocol = $c->config->{default_genotyping_protocol};
             $protocol_id = $schema->resultset('NaturalDiversity::NdProtocol')->find({name=>$default_genotyping_protocol})->nd_protocol_id();
+	    print STDERR "using default protocol_id = $protocol_id\n";
         }
     }
 

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -631,6 +631,41 @@ $dataset_id => undef
       var protocol_name = '<% $c->config->{default_genotyping_protocol} %>';
       $(".wizard-download-genotypes-info3").show();
       $(".wizard-download-genotypes-info3").val("genotype protocol \"" + protocol_name + "\""); 
+      jQuery.ajax({
+          url: '/get/genotyping/protocols/',
+          method: "POST",
+          dataType: "json",
+          error: function(response) {
+            console.log("ERROR: Could not get genotyping protocol");
+            console.log(response);
+          },
+          success: function(response) {
+           if (response.error) {
+              console.log("ERROR: Server returned an error trying to get genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
+              console.log(repsonse.error);
+            } else {
+              SELECTED_GENOTYPING_PROTOCOL = response.default_protocol.protocol_id;
+              console.log(response.default_protocol.protocol_id);
+              jQuery.ajax({
+                url: '/ajax/genotyping_protocol/num_markers',
+                method: "GET",
+                data: { 'protocol_ids': SELECTED_GENOTYPING_PROTOCOL },
+                error: function(response) {
+                  console.log("ERROR: Could not get markers for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
+                  console.log(response);
+                },
+                success: function(response) {
+                  if (response.error) {
+                    console.log("ERROR: Server returned an error trying to get markers for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
+                    console.log(repsonse.error);
+                  } else {
+                    num_markers = response.data;
+                  }
+               }
+              });
+            }
+          }
+      });
     }
     if ( selected_accessions !== SELECTED_ACCESSIONS ) {
       SELECTED_ACCESSIONS = selected_accessions;

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -3,6 +3,8 @@
 $dataset_id => undef
 </%args>
 
+% use Data::Dumper;
+
 <& /util/import_javascript.mas, entries => ["wizard"] &>
 <& /util/import_css.mas, paths => ['wizard.css'] &>
 
@@ -240,7 +242,9 @@ $dataset_id => undef
                             <span class="glyphicon glyphicon-download" aria-hidden="true"></span>
                             Download Genotypes
                         </button>
-                        <input class="wizard-download-genotypes-info2 form-control btn-warning" type="text" hidden></input>
+                        <input class="wizard-download-genotypes-info2 form-control btn-warning" type="text"></input>  <!-- warn too many genotype protocols-->
+                        <input class="wizard-download-genotypes-info3 form-control btn-warning" type="text"></input>  <!-- show default protocol -->
+                        <input class="wizard-download-genotypes-info4 form-control btn-warning" type="text"></input>  <!-- show slow download warning -->
                     </td>
                     <td colspan="4">
                     </td>
@@ -467,6 +471,9 @@ $dataset_id => undef
       document.getElementsByClassName("wizard-dataset-select")[0].value = <% $dataset_id %>;
       document.getElementsByClassName("wizard-dataset-load")[0].click();
 %  }
+   $(".wizard-download-genotypes-info2").hide();
+   $(".wizard-download-genotypes-info3").hide();
+   $(".wizard-download-genotypes-info4").hide();
   });
 
   d3.select('#update_wizard_show').on('click', function () {
@@ -496,16 +503,19 @@ $dataset_id => undef
 
   // Wizard Callback: get chromosome names for a single selected genotyping protocol
   var SELECTED_GENOTYPING_PROTOCOL = undefined;
+  var SELECTED_GENOTYPING_PROJECT = undefined;
   var SELECTED_ACCESSIONS = undefined;
   var num_markers = 0;
   var download_units = 0;
   window.sWizard.wizard.on_change(function(categories, selections, operations) {
     var selected_genotyping_protocols = selections.hasOwnProperty('genotyping_protocols') ? selections.genotyping_protocols : [];
+    var selected_genotyping_projects = selections.hasOwnProperty('genotyping_projects') ? selections.genotyping_projects : [];
     var selected_accessions = selections.hasOwnProperty('accessions') ? selections.accessions : [];
     selected_accessions = selected_accessions.length;
-    if ( selected_genotyping_protocols.length <= 1 ) {
+    if ( selected_genotyping_protocols.length >= 1 ) {
+      $(".wizard-download-genotypes-info3").hide();
       var selected_genotyping_protocol = selected_genotyping_protocols.length === 1 ? selected_genotyping_protocols[0].id : "";
-      if ( selected_genotyping_protocol !== SELECTED_GENOTYPING_PROTOCOL ) {
+      if ( selected_genotyping_protocol != SELECTED_GENOTYPING_PROTOCOL ) {
         SELECTED_GENOTYPING_PROTOCOL = selected_genotyping_protocol;
         jQuery.ajax({
           url: '/ajax/breeder/search/genotyping_protocol_chromosomes',
@@ -521,17 +531,11 @@ $dataset_id => undef
               console.log("ERROR: Server returned an error trying to get the chromosome names for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
               console.log(repsonse.error);
               updateChromosomeNames();
-            }
-            else {
+            } else {
               updateChromosomeNames(response.chromosome_names);
             }
           }
         });
-        if ( selected_accessions > 0 ) {
-            console.log("found " + selected_accessions);
-        } else {
-            console.log("no accessions");
-        }
         jQuery.ajax({
           url: '/ajax/genotyping_protocol/num_markers',
           method: "GET",
@@ -544,32 +548,106 @@ $dataset_id => undef
             if (response.error) {
               console.log("ERROR: Server returned an error trying to get markers for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
               console.log(repsonse.error);
-            }
-            else {
+            } else {
               num_markers = response.data;
             }
           }
         });
       }
-    }
-    else {
-      SELECTED_GENOTYPING_PROTOCOL = "";
-      updateChromosomeNames();
+      if ( selected_genotyping_protocols.length > 1 ) {
+        $(".wizard-download-genotypes-info2").show();
+        $(".wizard-download-genotypes-info2").val("too many genotype protocols");
+      } else {
+        $(".wizard-download-genotypes-info2").hide();
+      }
+    } else if ( selected_genotyping_projects.length >= 1 ) {
+      var selected_genotyping_project = selected_genotyping_projects.length === 1 ? selected_genotyping_projects[0].id : "";
+      if ( selected_genotyping_project !== SELECTED_GENOTYPING_PROJECT ) {
+        console.log("project new " + selected_genotyping_project);
+        SELECTED_GENOTYPING_PROJECT = selected_genotyping_project;
+        jQuery.ajax({
+          url: '/ajax/genotyping_project/protocols',
+          method: "GET",
+          data: { 'genotyping_project_id': SELECTED_GENOTYPING_PROJECT },
+          error: function(response) {
+            console.log("ERROR: Could not get protocol for genotyping project #" + SELECTED_GENOTYPING_PROJECT);
+            console.log(response);
+          },
+          success: function(response) {
+            if (response.error) {
+              console.log("ERROR: Server returned an error trying to get protocol for genotyping project #" + SELECTED_GENOTYPING_PROJECT);
+              console.log(response.error);
+            }
+            else {
+              genotyping_protocol = response.data;
+              SELECTED_GENOTYPING_PROTOCOL = genotyping_protocol[0]["protocol_id"];
+              // console.log(genotyping_protocol[0]["protocol_id"]);
+              // console.log(genotyping_protocol[0]["protocol_name"]);
+              console.log("genotype protocol from project = " + SELECTED_GENOTYPING_PROTOCOL);
+              if ( selected_genotyping_protocols.length < 1 ) {
+                $(".wizard-download-genotypes-info3").show();
+                $(".wizard-download-genotypes-info3").val("genotype protocol \"" + genotyping_protocol[0]["protocol_name"] + "\""); 
+              }
+            }
+            jQuery.ajax({
+              url: '/ajax/breeder/search/genotyping_protocol_chromosomes',
+              method: "GET",
+              data: { 'genotyping_protocol': SELECTED_GENOTYPING_PROTOCOL },
+              error: function(response) {
+                console.log("ERROR: Could not get chromosome names for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
+                console.log(response);
+                updateChromosomeNames();
+              },
+              success: function(response) {
+                if (response.error) {
+                  console.log("ERROR: Server returned an error trying to get the chromosome names for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
+                  console.log(repsonse.error);
+                  updateChromosomeNames();
+                } else {
+                  updateChromosomeNames(response.chromosome_names);
+                }
+              }
+            });
+            // console.log("calling ajax " + SELECTED_GENOTYPING_PROTOCOL);
+            jQuery.ajax({
+              url: '/ajax/genotyping_protocol/num_markers',
+              method: "GET",
+              data: { 'protocol_ids': SELECTED_GENOTYPING_PROTOCOL },
+              error: function(response) {
+                console.log("ERROR: Could not get markers for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
+                console.log(response);
+              },
+              success: function(response) {
+                if (response.error) {
+                  console.log("ERROR: Server returned an error trying to get markers for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
+                  console.log(repsonse.error);
+                } else {
+                  num_markers = response.data;
+                }
+             }
+            });
+          }
+        });
+      }
+    } else {
+      var protocol_name = '<% $c->config->{default_genotyping_protocol} %>';
+      $(".wizard-download-genotypes-info3").show();
+      $(".wizard-download-genotypes-info3").val("genotype protocol \"" + protocol_name + "\""); 
     }
     if ( selected_accessions !== SELECTED_ACCESSIONS ) {
-      console.log("accessions new " + selected_accessions);
       SELECTED_ACCESSIONS = selected_accessions;
-      download_units = num_markers * selected_accessions;
-      if (download_units > 1000000) {
-            $(".wizard-download-genotypes-info2").show();
-            $(".wizard-download-genotypes-info2").val(download_units + " download will be slow");
+      download_units = parseInt((num_markers * selected_accessions) / 1000000);
+      if (download_units > 1) {
+            $(".wizard-download-genotypes-info4").show();
+            $(".wizard-download-genotypes-info4").val(download_units + "M values, download will be slow");
+            // console.log("download units " + download_units);
       } else {
-            $(".wizard-download-genotypes-info2").hide();
-            $(".wizard-download-genotypes-info2").val(download_units.toString());
+            $(".wizard-download-genotypes-info4").hide();
+            $(".wizard-download-genotypes-info4").val(download_units.toString());
       }
     }
   });
-  updateChromosomeNames();
+  // updateChromosomeNames();
 
   // Set the chromosome names for the select dropdown menu
   function updateChromosomeNames(names) {

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -3,8 +3,6 @@
 $dataset_id => undef
 </%args>
 
-% use Data::Dumper;
-
 <& /util/import_javascript.mas, entries => ["wizard"] &>
 <& /util/import_css.mas, paths => ['wizard.css'] &>
 

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -178,7 +178,6 @@ $dataset_id => undef
                 <span class="glyphicon glyphicon-info-sign" title="To download related genotype data, select 1 or more Accessions and optionally no more than 1 Genotyping Protocol in the wizard. If no genotyping protocol is selected, the database default protocol will be used. Click the checkbox here to compute genotypes for the selected accessions from genotypes of parents; this works for downloading genotypes, downloading the GRM, and performing GWAS."></span>
                 <span>Download Genotype Data</span>
                 <input class="wizard-download-genotypes-info form-control input-sm" type="text" disabled></input>
-                <input class="wizard-download-genotypes-info2 form-control input-sm" type="text" hidden></input>
               </td>
               <td colspan="4">
                   <span>Compute From Parents</span><br/>
@@ -234,15 +233,16 @@ $dataset_id => undef
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="6">
+                    <td colspan="8">
                         <span class="glyphicon glyphicon-info-sign" title="Select accessions, and optionally a genotyping protocol. If no genotyping protocol is selected, the default genotyping protocol is used in your system. If you want to filter genotypes, use the chromosome, start position, end position, or markerset. Can compute genotypes from parents if the parents of the accessions you selected have genotypes by checking the checkbox. Genotypes can be downloaded in VCF and Dosage Matrix Formats."></span>
                         <span>Download Genotypes</span><br/>
                         <button class="wizard-download-genotypes btn btn-sm btn-primary">
                             <span class="glyphicon glyphicon-download" aria-hidden="true"></span>
                             Download Genotypes
                         </button>
+                        <input class="wizard-download-genotypes-info2 form-control btn-warning" type="text" hidden></input>
                     </td>
-                    <td colspan="6">
+                    <td colspan="4">
                     </td>
                 </tr>
             </table>
@@ -560,7 +560,7 @@ $dataset_id => undef
       console.log("accessions new " + selected_accessions);
       SELECTED_ACCESSIONS = selected_accessions;
       download_units = num_markers * selected_accessions;
-      if (download_units > 100000) {
+      if (download_units > 1000000) {
             $(".wizard-download-genotypes-info2").show();
             $(".wizard-download-genotypes-info2").val(download_units + " download will be slow");
       } else {

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -178,6 +178,7 @@ $dataset_id => undef
                 <span class="glyphicon glyphicon-info-sign" title="To download related genotype data, select 1 or more Accessions and optionally no more than 1 Genotyping Protocol in the wizard. If no genotyping protocol is selected, the database default protocol will be used. Click the checkbox here to compute genotypes for the selected accessions from genotypes of parents; this works for downloading genotypes, downloading the GRM, and performing GWAS."></span>
                 <span>Download Genotype Data</span>
                 <input class="wizard-download-genotypes-info form-control input-sm" type="text" disabled></input>
+                <input class="wizard-download-genotypes-info2 form-control input-sm" type="text" hidden></input>
               </td>
               <td colspan="4">
                   <span>Compute From Parents</span><br/>
@@ -493,11 +494,15 @@ $dataset_id => undef
     window.sWizard.reload_lists();
   });
 
-
   // Wizard Callback: get chromosome names for a single selected genotyping protocol
   var SELECTED_GENOTYPING_PROTOCOL = undefined;
+  var SELECTED_ACCESSIONS = undefined;
+  var num_markers = 0;
+  var download_units = 0;
   window.sWizard.wizard.on_change(function(categories, selections, operations) {
     var selected_genotyping_protocols = selections.hasOwnProperty('genotyping_protocols') ? selections.genotyping_protocols : [];
+    var selected_accessions = selections.hasOwnProperty('accessions') ? selections.accessions : [];
+    selected_accessions = selected_accessions.length;
     if ( selected_genotyping_protocols.length <= 1 ) {
       var selected_genotyping_protocol = selected_genotyping_protocols.length === 1 ? selected_genotyping_protocols[0].id : "";
       if ( selected_genotyping_protocol !== SELECTED_GENOTYPING_PROTOCOL ) {
@@ -522,11 +527,46 @@ $dataset_id => undef
             }
           }
         });
+        if ( selected_accessions > 0 ) {
+            console.log("found " + selected_accessions);
+        } else {
+            console.log("no accessions");
+        }
+        jQuery.ajax({
+          url: '/ajax/genotyping_protocol/num_markers',
+          method: "GET",
+          data: { 'protocol_ids': SELECTED_GENOTYPING_PROTOCOL },
+          error: function(response) {
+            console.log("ERROR: Could not get markers for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
+            console.log(response);
+          },
+          success: function(response) {
+            if (response.error) {
+              console.log("ERROR: Server returned an error trying to get markers for genotyping protocol #" + SELECTED_GENOTYPING_PROTOCOL);
+              console.log(repsonse.error);
+            }
+            else {
+              num_markers = response.data;
+            }
+          }
+        });
       }
     }
     else {
       SELECTED_GENOTYPING_PROTOCOL = "";
       updateChromosomeNames();
+    }
+    if ( selected_accessions !== SELECTED_ACCESSIONS ) {
+      console.log("accessions new " + selected_accessions);
+      SELECTED_ACCESSIONS = selected_accessions;
+      download_units = num_markers * selected_accessions;
+      if (download_units > 100000) {
+            $(".wizard-download-genotypes-info2").show();
+            $(".wizard-download-genotypes-info2").val(download_units + " download will be slow");
+      } else {
+            $(".wizard-download-genotypes-info2").hide();
+            $(".wizard-download-genotypes-info2").val(download_units.toString());
+      }
     }
   });
   updateChromosomeNames();


### PR DESCRIPTION
If large genotype protocols are used the download will crash after a few minutes
These changes will warn user if number or markers * number of accessions is larger than one million
Also changes the wizard to require selection of genotype protocol


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
