### PR TITLE
Add Seedlot Transaction Deletion

### DIFF
--- a/lib/CXGN/Stock/Seedlot/Transaction.pm
+++ b/lib/CXGN/Stock/Seedlot/Transaction.pm
@@ -306,9 +306,11 @@ sub update_transaction_object_id {
     return $row->stock_relationship_id();
 }
 
-sub delete {
-
-
+sub delete_transaction {
+    my $self = shift;
+    my $row = $self->schema()->resultset("Stock::StockRelationship")->find({ stock_relationship_id => $self->transaction_id });
+    $row->delete();
+    return $row->stock_relationship_id();
 }
 
 1;

--- a/lib/SGN/Controller/AJAX/Seedlot.pm
+++ b/lib/SGN/Controller/AJAX/Seedlot.pm
@@ -1223,6 +1223,27 @@ sub add_seedlot_transaction :Chained('seedlot_base') :PathPart('transaction/add'
     $c->stash->{rest} = { success => 1, transaction_id => $transaction_id };
 }
 
+sub delete_seedlot_transaction :Chained('seedlot_transaction_base') PathPart('delete') Args(0) {
+#depends on CXGN/Stock/Seedlot/Transaction.pm: delete_transaction sub
+    my $self = shift;
+    my $c = shift;
+
+    if (!$c->user()){
+        $c->stash->{rest} = { error => "You must be logged in to delete seedlot transactions" };
+        $c->detach();
+    }
+    if (!$c->user()->check_roles("curator")) {
+        $c->stash->{rest} = { error => "You do not have the correct role to delete seedlot transactions. Please contact us." };
+        $c->detach();
+    }
+    my $success = $c->stash->{transaction_object}->delete_transaction();
+    if ($success){
+        $c->stash->{rest} = { success => 1 };
+    }
+    else {
+        $c->stash->{rest} = { error => "An error occured deleting the seedlot transaction" };
+    }
+}
 
 #
 # SEEDLOT MAINTENANCE EVENTS

--- a/mason/breeders_toolbox/seedlot_details.mas
+++ b/mason/breeders_toolbox/seedlot_details.mas
@@ -487,11 +487,12 @@ $user_role => undef
             { title: "Transaction Weight (g)", "data": "weight" },
             { title: "Operator", "data": "operator" },
             { title: "Transaction Description", "data": "description" },
-            { title: "Options", "data": "null", "render" : function ( data, type, row ) {
+            { title: "Edit Transaction", "data": "null", "render" : function ( data, type, row ) {
                 if (status == 'discarded') {
                     return "";
                 } else {return "<a onclick='editSeedlotTransaction("+row.transaction_id+")' >[Edit]</a>";}
             }},
+            { title: "Delete Transaction", "data": "null", "render" : function ( data, type, row ) { return "<a onclick='deleteSeedlotTransaction("+row.transaction_id+")' >X</a>"; } },
         ],
     });
 
@@ -825,6 +826,32 @@ function editSeedlotTransaction(transaction_id){
             alert('An error occurred getting seedlot transaction');
         }
     });
+}
+
+function deleteSeedlotTransaction(transaction_id){
+    if (confirm("Are you sure you want to delete this seedlot transaction?")){
+      jQuery.ajax({
+          url: '/ajax/breeders/seedlot/<% $seedlot_id %>/transaction/'+transaction_id+'/delete',
+          beforeSend: function(){
+              jQuery('#working_modal').modal('show');
+          },
+          success: function(response) {
+              jQuery('#working_modal').modal('hide');
+                if (response.success == 1) {
+                    alert('The seedlot transaction has been deleted');
+                    location.reload();
+              }
+              if (response.error) {
+                  alert(response.error);
+              }
+          },
+          error: function(response){
+              jQuery('#working_modal').modal('hide');
+              alert('An error occurred deleting seedlot transaction');
+          }
+      });
+    }
+
 }
 
 </script>

--- a/t/unit_fixture/CXGN/Stock/Seedlot/Transaction.t
+++ b/t/unit_fixture/CXGN/Stock/Seedlot/Transaction.t
@@ -240,5 +240,92 @@ my $test_seedlot_after_editing = CXGN::Stock::Seedlot->new(
 
 is($test_seedlot_after_editing->current_count, 7);
 
+#Deleting transaction 3
+print STDERR "Deleting transaction 3...\n";
+my $saved_trans3 = CXGN::Stock::Seedlot::Transaction->new(schema=>$schema, transaction_id => $trans_id_3);
+$saved_trans3->delete_transaction();
 
+#Checking seedlots after transaction deletion
+#Checking source seedlot after transaction deletion
+print STDERR "Checking source seedlot after deletion...\n";
+my $source_seedlot_after_trans3_delete = CXGN::Stock::Seedlot->new(
+    schema => $schema,
+    seedlot_id => $source_seedlot_id
+    );
+is($source_seedlot_after_trans3_delete->current_count, -12, "check current count is correct");
+is($source_seedlot_after_trans3_delete->uniquename, $source_seedlot->uniquename, "check uniquename is saved");
+is($source_seedlot_after_trans3_delete->location_code, $source_seedlot->location_code, "check location is saved");
+is($source_seedlot_after_trans3_delete->organization_name, $source_seedlot->organization_name, "check organization is saved");
+is($source_seedlot_after_trans3_delete->population_name, $source_seedlot->population_name, "check population is saved");
+is_deeply($source_seedlot_after_trans3_delete->accession, [$test_accession_stock_id1, 'test_accession1'], "check accession is saved");
+is($source_seedlot_after_trans3_delete->breeding_program_name, $seedlot_breeding_program_name);
+is($source_seedlot_after_trans3_delete->breeding_program_id, $source_seedlot->breeding_program_id);
+
+my @transactions3;
+foreach my $t (@{$source_seedlot_after_trans3_delete->transactions()}) {
+    ok($t->timestamp, "check timestamps saved");
+    ok($t->transaction_id, "check transaction ids");
+    push @transactions3, [ $t->from_stock()->[1], $t->to_stock()->[1], $t->factor()*$t->amount(), $t->operator, $t->description ];
+}
+print STDERR "Source seedlot transactions...\n";
+print STDERR Dumper \@transactions3;
+is_deeply(\@transactions3, [
+          [
+            'test seedlot 2',
+            'test seedlot',
+            -7,
+            'janedoe',
+            'Moving 7 seed from seedlot 2 to seedlot 1'
+          ],
+          [
+            'test seedlot 2',
+            'test seedlot',
+            -5,
+            'janedoe',
+            'Moving 5 seed from seedlot 2 to seedlot 1'
+          ]
+        ], "check source seedlot transactions after transaction 3 deletion");
+
+#Checking destination seedlot after transaction deletion
+print STDERR "Checking destination seedlot after deletion...\n";
+my $dest_seedlot_after_trans3_delete = CXGN::Stock::Seedlot->new(
+    schema => $schema,
+    seedlot_id => $dest_seedlot_id
+    );
+is($dest_seedlot_after_trans3_delete->current_count, 12, "check current count is correct");
+is($dest_seedlot_after_trans3_delete->uniquename, $dest_seedlot->uniquename, "check uniquename is saved");
+is($dest_seedlot_after_trans3_delete->location_code, $dest_seedlot->location_code, "check location is saved");
+is($dest_seedlot_after_trans3_delete->organization_name, $dest_seedlot->organization_name, "check organization is saved");
+is($dest_seedlot_after_trans3_delete->population_name, $dest_seedlot->population_name, "check population is saved");
+is_deeply($dest_seedlot_after_trans3_delete->accession, [$test_accession_stock_id1, 'test_accession1'], "check accession is saved");
+is($dest_seedlot_after_trans3_delete->breeding_program_name, $seedlot_breeding_program_name);
+is($dest_seedlot_after_trans3_delete->breeding_program_id, $dest_seedlot->breeding_program_id);
+
+my @transactions4;
+foreach my $t (@{$dest_seedlot_after_trans3_delete->transactions()}) {
+    ok($t->timestamp, "check timestamps saved");
+    ok($t->transaction_id, "check transaction ids");
+    push @transactions4, [ $t->from_stock()->[1], $t->to_stock()->[1], $t->factor()*$t->amount(), $t->operator, $t->description ];
+}
+print STDERR "Destination seedlot transactions...\n";
+print STDERR Dumper \@transactions4;
+is_deeply(\@transactions4, [
+          [
+            'test seedlot 2',
+            'test seedlot',
+            7,
+            'janedoe',
+            'Moving 7 seed from seedlot 2 to seedlot 1'
+          ],
+          [
+            'test seedlot 2',
+            'test seedlot',
+            5,
+            'janedoe',
+            'Moving 5 seed from seedlot 2 to seedlot 1'
+          ]
+        ], 'check transactions of dest_seedlot after transaction 3 deletion');
+
+#clean up data and done testing
+$f->clean_up_db();
 done_testing();


### PR DESCRIPTION
Add option to delete seedlot transactions on the seedlot details page. 

![image](https://github.com/solgenomics/sgn/assets/26778258/20ad74d0-f3eb-4ef8-a0c1-95fb8534ddfe)


Closes #4231 

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
