### PR TITLE
fixing bug in the vector search page when no vectors 

### DIFF
--- a/mason/search/vectors.mas
+++ b/mason/search/vectors.mas
@@ -18,8 +18,9 @@ $editable_vector_props => undef
 use CXGN::Page::FormattingHelpers qw / conditional_like_input_html simple_selectbox_html/;
 
 my $vector_cvterm_id;
+my $stock_types_number = scalar(@$stock_types);
 
-for (my $i=0; $i<= scalar(@$stock_types); $i++) {
+for (my $i=0; $i<= $stock_types_number; $i++) {
     if ( $stock_types->[$i][1] eq "vector_construct" ) {
         $vector_cvterm_id = $stock_types->[$i][0];
         last();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes #4835 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
