### PR TITLE
Create Seedlot From Trial: add plot_name to name template

### DIFF
--- a/mason/breeders_toolbox/create_seedlots_from_trial_dialogs.mas
+++ b/mason/breeders_toolbox/create_seedlots_from_trial_dialogs.mas
@@ -92,6 +92,7 @@ $timestamp => localtime()
                             <ul>
                                 <li><code>trial_name</code></li>
                                 <li><code>accession_name</code></li>
+                                <li class="plot_level_variable"><code>plot_name</code></li>
                                 <li class="plot_level_variable"><code>plot_number</code></li>
                                 <li class="plot_level_variable"><code>rep</code></li>
                                 <li class="plot_level_variable"><code>block</code></li>
@@ -664,6 +665,9 @@ $timestamp => localtime()
         let trial_name = jQuery("#create_seedlots_trial_name").val();
         let stock_type = jQuery("#create_seedlots_trial_stock_type").val();
         let name_template = jQuery("#create_seedlots_trial_name_template").val();
+        if ( name_template === '{plot_name}' ) {
+            return alert("The seedlot name cannot be the same as the plot name, please add a prefix or suffix to make the name unique");
+        }
 
         let html = "<thead></tr>";
         if ( stock_type === 'accessions' ) html += "<th>Trial Name</th>";
@@ -682,6 +686,7 @@ $timestamp => localtime()
                 .replace("{index}", index);
             if ( stock_type === "plots" ) {
                 name = name
+                    .replace("{plot_name}", SEEDLOTS[i].plot.name)
                     .replace("{plot_number}", SEEDLOTS[i].plot.number)
                     .replace("{rep}", SEEDLOTS[i].plot.rep)
                     .replace("{block}", SEEDLOTS[i].plot.block);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Adds `{plot_name}` as a possible variable for the seedlot name template

Fixes #4843 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
