### PR TITLE
BrAPI Observations: include trait values of 0

### DIFF
--- a/lib/CXGN/BrAPI/v2/Observations.pm
+++ b/lib/CXGN/BrAPI/v2/Observations.pm
@@ -288,8 +288,7 @@ sub _search {
     my $counter = 0;
 
     foreach (@$data){
-
-        if (  $_->{phenotype_value}  && $_->{phenotype_value} ne "" ) {
+        if ( ($_->{phenotype_value} && $_->{phenotype_value} ne "") || $_->{phenotype_value} eq '0' ) {
             my $observation_id = "$_->{phenotype_id}";
             my $additional_info;
             my $external_references;

--- a/lib/CXGN/Trial/TrialLayoutSearch.pm
+++ b/lib/CXGN/Trial/TrialLayoutSearch.pm
@@ -321,7 +321,7 @@ sub _include_observations {
 
     foreach (@$data){
 
-        if (  $_->{phenotype_value}  && $_->{phenotype_value} ne "" ) {
+        if ( ($_->{phenotype_value} && $_->{phenotype_value} ne "") || $_->{phenotype_value} eq '0' ) {
             my $observation_id = "$_->{phenotype_id}";
             my $observation_unit_id = "$_->{obsunit_stock_id}";
             my $additional_info;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This stops the BrAPI `/observations` from filtering out trait values of 0.

This fixes #4851, but there might be other places where 0s are being filtered out...


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
