### PR TITLE
fix another check for cross_types

### DIFF
--- a/lib/CXGN/Pedigree/AddCrosses.pm
+++ b/lib/CXGN/Pedigree/AddCrosses.pm
@@ -437,7 +437,7 @@ sub _validate_cross {
             return;
         }
 
-    } elsif ($cross_type eq "self") {
+    } elsif ($cross_type eq "self" || $cross_type eq "dihaploid_induction" || $cross_type eq "doubled_haploid" ) {
         $female_parent_name = $pedigree->get_female_parent()->get_name();
         $female_parent = $self->_get_accession($female_parent_name);
 
@@ -460,12 +460,13 @@ sub _validate_cross {
 	        $female_parent = $self->_get_accession_or_cross($female_parent_name);
 	        $male_parent = $self->_get_accession_or_cross($male_parent_name);
 
+    
         if (!$female_parent || !$male_parent) {
             print STDERR "Parent $female_parent_name or $male_parent_name in pedigree is not a stock\n";
             return;
 	    }
 
-	}
+    }
 
     #add support for other cross types here
 

--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -1227,6 +1227,7 @@ sub get_ancestor_hash {
     $pedigree{'cross_type'} = $female_parent_relationship->value();
 	$pedigree{'female_parent'} = get_ancestor_hash( $self, $female_parent_stock_id, $direct_descendant_ids );
   }
+
   my $male_parent_relationship = $stock_relationships->find({type_id => { in => [ $cvterm_male_parent->cvterm_id(), $cvterm_rootstock_of->cvterm_id() ]}, subject_id => {'not_in' => $direct_descendant_ids}});
   if ($male_parent_relationship) {
     my $male_parent_stock_id = $male_parent_relationship->subject_id();
@@ -1430,6 +1431,7 @@ sub get_parents {
     $parents{'mother_id'} = $pedigree_hashref->{'female_parent'}->{'id'};
     $parents{'father'} = $pedigree_hashref->{'male_parent'}->{'name'};
     $parents{'father_id'} = $pedigree_hashref->{'male_parent'}->{'id'};
+    $parents{'cross_type'} = $pedigree_hashref->{'female_parent'}->{'cross_type'};
     return \%parents;
 }
 

--- a/lib/CXGN/Stock/RelatedStocks.pm
+++ b/lib/CXGN/Stock/RelatedStocks.pm
@@ -63,7 +63,7 @@ sub get_progenies {
     my $male_parent_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'male_parent', 'stock_relationship')->cvterm_id();
     my $accession_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
 
-    my $q = "SELECT cvterm.name, stock.stock_id, stock.uniquename FROM stock_relationship
+    my $q = "SELECT cvterm.name, stock.stock_id, stock.uniquename, stock_relationship.value FROM stock_relationship
              INNER JOIN stock ON (stock_relationship.object_id = stock.stock_id)
              INNER JOIN cvterm ON (stock_relationship.type_id =cvterm.cvterm_id)
              WHERE stock_relationship.subject_id = ? AND(stock_relationship.type_id =?
@@ -73,8 +73,8 @@ sub get_progenies {
     $h->execute($stock_id, $female_parent_type_id, $male_parent_type_id, $accession_type_id);
 
     my @progenies =();
-        while(my($cvterm_name, $stock_id, $stock_name) = $h->fetchrow_array()){
-        push @progenies, [$cvterm_name, $stock_id, $stock_name]
+        while(my($cvterm_name, $stock_id, $stock_name, $cross_type) = $h->fetchrow_array()){
+        push @progenies, [$cvterm_name, $stock_id, $stock_name, $cross_type]
         }
 
         return\@progenies;

--- a/lib/SGN/Controller/AJAX/Pedigrees.pm
+++ b/lib/SGN/Controller/AJAX/Pedigrees.pm
@@ -251,12 +251,12 @@ sub _get_pedigrees_from_file {
             $c->stash->{rest} = { error => "No cross type on line $line_num! Must be one of these: biparental, open, self, sib, backcross, reselected, polycross." };
             $c->detach();
         }
-        if ($cross_type ne 'biparental' && $cross_type ne 'open' && $cross_type ne 'self' && $cross_type ne 'sib' && $cross_type ne 'polycross' && $cross_type ne 'backcross' && $cross_type ne 'reselected'){
+        if ($cross_type ne 'biparental' && $cross_type ne 'open' && $cross_type ne 'self' && $cross_type ne 'sib' && $cross_type ne 'polycross' && $cross_type ne 'backcross' && $cross_type ne 'reselected' && $cross_type ne 'doubled_haploid' && $cross_type ne 'dihaploid_induction'){
             $c->stash->{rest} = { error => "Invalid cross type on line $line_num! Must be one of these: biparental, open, self, backcross, sib, reselected, polycross." };
             $c->detach();
         }
         if ($female eq $male) {
-            if ($cross_type ne 'self' && $cross_type ne 'sib' && $cross_type ne 'reselected'){
+            if ($cross_type ne 'self' && $cross_type ne 'sib' && $cross_type ne 'reselected' && $cross_type ne 'doubled_haploid' && $cross_type ne 'dihaploid_induction'){
                 $c->stash->{rest} = { error => "Female parent and male parent are the same on line $line_num, but cross type is not self, sib or reselected." };
                 $c->detach();
             }
@@ -266,7 +266,7 @@ sub _get_pedigrees_from_file {
             $c->detach();
         }
 
-        if(($cross_type eq "self") || ($cross_type eq "reselected")) {
+        if(($cross_type eq "self") || ($cross_type eq "reselected") || ($cross_type eq "dihaploid_induction") || ($cross_type eq "doubled_haploid") ) {
             $female_parent = Bio::GeneticRelationships::Individual->new( { name => $female });
             $male_parent = Bio::GeneticRelationships::Individual->new( { name => $female });
         }
@@ -321,6 +321,8 @@ sub _get_pedigrees_from_file {
             $opts->{male_parent} = $male_parent;
         }
 
+	print STDERR "PEDIGREE NOW: ".Dumper($opts);
+	
         my $p = Bio::GeneticRelationships::Pedigree->new($opts);
         push @pedigrees, $p;
         $line_num++;

--- a/lib/SGN/Controller/AJAX/Pedigrees.pm
+++ b/lib/SGN/Controller/AJAX/Pedigrees.pm
@@ -123,7 +123,7 @@ sub upload_pedigrees_verify : Path('/ajax/pedigrees/upload_verify') Args(0)  {
 	return;
     }
 
-    my %legal_cross_types = ( biparental => 1, open => 1, self => 1, sib => 1, polycross => 1, backcross => 1, reselected => 1 );
+    my %legal_cross_types = ( biparental => 1, open => 1, self => 1, sib => 1, polycross => 1, backcross => 1, reselected => 1, doubled_haploid => 1, dihaploid_induction => 1 );
     my %errors;
 
     while (<$F>) {

--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -2068,7 +2068,7 @@ sub get_progenies:Chained('/stock/get_stock') PathPart('datatables/progenies') A
 
 	if (! $cross_type) { $cross_type = 'unspecified'; }
 	
-      push @stocks, [$cvterm_name, $cross_type, qq{<a href = "/stock/$stock_id/view">$stock_name</a>} ];
+	push @stocks, [$cvterm_name, $cross_type, qq{<a href = "/stock/$stock_id/view">$stock_name</a>}, $stock_name ];	
     }
 
     $c->stash->{rest}={data=>\@stocks};
@@ -2091,9 +2091,12 @@ sub get_siblings:Chained('/stock/get_stock') PathPart('datatables/siblings') Arg
         foreach my $sib(@$family){
             my ($female_parent_id, $female_parent_name, $male_parent_id, $male_parent_name, $sibling_id, $sibling_name, $cross_type) = @$sib;
             if ($sibling_id != $stock_id) {
-                push @siblings, [ qq{<a href="/stock/$sibling_id/view">$sibling_name</a>},
-                qq{<a href="/stock/$female_parent_id/view">$female_parent_name</a>},
-                qq{<a href="/stock/$male_parent_id/view">$male_parent_name</a>}, $cross_type, $sibling_name ];
+                push @siblings, [
+		    qq{<a href="/stock/$sibling_id/view">$sibling_name</a>},
+		    qq{<a href="/stock/$female_parent_id/view">$female_parent_name</a>},
+		    qq{<a href="/stock/$male_parent_id/view">$male_parent_name</a>},
+		    $cross_type,
+		    $sibling_name ];
             }
         }
     }

--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -2064,8 +2064,11 @@ sub get_progenies:Chained('/stock/get_stock') PathPart('datatables/progenies') A
     my $result = $progenies->get_progenies();
     my @stocks;
     foreach my $r (@$result){
-      my ($cvterm_name, $stock_id, $stock_name) = @$r;
-      push @stocks, [$cvterm_name, qq{<a href = "/stock/$stock_id/view">$stock_name</a>}, $stock_name];
+	my ($cvterm_name, $stock_id, $stock_name, $cross_type) = @$r;
+
+	if (! $cross_type) { $cross_type = 'unspecified'; }
+	
+      push @stocks, [$cvterm_name, $cross_type, qq{<a href = "/stock/$stock_id/view">$stock_name</a>} ];
     }
 
     $c->stash->{rest}={data=>\@stocks};
@@ -2096,6 +2099,31 @@ sub get_siblings:Chained('/stock/get_stock') PathPart('datatables/siblings') Arg
     }
     $c->stash->{rest}={data=>\@siblings};
 }
+
+sub get_parents :Chained('/stock/get_stock') PathPart('datatables/parents') Args(0) {
+    my $self = shift;
+    my $c = shift;
+    my $stock_id = $c->stash->{stock_row}->stock_id();
+
+    my $schema = $c->dbic_schema("Bio::Chado::Schema", 'sgn_chado');
+    my $stock = CXGN::Stock->new({schema => $schema, stock_id=>$stock_id});
+    my $parents = $stock->get_parents();
+    my $female_parent = $parents->{'mother'};
+    my $female_parent_id = $parents->{'mother_id'};
+    my $male_parent = $parents->{'father'};
+    my $male_parent_id = $parents->{'father_id'};
+    
+    my $female_parent_link = qq { <a href="/stock/$female_parent_id/view">$female_parent</a> };
+
+    my $male_parent_link = qq { <a href="/stock/$male_parent_id/view">$male_parent</a> };
+
+    my $cross_type = $parents->{'cross_type'};
+    
+    print STDERR "PARENTS: ".Dumper($parents);
+    $c->stash->{rest}= { data => [ [ $female_parent_link, $male_parent_link, $cross_type ] ] };
+
+}
+    
 
 sub get_group_and_member:Chained('/stock/get_stock') PathPart('datatables/group_and_member') Args(0){
     my $self = shift;

--- a/mason/stock/related_stock.mas
+++ b/mason/stock/related_stock.mas
@@ -259,7 +259,7 @@ jQuery(document).ready(function(){
                 } else {
                     var html = "";
                     for(var i=0; i<json.data.length; i++){
-                        html += json.data[i][2]+"\n";
+                        html += json.data[i][3]+"\n";
                     }
                     jQuery("#progeny_names").html(html);
                     addToListMenu("progenies_to_list_menu", "progeny_names", {

--- a/mason/stock/related_stock.mas
+++ b/mason/stock/related_stock.mas
@@ -100,6 +100,7 @@ $stock_type => undef
                         <thead>
                         <tr>
                             <th>As female or male parent</th>
+			    <th>Cross type</th>
                             <th>Progeny name</th>
                         </tr>
                         </thead>
@@ -115,6 +116,29 @@ $stock_type => undef
             </&>
         </div>
     </&>
+
+
+<&| /page/info_section.mas, id=>'related_stock_parents', title => 'Parents of this Accession', collapsible=>1, collapsed=>1 &>
+        <div class="well well-sm">
+            <div class="panel panel-default">
+                <div class="panel-body">
+                    <table id = "parents" class="table table-hover table-striped">
+                        <thead>
+                        <tr>
+                            <th>Female Parent</th>
+                            <th>Male Parent</th>
+                            <th>Cross Type</th>
+                        </tr>
+                        </thead>
+                    </table>
+                </div>
+            </div>
+
+        </div>
+    </&>
+
+
+
 
     <&| /page/info_section.mas, id=>'related_stock_siblings', title => 'Siblings of this Accession', collapsible=>1, collapsed=>1 &>
         <div class="well well-sm">
@@ -314,6 +338,30 @@ jQuery(document).ready(function(){
             }
         });
     });
+
+        jQuery('#related_stock_parents_onswitch').one("click", function(){
+        var siblings_table = jQuery('#parents').DataTable({
+            'ordering': false,
+            'ajax':'/stock/'+ <% $stock_id %> + '/datatables/parents',
+            // "fnInitComplete": function(oSettings, json) {
+            //     //console.log(json);
+            //     if (!isLoggedIn()) {
+            //         jQuery('#siblings_to_list_menu').html("<div class='well well-sm'><h3>Please login to use lists!</h3></div>");
+            //     } else {
+            //         var html = "";
+            //         for(var i=0; i<json.data.length; i++){
+            //             html += json.data[i][4]+"\n";
+            //         }
+            //         jQuery("#sibling_names").html(html);
+            //         addToListMenu("siblings_to_list_menu", "sibling_names", {
+            //             selectText: true,
+            //             listType:'accessions'
+            //         });
+            //     }
+            // }
+        });
+    });
+
 
 });
 

--- a/t/unit_mech/AJAX/Stocks/Related_stocks.t
+++ b/t/unit_mech/AJAX/Stocks/Related_stocks.t
@@ -34,24 +34,24 @@ is_deeply($response, {'data'=> [
 
 $mech->get_ok("http://localhost:3010/stock/$accession_1_id/datatables/progenies");
 $response = decode_json $mech->content;
-#print STDERR Dumper $response;
+print STDERR "PROGENIES RESPONSE: ".Dumper $response;
 
 is_deeply($response, {'data'=> [
-['female_parent', '<a href = "/stock/38846/view">new_test_crossP001</a>', 'new_test_crossP001'],
-['female_parent', '<a href = "/stock/38847/view">new_test_crossP002</a>', 'new_test_crossP002'],
-['female_parent', '<a href = "/stock/38848/view">new_test_crossP003</a>', 'new_test_crossP003'],
-['female_parent', '<a href = "/stock/38849/view">new_test_crossP004</a>', 'new_test_crossP004'],
-['female_parent', '<a href = "/stock/38850/view">new_test_crossP005</a>', 'new_test_crossP005'],
-['female_parent', '<a href = "/stock/38851/view">new_test_crossP006</a>', 'new_test_crossP006'],
-['female_parent', '<a href = "/stock/38852/view">new_test_crossP007</a>', 'new_test_crossP007'],
-['female_parent', '<a href = "/stock/38853/view">new_test_crossP008</a>', 'new_test_crossP008'],
-['female_parent', '<a href = "/stock/38854/view">new_test_crossP009</a>', 'new_test_crossP009'],
-['female_parent', '<a href = "/stock/38855/view">new_test_crossP010</a>', 'new_test_crossP010'],
-['female_parent', '<a href = "/stock/38873/view">test5P001</a>', 'test5P001'],
-['female_parent', '<a href = "/stock/38874/view">test5P002</a>', 'test5P002'],
-['female_parent', '<a href = "/stock/38875/view">test5P003</a>', 'test5P003'],
-['female_parent', '<a href = "/stock/38876/view">test5P004</a>', 'test5P004'],
-['female_parent', '<a href = "/stock/38877/view">test5P005</a>', 'test5P005']
+['female_parent', 'unspecified', '<a href = "/stock/38846/view">new_test_crossP001</a>',  'new_test_crossP001'],
+['female_parent', 'unspecified', '<a href = "/stock/38847/view">new_test_crossP002</a>', 'new_test_crossP002'],
+['female_parent', 'unspecified', '<a href = "/stock/38848/view">new_test_crossP003</a>', 'new_test_crossP003'],
+['female_parent', 'unspecified', '<a href = "/stock/38849/view">new_test_crossP004</a>', 'new_test_crossP004'],
+['female_parent', 'unspecified', '<a href = "/stock/38850/view">new_test_crossP005</a>', 'new_test_crossP005'],
+['female_parent', 'unspecified', '<a href = "/stock/38851/view">new_test_crossP006</a>', 'new_test_crossP006'],
+['female_parent', 'unspecified', '<a href = "/stock/38852/view">new_test_crossP007</a>', 'new_test_crossP007'],
+['female_parent', 'unspecified', '<a href = "/stock/38853/view">new_test_crossP008</a>', 'new_test_crossP008'],
+['female_parent', 'unspecified', '<a href = "/stock/38854/view">new_test_crossP009</a>', 'new_test_crossP009'],
+['female_parent', 'unspecified', '<a href = "/stock/38855/view">new_test_crossP010</a>', 'new_test_crossP010'],
+['female_parent', 'unspecified', '<a href = "/stock/38873/view">test5P001</a>', 'test5P001'],
+['female_parent', 'unspecified', '<a href = "/stock/38874/view">test5P002</a>', 'test5P002'],
+['female_parent', 'unspecified', '<a href = "/stock/38875/view">test5P003</a>', 'test5P003'],
+['female_parent', 'unspecified', '<a href = "/stock/38876/view">test5P004</a>', 'test5P004'],
+['female_parent', 'unspecified', '<a href = "/stock/38877/view">test5P005</a>', 'test5P005']
 ]}, 'progenies');
 
 $mech->get_ok("http://localhost:3010/stock/$accession_2_id/datatables/group_and_member");


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
need to include dihaploid_induction and doubled_haploid in the checks. 

Also, added the cross type to the progenies table on the stock detail page in the related stock section.

Added a parents table to the related stocks table.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
