### PR TITLE
Create Seedlots from Trial: fix bug if no trait data

### DIFF
--- a/mason/breeders_toolbox/create_seedlots_from_trial_dialogs.mas
+++ b/mason/breeders_toolbox/create_seedlots_from_trial_dialogs.mas
@@ -1309,8 +1309,13 @@ $timestamp => localtime()
         
         let count = 0;
         let total = TRAITS.length;
-        for ( let i = 0; i < TRAITS.length; i++ ) {
-            _getTraitData(TRAITS[i].id, TRAITS[i].name);
+        if ( total > 0 ) {
+            for ( let i = 0; i < TRAITS.length; i++ ) {
+                _getTraitData(TRAITS[i].id, TRAITS[i].name);
+            }
+        }
+        else {
+            _finish();
         }
 
         function _getTraitData(trait_id, trait_name) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes a bug that was preventing the Create Seedlots from Trial tool from continuing if the trial has no trait data.

Fixes #4431

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
