### PR TITLE
Plot Order Download: fix content-disposition header

### DIFF
--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -5029,7 +5029,7 @@ sub get_trial_plot_order : Path('/ajax/breeders/trial_plot_order') : Args(0) {
     my $filename;
     my @data;
     if ( $type eq 'planting' || $type eq 'harvest' ) {
-        $filename = $type . "_order.csv";
+        $filename = $type . "_order_" . join("-", @trial_ids) . ".csv";
         my $col = $type . "_order";
 
         # Add CSV headers
@@ -5079,7 +5079,7 @@ sub get_trial_plot_order : Path('/ajax/breeders/trial_plot_order') : Args(0) {
     }
 
     elsif ( $type eq 'harvestmaster' ) {
-        $filename = "harvest_master.csv";
+        $filename = "harvestmaster_" . join("-", @trial_ids) . ".csv";
 
         # Add CSV headers
         my @headers = ("PLTID", "Range", "Row", "type", "location_name", "trial_name", "plot_number", "plot_name", "accession_name", "seedlot_name", "rep_number", "block_number", "is_a_control");
@@ -5130,7 +5130,7 @@ sub get_trial_plot_order : Path('/ajax/breeders/trial_plot_order') : Args(0) {
 
     # Return the generated file
     $c->res->content_type('text/csv');
-    $c->res->headers->push_header("Content-disposition', 'attachment; filename=\"$filename\"");
+    $c->res->headers->push_header("Content-disposition", "attachment; filename=\"$filename\"");
     $c->res->body( join("\n", map { $_ = join(",", @{$_}) } @data) );
     return;
 }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes the Content-Disposition header for the plot order download.

The download file name will now include planting/harvest and the trial id(s) in the name.

Fixes #4907 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
