### PR TITLE
Geo Field Map improvements

### DIFF
--- a/js/source/legacy/brapi/BrAPIFieldmap.js
+++ b/js/source/legacy/brapi/BrAPIFieldmap.js
@@ -2251,10 +2251,25 @@
 	      .style("position","absolute")
 	      .style("z-index", 2000)
 	      .style("background", "#DC3545")
-	      .style("color", "#000")
+	      .style("color", "#fff")
 	      .style("border-radius", "5px")
 	      .style("padding", "10px")
+	      .style("font-weight", "bold")
 	      .style("display", "none");
+
+	    this.loading = this.map_container.append("div")
+	      .style("top", 0)
+	      .style("left", 0)
+	      .style("position","absolute")
+	      .style("z-index", 500)
+	      .style("width", "100%")
+	      .style("background", "#FFC107")
+	      .style("display", "none")
+	      .html("<p style='margin: 10px; text-align: center; font-weight: bold'>Loading Plots...</p>");
+
+	    this.onLoading = (loading) => {
+	      this.loading.style("display", loading ? 'block' : 'none');
+	    }
 	  }
 
 	  removeControls() {
@@ -2264,11 +2279,15 @@
 	  }
 
 	  load(studyDbId) {
+	    this.onLoading(true);
 	    this.generatePlots(studyDbId);
 	    return this.data.then(()=>{
-	      this.drawPlots(); return true;
+	      this.drawPlots();
+	      this.onLoading(false);
+	      return true;
 	    }).catch(resp=>{
 	      console.log(resp);
+	      this.onLoading(false);
 	    });
 	  }
 

--- a/js/source/legacy/brapi/BrAPIFieldmap.js
+++ b/js/source/legacy/brapi/BrAPIFieldmap.js
@@ -2144,12 +2144,12 @@
 	};
 
 	class Fieldmap {
-	  constructor(map_container, brapi_endpoint, opts) {
+	  constructor(map_container, brapi_endpoint, opts = {}) {
 	    this.map_container = d3.select(map_container).style("background-color", "#888");
 	    this.brapi_endpoint = brapi_endpoint;
 
 	    // Parse Options
-	    this.opts = Object.assign(Object.create(DEFAULT_OPTS), opts || {});
+	    this.opts = Object.assign(Object.create(DEFAULT_OPTS), opts);
 	    this.map = L.map(this.map_container.node(), {editable: true}).setView(this.opts.defaultPos, 2);
 	    this.map.on('preclick', ()=>{
 	      if (this.editablePolygon) this.finishTranslate();
@@ -2213,25 +2213,28 @@
 	        }
 	      });
 
-	    this.map.addControl(new L.Control.Search({
-	      url: 'https://nominatim.openstreetmap.org/search?format=json&q={s}',
-	      jsonpParam: 'json_callback',
-	      propertyName: 'display_name',
-	      propertyLoc: ['lat', 'lon'],
-	      autoCollapse: true,
-	      autoType: false,
-	      minLength: 2,
-	      marker: false,
-	      zoom: this.opts.normalZoom
-	    }));
+	    // Add additional map controls if NOT view only
+	    if ( !this.opts.viewOnly ) {
+	      this.map.addControl(new L.Control.Search({
+	        url: 'https://nominatim.openstreetmap.org/search?format=json&q={s}',
+	        jsonpParam: 'json_callback',
+	        propertyName: 'display_name',
+	        propertyLoc: ['lat', 'lon'],
+	        autoCollapse: true,
+	        autoType: false,
+	        minLength: 2,
+	        marker: false,
+	        zoom: this.opts.normalZoom
+	      }));
 
-	    this.polygonControl = new L.NewPolygonControl();
-	    this.rectangleControl = new L.NewRectangleControl();
-	    this.clearPolygonsControl = new L.NewClearControl();
+	      this.polygonControl = new L.NewPolygonControl();
+	      this.rectangleControl = new L.NewRectangleControl();
+	      this.clearPolygonsControl = new L.NewClearControl();
 
-	    this.map.addControl(this.polygonControl);
-	    this.map.addControl(this.rectangleControl);
-	    this.map.addControl(this.clearPolygonsControl);
+	      this.map.addControl(this.polygonControl);
+	      this.map.addControl(this.rectangleControl);
+	      this.map.addControl(this.clearPolygonsControl);
+			}
 
 	    this.info = this.map_container.append("div")
 	      .style("bottom","5px")
@@ -2279,7 +2282,7 @@
 	      }
 	      this.enableEdition(e.sourceTarget);
 	    }).on('click', (e)=>{
-	      this.enableTransform(e.target);
+	      if ( !this.opts.viewOnly ) this.enableTransform(e.target);
 	    }).on('mousemove', (e)=>{
 	      let sourceTarget = e.sourceTarget;
 	      let ou = this.plot_map[sourceTarget.feature.properties.observationUnitDbId];

--- a/js/source/legacy/brapi/BrAPIFieldmap.js
+++ b/js/source/legacy/brapi/BrAPIFieldmap.js
@@ -2237,10 +2237,21 @@
 	      .style("bottom","5px")
 	      .style("left","5px")
 	      .style("position","absolute")
-	      .style("z-index",999)
+	      .style("z-index",2000)
 	      .style("pointer-events","none")
 	      .style("background", "white")
 	      .style("border-radius", "5px");
+
+	    this.missing_plots = this.map_container.append("div")
+	      .style("bottom","5px")
+	      .style("right","5px")
+	      .style("position","absolute")
+	      .style("z-index", 2000)
+	      .style("background", "#DC3545")
+	      .style("color", "#000")
+	      .style("border-radius", "5px")
+	      .style("padding", "10px")
+	      .style("display", "none");
 	  }
 
 	  removeControls() {
@@ -2503,9 +2514,31 @@
 	        }
 	      }
 	      if(ou._geoJSON){
-	        ou._type = turf.getType(ou._geoJSON);
+	        try {
+	          ou._type = turf.getType(ou._geoJSON);
+	        }
+	        catch (err) {
+	          ou._type = "invalid";
+	        }
+	      }
+	      else {
+	        ou._type = "missing";
 	      }
 	    });
+
+	    // Separate out plots with invalid / missing geojson
+	    const plots_invalid = data.plots.filter((e) => e._type === 'invalid' || e._type === 'missing');
+	    const plots_valid = data.plots.filter((e) => e._type !== 'invalid' && e._type !== 'missing');
+	    if ( plots_invalid.length > 0 ) {
+	      let html = "Plots with no geo coordinates:";
+	      html += "<ul style='padding-left: 25px; margin-bottom: 0'>";
+	      plots_invalid.forEach((p) => html += `<li>${p.observationUnitName}</li>`);
+	      html += "</ul>";
+	      this.missing_plots.style("display", "block");
+	      this.missing_plots.html(html);
+	    }
+	    if ( plots_valid.length === 0 ) throw NO_POLYGON_ERROR;
+	    data.plots = plots_valid;
 
 	    // Generate a reasonable plot layout if there is missing row/col data
 	    if( data.plots.some(plot=>isNaN(plot._row)||isNaN(plot._col)) ){

--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -143,7 +143,7 @@ $has_col_and_row_numbers => undef
 </div>
 
 <div id="container_heatmap" ></div>
-<div>
+<div id="container_legend">
     <ul class="legend">
         <li><span class="border_plots"></span> Border Plots and Filler Plots</li>
         <li><span class="block_even_number"></span> Even Block Numbers (e.g. 2,4,...)</li>
@@ -1186,6 +1186,7 @@ jQuery(document).ready( function() {
         jQuery("#container_heatmap").css("display", "none");
         jQuery("#chart_fm").css("display", "none");
         jQuery("#container_fm").css("display", "none");
+        jQuery("#container_legend").css("display", "none");
         jQuery("#trial_no_phenoMSG").css("display", "none");
         jQuery("#d3legend").css("display", "none");
     });
@@ -1197,6 +1198,7 @@ jQuery(document).ready( function() {
             d3.select("svg").remove();
             jQuery("#view_ctrl_button").css("display", "none");
             jQuery("#container_heatmap").css("display", "none");
+            jQuery("#container_legend").css("display", "block");
             jQuery("#ctrldiv").css("display", "none");
             jQuery("#include_linked_trials").css("display", "block");
             d3.select("#container_heatmap_geo_div").remove();
@@ -1210,6 +1212,7 @@ jQuery(document).ready( function() {
             jQuery("#container_heatmap").css("display", "none");
             jQuery("#d3legend").css("display", "none");
             jQuery("#container_fm").css("display", "none");
+            jQuery("#container_legend").css("display", "none");
             jQuery("#delete_button_fm").css("display", "none");
             jQuery("#view_ctrl_button").css("display", "none");
             jQuery("#ctrldiv").css("display", "none");

--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -800,7 +800,7 @@ jQuery(document).ready( function() {
             }
         }
       
-        var fieldMap = new BrAPIFieldmap("#container_heatmap_geo_div",brapi_endpoint);
+        var fieldMap = new BrAPIFieldmap("#container_heatmap_geo_div", brapi_endpoint, { viewOnly: true });
 
         fieldMap.brapi_endpoint = brapi_endpoint;
         fieldMap.opts.brapi_pageSize = 1000;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds some improvements to the Geo Field Map:
  - allow missing plots (plots with no geo coordinates)
  - display a list of plots with missing geo coordinates
  - add ‘viewOnly’ mode that disables the edit features (when just viewing the map on the trial detail page)
  - add loading banner when loading plots via BrAPI
  - hide regular field map legend when viewing the geo field map or phenotype heatmap

[Screencast from 05-01-2024 02:20:03 PM.webm](https://github.com/solgenomics/sgn/assets/7526014/3bb7c62a-ecd6-48aa-8793-93ab43a12921)


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
