### PR TITLE
Trial Folder: set breeding program for folders of type 'breeding_program'

### DIFF
--- a/lib/CXGN/Trial/Folder.pm
+++ b/lib/CXGN/Trial/Folder.pm
@@ -129,6 +129,7 @@ sub BUILD {
 			$self->is_folder(1);
 		} elsif ($folder_type_row->type_id() == $self->breeding_program_cvterm_id()) {
 			$self->folder_type("breeding_program");
+			$self->breeding_program($row);
 		} elsif ($folder_type_row->type_id() == $folder_for_trials_cvterm_id) {
 			$self->folder_for_trials(1);
 		} elsif ($folder_type_row->type_id() == $folder_for_crosses_cvterm_id) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

CXGN::Trial::Folder has a 'breeding_program' attribute that is required by some BrAPI calls.

A trial can be located in a folder and a folder will have a project relationship to the breeding program it is within.  This is used to set the 'breeding_program' attribute of the folder.

However, if a trial is not within a folder (it exists directly under the breeding program), then the "folder" is the breeding program itself.  The problem is the breeding program folder does not have the 'breeding_program' attribute set.  This fix sets the breeding program of a folder of type 'breeding_program' as itself.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
