### PR TITLE
fix for dependabot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout sgn
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
     
       - name: Run unit tests
         run: prove --recurse t/unit 2>/dev/null

--- a/.github/workflows/test_static.yml
+++ b/.github/workflows/test_static.yml
@@ -23,7 +23,7 @@ jobs:
       image: bienkowskid/fedora40-r-bookdown
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:          
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}        

--- a/js/install_node.sh
+++ b/js/install_node.sh
@@ -9,7 +9,7 @@ fi
 curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 # Add the desired NodeSource repository
-VERSION=node_16.x
+VERSION=node_20.x
 # The below command will set this correctly, but if lsb_release isn't available, you can set it manually:
 # - For Debian distributions: jessie, sid, etc...
 # - For Ubuntu distributions: xenial, bionic, etc...

--- a/js/install_node.sh
+++ b/js/install_node.sh
@@ -9,7 +9,7 @@ fi
 curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 # Add the desired NodeSource repository
-VERSION=node_10.x
+VERSION=node_16.x
 # The below command will set this correctly, but if lsb_release isn't available, you can set it manually:
 # - For Debian distributions: jessie, sid, etc...
 # - For Ubuntu distributions: xenial, bionic, etc...

--- a/js/package.json
+++ b/js/package.json
@@ -20,7 +20,7 @@
     "babel-loader": "^8.0.5",
     "deepmerge": "^2.2.1",
     "del": "^3.0.0",
-    "jsdom": "^13.2.0",
+    "jsdom": "^16",
     "loader-utils": "^1.2.3",
     "nock": "^10.0.6",
     "node-fetch": "^2.3.0",

--- a/t/selenium2/03_dataset/dataset.t
+++ b/t/selenium2/03_dataset/dataset.t
@@ -6,7 +6,7 @@ use Test::More;
 use SGN::Test::Fixture;
 use SGN::Test::WWW::WebDriver;
 use CXGN::List;
-use SimulateC;
+#use SimulateC;
 
 my $d = SGN::Test::WWW::WebDriver->new();
 


### PR DESCRIPTION
fix dependabot error by changing  jsdom package from v13 to v16
changed action/checkout from v2 to v4 may fix random crash in dataset.t


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
