### PR TITLE
remove loading of devtools R package...not necessary

### DIFF
--- a/lib/CXGN/Trial/TrialDesign/Plugin/Westcott.pm
+++ b/lib/CXGN/Trial/TrialDesign/Plugin/Westcott.pm
@@ -55,7 +55,6 @@ sub create_design {
 
     $r_block = $rbase->create_block('r_block');
     $stock_data_matrix->send_rbase($rbase, 'r_block');
-    $r_block->add_command('library(devtools)');
     $r_block->add_command('library(st4gi)');
     $r_block->add_command('geno <-  stock_data_matrix[1,]');
     $r_block->add_command('ch1 <- "'.$westcott_check_1.'"');


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

-- the devtools package is not used in the trial designs. So not required to load it.
-- pass unit tests for TrialCreate.t and TrialForCrossesFamilyNames.t

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
