### PR TITLE
Single/Multi Trial Upload: flexible headers & entry numbers

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/UploadTrial.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/UploadTrial.js
@@ -39,18 +39,18 @@ jQuery(document).ready(function ($) {
     }
 
     function upload_trial_validate_form(){
-        var trial_name = $("#trial_upload_name").val();
-        var breeding_program = $("#trial_upload_breeding_program").val();
-        var location = $("#trial_upload_location").val();
-        var trial_year = $("#trial_upload_year").val();
-        var description = $("#trial_upload_description").val();
-        var design_type = $("#trial_upload_design_method").val();
-        var uploadFile = $("#trial_uploaded_file").val();
-        var trial_stock_type = $("#trial_upload_trial_stock_type").val();
-        var plot_width = $("#trial_upload_plot_width").val();
-        var plot_length = $("#trial_upload_plot_length").val();
-        plants_per_plot = $("#trial_upload_plant_entries").val();
-        inherits_plot_treatments = $('#trial_upload_plants_per_plot_inherit_treatments').val();
+        var trial_name = jQuery("#trial_upload_name").val();
+        var breeding_program = jQuery("#trial_upload_breeding_program").val();
+        var location = jQuery("#trial_upload_location").val();
+        var trial_year = jQuery("#trial_upload_year").val();
+        var description = jQuery("#trial_upload_description").val();
+        var design_type = jQuery("#trial_upload_design_method").val();
+        var uploadFile = jQuery("#trial_uploaded_file").val();
+        var trial_stock_type = jQuery("#trial_upload_trial_stock_type").val();
+        var plot_width = jQuery("#trial_upload_plot_width").val();
+        var plot_length = jQuery("#trial_upload_plot_length").val();
+        plants_per_plot = jQuery("#trial_upload_plant_entries").val();
+        inherits_plot_treatments = jQuery('#trial_upload_plants_per_plot_inherit_treatments').val();
 
 
         if (trial_name === '') {
@@ -124,32 +124,32 @@ jQuery(document).ready(function ($) {
     }
 
     function upload_trial_file() {
-        $('#upload_trial_form').attr("action", "/ajax/trial/upload_trial_file");
-        $("#upload_trial_form").submit();
+        jQuery('#upload_trial_form').attr("action", "/ajax/trial/upload_trial_file");
+        jQuery("#upload_trial_form").submit();
     }
 
     function upload_multiple_trial_designs_file() {
-      $("#upload_multiple_trials_warning_messages").html('');
-      $("#upload_multiple_trials_error_messages").html('');
-      $("#upload_multiple_trials_success_messages").html('');
-      $('#upload_multiple_trial_designs_form').attr("action", "/ajax/trial/upload_multiple_trial_designs_file");
-      $("#upload_multiple_trial_designs_form").submit();
+      jQuery("#upload_multiple_trials_warning_messages").html('');
+      jQuery("#upload_multiple_trials_error_messages").html('');
+      jQuery("#upload_multiple_trials_success_messages").html('');
+      jQuery('#upload_multiple_trial_designs_form').attr("action", "/ajax/trial/upload_multiple_trial_designs_file");
+      jQuery("#upload_multiple_trial_designs_form").submit();
   }
 
 
     function open_upload_trial_dialog() {
-        $('#upload_trial_dialog').modal("show");
+        jQuery('#upload_trial_dialog').modal("show");
         //add a blank line to design method select dropdown that dissappears when dropdown is opened
-        $("#trial_upload_design_method").prepend("<option value=''></option>").val('');
-        $("#trial_upload_design_method").one('mousedown', function () {
-            $("option:first", this).remove();
-            $("#trial_design_more_info").show();
+        jQuery("#trial_upload_design_method").prepend("<option value=''></option>").val('');
+        jQuery("#trial_upload_design_method").one('mousedown', function () {
+            jQuery("option:first", this).remove();
+            jQuery("#trial_design_more_info").show();
             //trigger design method change events in case the first one is selected after removal of the first blank select item
-            $("#trial_upload_design_method").change();
+            jQuery("#trial_upload_design_method").change();
         });
 
         //reset previous selections
-        $("#trial_upload_design_method").change();
+        jQuery("#trial_upload_design_method").change();
     }
 
     function add_plants_per_plot() {
@@ -178,45 +178,45 @@ jQuery(document).ready(function ($) {
     }
 
 
-    $('[name="upload_trial_link"]').click(function () {
+    jQuery('[name="upload_trial_link"]').click(function () {
         get_select_box('years', 'trial_upload_year', {'auto_generate': 1 });
         get_select_box('trial_types', 'trial_upload_trial_type', {'empty': 1 });
         populate_upload_trial_linkage_selects();
         open_upload_trial_dialog();
     });
 
-    $('#upload_trial_validate_form_button').click(function(){
+    jQuery('#upload_trial_validate_form_button').click(function(){
         upload_trial_validate_form();
     });
 
-    $('[name="upload_trial_submit_first"]').click(function () {
+    jQuery('[name="upload_trial_submit_first"]').click(function () {
         upload_trial_file();
     });
 
-    $('[name="upload_trial_submit_second"]').click(function () {
+    jQuery('[name="upload_trial_submit_second"]').click(function () {
         upload_trial_file();
     });
 
-    $('#multiple_trial_designs_upload_submit').click(function () {
+    jQuery('#multiple_trial_designs_upload_submit').click(function () {
       console.log("Registered click on multiple_trial_designs_upload_submit button");
         upload_multiple_trial_designs_file();
     });
 
-    $("#upload_single_trial_design_format_info").click( function () {
-        $("#trial_upload_spreadsheet_info_dialog" ).modal("show");
+    jQuery("#upload_single_trial_design_format_info").click( function () {
+        jQuery("#trial_upload_spreadsheet_info_dialog" ).modal("show");
     });
 
-    $("#upload_multiple_trial_designs_format_info").click( function () {
-        $("#multiple_trial_upload_spreadsheet_info_dialog" ).modal("show");
+    jQuery("#upload_multiple_trial_designs_format_info").click( function () {
+        jQuery("#multiple_trial_upload_spreadsheet_info_dialog" ).modal("show");
     });
 
-    $('#upload_trial_form').iframePostForm({
+    jQuery('#upload_trial_form').iframePostForm({
         json: true,
         post: function () {
-            var uploadedTrialLayoutFile = $("#trial_uploaded_file").val();
-            $('#working_modal').modal("show");
+            var uploadedTrialLayoutFile = jQuery("#trial_uploaded_file").val();
+            jQuery('#working_modal').modal("show");
             if (uploadedTrialLayoutFile === '') {
-                $('#working_modal').modal("hide");
+                jQuery('#working_modal').modal("hide");
                 alert("No file selected");
                 return;
             }
@@ -225,7 +225,7 @@ jQuery(document).ready(function ($) {
             trial_id = response.trial_id;
             console.log(response);
 
-            $('#working_modal').modal("hide");
+            jQuery('#working_modal').modal("hide");
             if (response.error) {
                 alert(response.error);
                 return;
@@ -235,13 +235,13 @@ jQuery(document).ready(function ($) {
                 if (response.missing_accessions) {
                     jQuery('#upload_trial_missing_accessions_div').show();
                     var missing_accessions_html = "<div class='well well-sm'><h3>Add the missing accessions to a list</h3><div id='upload_trial_missing_accessions' style='display:none'></div><div id='upload_trial_add_missing_accessions'></div></div><br/>";
-                    $("#upload_trial_add_missing_accessions_html").html(missing_accessions_html);
+                    jQuery("#upload_trial_add_missing_accessions_html").html(missing_accessions_html);
 
                     var missing_accessions_vals = '';
                     for(var i=0; i<response.missing_accessions.length; i++) {
                         missing_accessions_vals = missing_accessions_vals + response.missing_accessions[i] + '\n';
                     }
-                    $("#upload_trial_missing_accessions").html(missing_accessions_vals);
+                    jQuery("#upload_trial_missing_accessions").html(missing_accessions_vals);
                     addToListMenu('upload_trial_add_missing_accessions', 'upload_trial_missing_accessions', {
                         selectText: true,
                         listType: 'accessions'
@@ -262,10 +262,10 @@ jQuery(document).ready(function ($) {
                     Workflow.skip('#upload_trial_missing_seedlots_div', false);
                 }
 
-                $("#upload_trial_error_display tbody").html(response.error_string);
-                //$("#upload_trial_error_display_seedlot tbody").html(response.error_string);
-                $("#upload_trial_error_display_second_try").show();
-                $("#upload_trial_error_display_second_try tbody").html(response.error_string);
+                jQuery("#upload_trial_error_display tbody").html(response.error_string);
+                //jQuery("#upload_trial_error_display_seedlot tbody").html(response.error_string);
+                jQuery("#upload_trial_error_display_second_try").show();
+                jQuery("#upload_trial_error_display_second_try tbody").html(response.error_string);
             }
             if (response.missing_accessions){
                 Workflow.focus("#trial_upload_workflow", 4);
@@ -273,13 +273,13 @@ jQuery(document).ready(function ($) {
                 Workflow.focus("#trial_upload_workflow", 5);
             } else if(response.error_string){
                 Workflow.focus("#trial_upload_workflow", 6);
-                $("#upload_trial_error_display_second_try").show();
+                jQuery("#upload_trial_error_display_second_try").show();
             }
             if (response.warnings) {
                 warnings = response.warnings;
                 warning_html = "<li>"+warnings.join("</li><li>")+"</li>"
-                $("#upload_trial_warning_messages").show();
-                $("#upload_trial_warning_messages").html('<b>Warnings. Fix or ignore the following warnings and try again.</b><br><br>'+warning_html);
+                jQuery("#upload_trial_warning_messages").show();
+                jQuery("#upload_trial_warning_messages").html('<b>Warnings. Fix or ignore the following warnings and try again.</b><br><br>'+warning_html);
                 return;
             }
             if (response.success) {
@@ -297,26 +297,26 @@ jQuery(document).ready(function ($) {
         }
     });
 
-    $('#upload_multiple_trial_designs_form').iframePostForm({
+    jQuery('#upload_multiple_trial_designs_form').iframePostForm({
         json: true,
         post: function () {
-            var uploadedTrialLayoutFile = $("#multiple_trial_designs_upload_file").val();
-            $('#working_modal').modal("show");
+            var uploadedTrialLayoutFile = jQuery("#multiple_trial_designs_upload_file").val();
+            jQuery('#working_modal').modal("show");
             if (uploadedTrialLayoutFile === '') {
-                $('#working_modal').modal("hide");
+                jQuery('#working_modal').modal("hide");
                 alert("No file selected");
                 return;
             }
         },
         complete: function(response) {
             console.log(response);
-            $('#working_modal').modal("hide");
+            jQuery('#working_modal').modal("hide");
 
             if (response.warnings) {
                 warnings = response.warnings;
                 warning_html = "<li>"+warnings.join("</li><li>")+"</li>"
-                $("#upload_multiple_trials_warning_messages").show();
-                $("#upload_multiple_trials_warning_messages").html('<b>Warnings. Fix or ignore the following warnings and try again.</b><br><br>'+warning_html);
+                jQuery("#upload_multiple_trials_warning_messages").show();
+                jQuery("#upload_multiple_trials_warning_messages").html('<b>Warnings. Fix or ignore the following warnings and try again.</b><br><br>'+warning_html);
                 return;
             }
             if (response.errors) {
@@ -326,23 +326,23 @@ jQuery(document).ready(function ($) {
                 } else {
                     error_html = "<li>"+errors+"</li>";
                 }
-                $("#upload_multiple_trials_error_messages").show();
-                $("#upload_multiple_trials_error_messages").html('<b>Errors found. Fix the following problems and try again.</b><br><br>'+error_html);
+                jQuery("#upload_multiple_trials_error_messages").show();
+                jQuery("#upload_multiple_trials_error_messages").html('<b>Errors found. Fix the following problems and try again.</b><br><br>'+error_html);
                 return;
             }
             if (response.success) {
                 console.log("Success!!");
                 refreshTrailJsTree(0);
-                $("#upload_multiple_trials_success_messages").show();
-                $("#upload_multiple_trials_success_messages").html("Success! All trials successfully loaded.");
-                $("#multiple_trial_designs_upload_submit").hide();
-                $("#upload_multiple_trials_success_button").show();
+                jQuery("#upload_multiple_trials_success_messages").show();
+                jQuery("#upload_multiple_trials_success_messages").html("Success! All trials successfully loaded.");
+                jQuery("#multiple_trial_designs_upload_submit").hide();
+                jQuery("#upload_multiple_trials_success_button").show();
                 return;
             }
         },
         error: function(response) {
             jQuery("#working_modal").modal("hide");
-            $("#upload_multiple_trials_error_messages").html("An error occurred while trying to upload this file. Please check the formatting and try again");
+            jQuery("#upload_multiple_trials_error_messages").html("An error occurred while trying to upload this file. Please check the formatting and try again");
             return;
         }
     });

--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
@@ -11,10 +11,9 @@ use CXGN::Stock::Seedlot;
 use CXGN::Calendar;
 use CXGN::Trial;
 
-# TODO: Add T3 is_private as an optional column
-
 my @REQUIRED_COLUMNS = qw|trial_name breeding_program location year design_type description plot_name accession_name plot_number block_number|;
 my @OPTIONAL_COLUMNS = qw|trial_type plot_width plot_length field_size planting_date transplanting_date harvest_date is_a_control rep_number range_number row_number col_number seedlot_name num_seed_per_plot weight_gram_seed_per_plot entry_number|;
+# Any additional columns that are not required or optional will be used as a treatment
 
 sub _validate_with_plugin {
 

--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
@@ -11,6 +11,11 @@ use CXGN::Stock::Seedlot;
 use CXGN::Calendar;
 use CXGN::Trial;
 
+# TODO: Add T3 is_private as an optional column
+
+my @REQUIRED_COLUMNS = qw|trial_name breeding_program location year design_type description plot_name accession_name plot_number block_number|;
+my @OPTIONAL_COLUMNS = qw|trial_type plot_width plot_length field_size planting_date transplanting_date harvest_date is_a_control rep_number range_number row_number col_number seedlot_name num_seed_per_plot weight_gram_seed_per_plot entry_number|;
+
 sub _validate_with_plugin {
 
   # print STDERR "Starting validation\t".localtime()."\n";
@@ -49,32 +54,28 @@ sub _validate_with_plugin {
 
   $worksheet = ( $excel_obj->worksheets() )[0]; #support only one worksheet
   if (!$worksheet) {
-      push @error_messages, "Spreadsheet must be on 1st tab in Excel (.xls) file";
-      $errors{'error_messages'} = \@error_messages;
-      $self->_set_parse_errors(\%errors);
-      return;
+    push @error_messages, "Spreadsheet must be on 1st tab in Excel (.xls) file";
+    $errors{'error_messages'} = \@error_messages;
+    $self->_set_parse_errors(\%errors);
+    return;
   }
   my ( $row_min, $row_max ) = $worksheet->row_range();
   my ( $col_min, $col_max ) = $worksheet->col_range();
-  if (($col_max - $col_min)  < 2 || ($row_max - $row_min) < 1 ) { #must have header and at least one row of plot data
+  if ( ($col_max - $col_min) < 2 || ($row_max - $row_min) < 1 ) { #must have header and at least one row of plot data
     push @error_messages, "Spreadsheet is missing header or contains no rows";
     $errors{'error_messages'} = \@error_messages;
     $self->_set_parse_errors(\%errors);
     return;
   }
 
-  my $header_errors = _parse_header($worksheet);
-  if (scalar(@{$header_errors}) >= 1) {
-    foreach my $error (@{$header_errors}) {
+  my $headers = _parse_headers($worksheet);
+  my %columns = %{$headers->{columns}};
+  my @treatment_names = @{$headers->{treatments}};
+  my @errors = @{$headers->{errors}};
+    if (scalar(@errors) >= 1) {
+    foreach my $error (@errors) {
       push @error_messages, $error;
     }
-  }
-
-  my @treatment_names;
-  for (24 .. $col_max){
-      if ($worksheet->get_cell(0,$_)){
-          push @treatment_names, $worksheet->get_cell(0,$_)->value();
-      }
   }
 
   my $calendar_funcs = CXGN::Calendar->new({});
@@ -107,7 +108,7 @@ sub _validate_with_plugin {
 
   for my $row ( 1 .. $row_max ) {
 
-      #print STDERR "Check 01 ".localtime();
+    #print STDERR "Check 01 ".localtime();
     my $row_name = $row+1;
     my $plot_name;
     my $accession_name;
@@ -122,138 +123,135 @@ sub _validate_with_plugin {
     my $row_number;
     my $col_number;
 
-    if ($worksheet->get_cell($row,0)) {
-      $current_trial_name = $worksheet->get_cell($row,0)->value();
+    if ($worksheet->get_cell($row,$columns{trial_name}->{index})) {
+      $current_trial_name = $worksheet->get_cell($row,$columns{trial_name}->{index})->value();
     } else {
       $current_trial_name = undef;
     }
 
     if ($current_trial_name && $current_trial_name ne $trial_name) {
       $working_on_new_trial = 1;
-      if ($worksheet->get_cell($row,1)) {
-          $breeding_program = $worksheet->get_cell($row,1)->value();
+      if ($worksheet->get_cell($row,$columns{breeding_program}->{index})) {
+          $breeding_program = $worksheet->get_cell($row,$columns{breeding_program}->{index})->value();
       } else {
           $breeding_program = undef;
       }
 
-      if ($worksheet->get_cell($row,2)) {
-        $location = $worksheet->get_cell($row,2)->value();
+      if ($worksheet->get_cell($row,$columns{location}->{index})) {
+        $location = $worksheet->get_cell($row,$columns{location}->{index})->value();
       } else {
           $location = undef;
       }
 
-      if ($worksheet->get_cell($row,3)) {
-        $year = $worksheet->get_cell($row,3)->value();
+      if ($worksheet->get_cell($row,$columns{year}->{index})) {
+        $year = $worksheet->get_cell($row,$columns{year}->{index})->value();
       } else {
         $year = undef;
       }
 
-      if ($worksheet->get_cell($row,4)) {
-        $transplanting_date = $worksheet->get_cell($row,4)->value();
+      if ($worksheet->get_cell($row,$columns{transplanting_date}->{index})) {
+        $transplanting_date = $worksheet->get_cell($row,$columns{transplanting_date}->{index})->value();
       } else {
         $transplanting_date = undef;
       }
 
-      if ($worksheet->get_cell($row,5)) {
-        $design_type = $worksheet->get_cell($row,5)->value();
+      if ($worksheet->get_cell($row,$columns{design_type}->{index})) {
+        $design_type = $worksheet->get_cell($row,$columns{design_type}->{index})->value();
       } else {
         $design_type = undef;
       }
 
-      if ($worksheet->get_cell($row,6)) {
-        $description = $worksheet->get_cell($row,6)->value();
+      if ($worksheet->get_cell($row,$columns{description}->{index})) {
+        $description = $worksheet->get_cell($row,$columns{description}->{index})->value();
       } else {
         $description = undef;
       }
 
-      if ($worksheet->get_cell($row,7)) {
-        $trial_type = $worksheet->get_cell($row,7)->value();
+      if ($worksheet->get_cell($row,$columns{trial_type}->{index})) {
+        $trial_type = $worksheet->get_cell($row,$columns{trial_type}->{index})->value();
       } else {
         $trial_type = undef;
       }
 
-      if ($worksheet->get_cell($row,8)) {
-        $plot_width = $worksheet->get_cell($row,8)->value();
+      if ($worksheet->get_cell($row,$columns{plot_width}->{index})) {
+        $plot_width = $worksheet->get_cell($row,$columns{plot_width}->{index})->value();
       } else {
         $plot_width = undef;
       }
 
-      if ($worksheet->get_cell($row,9)) {
-        $plot_length = $worksheet->get_cell($row,9)->value();
+      if ($worksheet->get_cell($row,$columns{plot_length}->{index})) {
+        $plot_length = $worksheet->get_cell($row,$columns{plot_length}->{index})->value();
       } else {
         $plot_length = undef;
       }
 
-      if ($worksheet->get_cell($row,10)) {
-        $field_size = $worksheet->get_cell($row,10)->value();
+      if ($worksheet->get_cell($row,$columns{field_size}->{index})) {
+        $field_size = $worksheet->get_cell($row,$columns{field_size}->{index})->value();
       } else {
         $field_size = undef;
       }
 
-      if ($worksheet->get_cell($row,11)) {
-        $planting_date = $worksheet->get_cell($row,11)->value();
+      if ($worksheet->get_cell($row,$columns{planting_date}->{index})) {
+        $planting_date = $worksheet->get_cell($row,$columns{planting_date}->{index})->value();
       } else {
         $planting_date = undef;
       }
 
-      if ($worksheet->get_cell($row,12)) {
-        $harvest_date = $worksheet->get_cell($row,12)->value();
+      if ($worksheet->get_cell($row,$columns{harvest_date}->{index})) {
+        $harvest_date = $worksheet->get_cell($row,$columns{harvest_date}->{index})->value();
       } else {
         $harvest_date = undef;
       }
     }
 
     #skip blank rows
-    if (
-      !$worksheet->get_cell($row,0)
-      && !$worksheet->get_cell($row,1)
-      && !$worksheet->get_cell($row,2)
-      && !$worksheet->get_cell($row,3)
-      && !$worksheet->get_cell($row,4)
-      && !$worksheet->get_cell($row,5)
-      && !$worksheet->get_cell($row,12)
-      && !$worksheet->get_cell($row,13)
-      && !$worksheet->get_cell($row,14)
-      && !$worksheet->get_cell($row,15)
-    ) {
+    my $has_row_value;
+    foreach (keys %columns) {
+      if ( $worksheet->get_cell($row,$columns{$_}->{index})) {
+        if ( $worksheet->get_cell($row,$columns{$_}->{index})->value() ) {
+          $has_row_value = 1;
+        }
+      }
+    }
+    if ( !$has_row_value ) {
       next;
     }
 
-    if ($worksheet->get_cell($row,13)) {
-      $plot_name = $worksheet->get_cell($row,13)->value();
+    if ($worksheet->get_cell($row,$columns{plot_name}->{index})) {
+      $plot_name = $worksheet->get_cell($row,$columns{plot_name}->{index})->value();
     }
-    if ($worksheet->get_cell($row,14)) {
-      $accession_name = $worksheet->get_cell($row,14)->value();
+    if ($worksheet->get_cell($row,$columns{accession_name}->{index})) {
+      $accession_name = $worksheet->get_cell($row,$columns{accession_name}->{index})->value();
     }
-    if ($worksheet->get_cell($row,15)) {
-      $plot_number =  $worksheet->get_cell($row,15)->value();
+    if ($worksheet->get_cell($row,$columns{plot_number}->{index})) {
+      $plot_number =  $worksheet->get_cell($row,$columns{plot_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,16)) {
-      $block_number =  $worksheet->get_cell($row,16)->value();
+    if ($worksheet->get_cell($row,$columns{block_number}->{index})) {
+      $block_number =  $worksheet->get_cell($row,$columns{block_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,17)) {
-      $is_a_control =  $worksheet->get_cell($row,17)->value();
+    if ($worksheet->get_cell($row,$columns{is_a_control}->{index})) {
+      $is_a_control =  $worksheet->get_cell($row,$columns{is_a_control}->{index})->value();
     }
-    if ($worksheet->get_cell($row,18)) {
-      $rep_number =  $worksheet->get_cell($row,18)->value();
+    if ($worksheet->get_cell($row,$columns{rep_number}->{index})) {
+      $rep_number =  $worksheet->get_cell($row,$columns{rep_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,19)) {
-      $range_number =  $worksheet->get_cell($row,19)->value();
+    if ($worksheet->get_cell($row,$columns{range_number}->{index})) {
+      $range_number =  $worksheet->get_cell($row,$columns{range_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,20)) {
-	     $row_number = $worksheet->get_cell($row,20)->value();
+    if ($worksheet->get_cell($row,$columns{row_number}->{index})) {
+	     $row_number = $worksheet->get_cell($row,$columns{row_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,21)) {
-	     $col_number = $worksheet->get_cell($row,21)->value();
+    if ($worksheet->get_cell($row,$columns{col_number}->{index})) {
+	     $col_number = $worksheet->get_cell($row,$columns{col_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,22)) {
-      $seedlot_name = $worksheet->get_cell($row,22)->value();
+    if ($worksheet->get_cell($row,$columns{seedlot_name}->{index})) {
+      $seedlot_name = $worksheet->get_cell($row,$columns{seedlot_name}->{index})->value();
     }
-    if ($worksheet->get_cell($row,23)) {
-      $num_seed_per_plot = $worksheet->get_cell($row,23)->value();
+    if ($worksheet->get_cell($row,$columns{num_seed_per_plot}->{index})) {
+      $num_seed_per_plot = $worksheet->get_cell($row,$columns{num_seed_per_plot}->{index})->value();
     }
-    if ($worksheet->get_cell($row,24)) {
-      $weight_gram_seed_per_plot = $worksheet->get_cell($row,24)->value();
+    if ($worksheet->get_cell($row,$columns{weight_gram_seed_per_plot}->{index})) {
+      $weight_gram_seed_per_plot = $worksheet->get_cell($row,$columns{weight_gram_seed_per_plot}->{index})->value();
     }
 
     if ( $row_number && $col_number ) {
@@ -937,193 +935,41 @@ sub _parse_with_plugin {
 
 }
 
-sub _parse_header {
-  #get column headers
+sub _parse_headers {
   my $worksheet = shift;
+  my ( $col_min, $col_max ) = $worksheet->col_range();
+  my %columns;
+  my @treatments;
+  my @errors;
 
-  my $trial_name_head;
-  my $breeding_program_head;
-  my $location_head;
-  my $year_head;
-  my $transplanting_date_head;
-  my $design_type_head;
-  my $description_head;
-  my $trial_type_head;
-  my $plot_width_head;
-  my $plot_length_head;
-  my $field_size_head;
-  my $planting_date_head;
-  my $harvest_date_head;
-  my $plot_name_head;
-  my $accession_name_head;
-  my $seedlot_name_head;
-  my $num_seed_per_plot_head;
-  my $weight_gram_seed_per_plot_head;
-  my $plot_number_head;
-  my $block_number_head;
-  my $is_a_control_head;
-  my $rep_number_head;
-  my $range_number_head;
-  my $row_number_head;
-  my $col_number_head;
-
-  if ($worksheet->get_cell(0,0)) {
-    $trial_name_head= $worksheet->get_cell(0,0)->value();
-  }
-  if ($worksheet->get_cell(0,1)) {
-    $breeding_program_head= $worksheet->get_cell(0,1)->value();
-  }
-  if ($worksheet->get_cell(0,2)) {
-    $location_head= $worksheet->get_cell(0,2)->value();
-  }
-  if ($worksheet->get_cell(0,3)) {
-    $year_head= $worksheet->get_cell(0,3)->value();
-  }
-  if ($worksheet->get_cell(0,4)) {
-    $transplanting_date_head= $worksheet->get_cell(0,4)->value();
-  }
-  if ($worksheet->get_cell(0,5)) {
-    $design_type_head= $worksheet->get_cell(0,5)->value();
-  }
-  if ($worksheet->get_cell(0,6)) {
-    $description_head= $worksheet->get_cell(0,6)->value();
-  }
-  if ($worksheet->get_cell(0,7)) {
-    $trial_type_head= $worksheet->get_cell(0,7)->value();
-  }
-  if ($worksheet->get_cell(0,8)) {
-    $plot_width_head= $worksheet->get_cell(0,8)->value();
-  }
-  if ($worksheet->get_cell(0,9)) {
-    $plot_length_head= $worksheet->get_cell(0,9)->value();
-  }
-  if ($worksheet->get_cell(0,10)) {
-    $field_size_head= $worksheet->get_cell(0,10)->value();
-  }
-  if ($worksheet->get_cell(0,11)) {
-    $planting_date_head= $worksheet->get_cell(0,11)->value();
-  }
-  if ($worksheet->get_cell(0,12)) {
-    $harvest_date_head= $worksheet->get_cell(0,12)->value();
-  }
-  if ($worksheet->get_cell(0,13)) {
-    $plot_name_head  = $worksheet->get_cell(0,13)->value();
-  }
-  if ($worksheet->get_cell(0,14)) {
-    $accession_name_head  = $worksheet->get_cell(0,14)->value();
-  }
-  if ($worksheet->get_cell(0,15)) {
-    $plot_number_head  = $worksheet->get_cell(0,15)->value();
-  }
-  if ($worksheet->get_cell(0,15)) {
-    $block_number_head  = $worksheet->get_cell(0,16)->value();
-  }
-  if ($worksheet->get_cell(0,17)) {
-    $is_a_control_head  = $worksheet->get_cell(0,17)->value();
-  }
-  if ($worksheet->get_cell(0,18)) {
-    $rep_number_head  = $worksheet->get_cell(0,18)->value();
-  }
-  if ($worksheet->get_cell(0,19)) {
-    $range_number_head  = $worksheet->get_cell(0,19)->value();
-  }
-  if ($worksheet->get_cell(0,20)) {
-      $row_number_head  = $worksheet->get_cell(0,20)->value();
-  }
-  if ($worksheet->get_cell(0,21)) {
-      $col_number_head  = $worksheet->get_cell(0,21)->value();
-  }
-  if ($worksheet->get_cell(0,22)) {
-    $seedlot_name_head  = $worksheet->get_cell(0,22)->value();
-  }
-  if ($worksheet->get_cell(0,23)) {
-    $num_seed_per_plot_head = $worksheet->get_cell(0,23)->value();
-  }
-  if ($worksheet->get_cell(0,24)) {
-    $weight_gram_seed_per_plot_head = $worksheet->get_cell(0,24)->value();
+  for ( $col_min .. $col_max ) {
+    my $header = $worksheet->get_cell(0,$_)->value();
+    my $is_required = !!grep( /^$header$/, @REQUIRED_COLUMNS );
+    my $is_optional = !!grep( /^$header$/, @OPTIONAL_COLUMNS );
+    my $is_treatment = !grep( /^$header$/, @REQUIRED_COLUMNS ) && !grep( /^$header$/, @OPTIONAL_COLUMNS );
+    $columns{$header} = {
+      header => $header,
+      index => $_,
+      is_required => $is_required,
+      is_optional => $is_optional,
+      is_treatment => $is_treatment
+    };
+    if ( $is_treatment ) {
+      push(@treatments, $header);
+    }
   }
 
-  my @error_messages;
-
-  if (!$trial_name_head || $trial_name_head ne 'trial_name' ) {
-    push @error_messages, "Cell A1: trial_name is missing from the header";
-  }
-  if (!$breeding_program_head || $breeding_program_head ne 'breeding_program' ) {
-    push @error_messages, "Cell B1: breeding_program is missing from the header";
-  }
-  if (!$location_head || $location_head ne 'location' ) {
-    push @error_messages, "Cell C1: location is missing from the header";
-  }
-  if (!$year_head || $year_head ne 'year' ) {
-    push @error_messages, "Cell D1: year is missing from the header";
-  }
-  if (!$transplanting_date_head || $transplanting_date_head ne 'transplanting_date' ) {
-    push @error_messages, "Cell E1: year is missing from the header";
-  }
-  if (!$design_type_head || $design_type_head ne 'design_type' ) {
-    push @error_messages, "Cell F1: design_type is missing from the header";
-  }
-  if (!$description_head || $description_head ne 'description' ) {
-    push @error_messages, "Cell G1: description is missing from the header";
-  }
-  if (!$trial_type_head || $trial_type_head ne 'trial_type' ) {
-    push @error_messages, "Cell H1: trial_type is missing from the header";
-  }
-  if (!$plot_width_head || $plot_width_head ne 'plot_width' ) {
-    push @error_messages, "Cell I1: plot_width is missing from the header";
-  }
-  if (!$plot_length_head || $plot_length_head ne 'plot_length' ) {
-    push @error_messages, "Cell J1: plot_length is missing from the header";
-  }
-  if (!$field_size_head || $field_size_head ne 'field_size' ) {
-    push @error_messages, "Cell K1: field_size is missing from the header";
-  }
-  if (!$planting_date_head || $planting_date_head ne 'planting_date' ) {
-    push @error_messages, "Cell L1: planting_date is missing from the header";
-  }
-  if (!$harvest_date_head || $harvest_date_head ne 'harvest_date' ) {
-    push @error_messages, "Cell M1: harvest_date is missing from the header";
-  }
-  if (!$plot_name_head || $plot_name_head ne 'plot_name' ) {
-    push @error_messages, "Cell N1: plot_name is missing from the header";
-  }
-  if (!$accession_name_head || $accession_name_head ne 'accession_name') {
-    push @error_messages, "Cell O1: accession_name is missing from the header";
-  }
-  if (!$plot_number_head || $plot_number_head ne 'plot_number') {
-    push @error_messages, "Cell P1: plot_number is missing from the header";
-  }
-  if (!$block_number_head || $block_number_head ne 'block_number') {
-    push @error_messages, "Cell Q1: block_number is missing from the header";
-  }
-  if (!$is_a_control_head || $is_a_control_head ne 'is_a_control') {
-    push @error_messages, "Cell R1: is_a_control is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$rep_number_head || $rep_number_head ne 'rep_number') {
-    push @error_messages, "Cell S1: rep_number is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$range_number_head || $range_number_head ne 'range_number') {
-    push @error_messages, "Cell T1: range_number is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$row_number_head || $row_number_head ne 'row_number') {
-    push @error_messages, "Cell U1: row_number is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$col_number_head || $col_number_head ne 'col_number') {
-    push @error_messages, "Cell V1: col_number is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$seedlot_name_head || $seedlot_name_head ne 'seedlot_name') {
-    push @error_messages, "Cell W1: seedlot_name is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$num_seed_per_plot_head || $num_seed_per_plot_head ne 'num_seed_per_plot') {
-    push @error_messages, "Cell X1: num_seed_per_plot is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$weight_gram_seed_per_plot_head || $weight_gram_seed_per_plot_head ne 'weight_gram_seed_per_plot') {
-    push @error_messages, "Cell Y1: weight_gram_seed_per_plot is missing from the header. (Header is required, but values are optional)";
+  foreach (@REQUIRED_COLUMNS) {
+    if ( !exists $columns{$_} ) {
+      push(@errors, "Required column $_ is missing from the file!");
+    }
   }
 
-  return \@error_messages;
-
+  return {
+    columns => \%columns,
+    treatments => \@treatments,
+    errors => \@errors
+  }
 }
-
 
 1;

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
@@ -9,8 +9,13 @@ use Data::Dumper;
 use CXGN::List::Validate;
 use CXGN::Stock::Seedlot;
 
+my @REQUIRED_COLUMNS = qw|plot_name plot_number block_number|;
+# accession_name, cross_unique_id, or family_name are required depending on the trial_stock_type
+my @OPTIONAL_COLUMNS = qw|is_a_control rep_number range_number row_number col_number seedlot_name num_seed_per_plot weight_gram_seed_per_plot entry_number|;
+# Any additional columns that are not required or optional will be used as a treatment
+
 sub _validate_with_plugin {
-    print STDERR "Check 3.1.1 ".localtime();
+  print STDERR "Check 3.1.1 ".localtime();
   my $self = shift;
   my $filename = $self->get_filename();
   my $schema = $self->get_chado_schema();
@@ -49,147 +54,48 @@ sub _validate_with_plugin {
     return;
   }
 
-    print STDERR "Check 3.1.2 ".localtime();
+  print STDERR "Check 3.1.2 ".localtime();
 
   $worksheet = ( $excel_obj->worksheets() )[0]; #support only one worksheet
   if (!$worksheet) {
-      push @error_messages, "Spreadsheet must be on 1st tab in Excel (.xls) file";
-      $errors{'error_messages'} = \@error_messages;
-      $self->_set_parse_errors(\%errors);
-      return;
+    push @error_messages, "Spreadsheet must be on 1st tab in Excel (.xls) file";
+    $errors{'error_messages'} = \@error_messages;
+    $self->_set_parse_errors(\%errors);
+    return;
   }
   my ( $row_min, $row_max ) = $worksheet->row_range();
   my ( $col_min, $col_max ) = $worksheet->col_range();
-  if (($col_max - $col_min)  < 2 || ($row_max - $row_min) < 1 ) { #must have header and at least one row of plot data
+  if ( ($col_max - $col_min) < 2 || ($row_max - $row_min) < 1 ) { #must have header and at least one row of plot data
     push @error_messages, "Spreadsheet is missing header or contains no rows";
     $errors{'error_messages'} = \@error_messages;
     $self->_set_parse_errors(\%errors);
     return;
   }
 
-  #get column headers
-  my $plot_name_head;
-  my $stock_name_head;
-  my $seedlot_name_head;
-  my $num_seed_per_plot_head;
-  my $weight_gram_seed_per_plot_head;
-  my $plot_number_head;
-  my $block_number_head;
-  my $is_a_control_head;
-  my $rep_number_head;
-  my $range_number_head;
-  my $row_number_head;
-  my $col_number_head;
+  # Add required stock column depending on selected trial stock type
+  my @req_cols = @REQUIRED_COLUMNS;
+  my $stock_column_name = 'accession_name';
+  if ($trial_stock_type eq 'family_name') {
+    $stock_column_name = 'family_name';
+  } elsif ($trial_stock_type eq 'cross') {
+    $stock_column_name = 'cross_unique_id';
+  }
+  push @req_cols, $stock_column_name;
 
-  if ($worksheet->get_cell(0,0)) {
-    $plot_name_head  = $worksheet->get_cell(0,0)->value();
-    $plot_name_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,1)) {
-    $stock_name_head  = $worksheet->get_cell(0,1)->value();
-    $stock_name_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,2)) {
-    $plot_number_head  = $worksheet->get_cell(0,2)->value();
-    $plot_number_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,3)) {
-    $block_number_head  = $worksheet->get_cell(0,3)->value();
-    $block_number_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,4)) {
-    $is_a_control_head  = $worksheet->get_cell(0,4)->value();
-    $is_a_control_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,5)) {
-    $rep_number_head  = $worksheet->get_cell(0,5)->value();
-    $rep_number_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,6)) {
-    $range_number_head  = $worksheet->get_cell(0,6)->value();
-    $range_number_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,7)) {
-      $row_number_head  = $worksheet->get_cell(0,7)->value();
-      $row_number_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,8)) {
-      $col_number_head  = $worksheet->get_cell(0,8)->value();
-      $col_number_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,9)) {
-    $seedlot_name_head  = $worksheet->get_cell(0,9)->value();
-    $seedlot_name_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,10)) {
-    $num_seed_per_plot_head = $worksheet->get_cell(0,10)->value();
-    $num_seed_per_plot_head =~ s/^\s+|\s+$//g;
-  }
-  if ($worksheet->get_cell(0,11)) {
-    $weight_gram_seed_per_plot_head = $worksheet->get_cell(0,11)->value();
-    $weight_gram_seed_per_plot_head =~ s/^\s+|\s+$//g;
-  }
-
-  my @treatment_names;
-  for (12 .. $col_max){
-      if ($worksheet->get_cell(0,$_)){
-          push @treatment_names, $worksheet->get_cell(0,$_)->value();
-      }
-  }
-
-  if (!$plot_name_head || $plot_name_head ne 'plot_name' ) {
-    push @error_messages, "Cell A1: plot_name is missing from the header";
-  }
-
-    if ($trial_stock_type eq 'family_name') {
-        if (!$stock_name_head || $stock_name_head ne 'family_name') {
-            push @error_messages, "Cell B1: family_name is missing from the header";
-        }
-    } elsif ($trial_stock_type eq 'cross') {
-        if (!$stock_name_head || $stock_name_head ne 'cross_unique_id') {
-            push @error_messages, "Cell B1: cross_unique_id is missing from the header";
-        }
-    } else {
-        if (!$stock_name_head || $stock_name_head ne 'accession_name') {
-            push @error_messages, "Cell B1: accession_name is missing from the header";
-        }
+  my $headers = _parse_headers($worksheet, \@req_cols, \@OPTIONAL_COLUMNS);
+  my %columns = %{$headers->{columns}};
+  my @treatment_names = @{$headers->{treatments}};
+  my @errors = @{$headers->{errors}};
+    if (scalar(@errors) >= 1) {
+    foreach my $error (@errors) {
+      push @error_messages, $error;
     }
-
-  if (!$plot_number_head || $plot_number_head ne 'plot_number') {
-    push @error_messages, "Cell C1: plot_number is missing from the header";
-  }
-  if (!$block_number_head || $block_number_head ne 'block_number') {
-    push @error_messages, "Cell D1: block_number is missing from the header";
-  }
-  if (!$is_a_control_head || $is_a_control_head ne 'is_a_control') {
-    push @error_messages, "Cell E1: is_a_control is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$rep_number_head || $rep_number_head ne 'rep_number') {
-    push @error_messages, "Cell F1: rep_number is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$range_number_head || $range_number_head ne 'range_number') {
-    push @error_messages, "Cell G1: range_number is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$row_number_head || $row_number_head ne 'row_number') {
-    push @error_messages, "Cell H1: row_number is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$col_number_head || $col_number_head ne 'col_number') {
-    push @error_messages, "Cell I1: col_number is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$seedlot_name_head || $seedlot_name_head ne 'seedlot_name') {
-    push @error_messages, "Cell J1: seedlot_name is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$num_seed_per_plot_head || $num_seed_per_plot_head ne 'num_seed_per_plot') {
-    push @error_messages, "Cell K1: num_seed_per_plot is missing from the header. (Header is required, but values are optional)";
-  }
-  if (!$weight_gram_seed_per_plot_head || $weight_gram_seed_per_plot_head ne 'weight_gram_seed_per_plot') {
-    push @error_messages, "Cell L1: weight_gram_seed_per_plot is missing from the header. (Header is required, but values are optional)";
   }
 
   my @pairs;
   my %seen_plot_numbers;
   for my $row ( 1 .. $row_max ) {
-      #print STDERR "Check 01 ".localtime();
+    #print STDERR "Check 01 ".localtime();
     my $row_name = $row+1;
     my $plot_name;
     my $stock_name;
@@ -204,41 +110,41 @@ sub _validate_with_plugin {
     my $row_number;
     my $col_number;
 
-    if ($worksheet->get_cell($row,0)) {
-      $plot_name = $worksheet->get_cell($row,0)->value();
+    if ($worksheet->get_cell($row,$columns{plot_name}->{index})) {
+      $plot_name = $worksheet->get_cell($row,$columns{plot_name}->{index})->value();
     }
-    if ($worksheet->get_cell($row,1)) {
-      $stock_name = $worksheet->get_cell($row,1)->value();
+    if ($worksheet->get_cell($row,$columns{$stock_column_name}->{index})) {
+      $stock_name = $worksheet->get_cell($row,$columns{$stock_column_name}->{index})->value();
     }
-    if ($worksheet->get_cell($row,2)) {
-      $plot_number =  $worksheet->get_cell($row,2)->value();
+    if ($worksheet->get_cell($row,$columns{plot_number}->{index})) {
+      $plot_number =  $worksheet->get_cell($row,$columns{plot_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,3)) {
-      $block_number =  $worksheet->get_cell($row,3)->value();
+    if ($worksheet->get_cell($row,$columns{block_number}->{index})) {
+      $block_number =  $worksheet->get_cell($row,$columns{block_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,4)) {
-      $is_a_control =  $worksheet->get_cell($row,4)->value();
+    if ($worksheet->get_cell($row,$columns{is_a_control}->{index})) {
+      $is_a_control =  $worksheet->get_cell($row,$columns{is_a_control}->{index})->value();
     }
-    if ($worksheet->get_cell($row,5)) {
-      $rep_number =  $worksheet->get_cell($row,5)->value();
+    if ($worksheet->get_cell($row,$columns{rep_number}->{index})) {
+      $rep_number =  $worksheet->get_cell($row,$columns{rep_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,6)) {
-      $range_number =  $worksheet->get_cell($row,6)->value();
+    if ($worksheet->get_cell($row,$columns{range_number}->{index})) {
+      $range_number =  $worksheet->get_cell($row,$columns{range_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row, 7)) {
-	     $row_number = $worksheet->get_cell($row, 7)->value();
+    if ($worksheet->get_cell($row, $columns{row_number}->{index})) {
+      $row_number = $worksheet->get_cell($row, $columns{row_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row, 8)) {
-	     $col_number = $worksheet->get_cell($row, 8)->value();
+    if ($worksheet->get_cell($row, $columns{col_number}->{index})) {
+      $col_number = $worksheet->get_cell($row, $columns{col_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,9)) {
-      $seedlot_name = $worksheet->get_cell($row,9)->value();
+    if ($worksheet->get_cell($row,$columns{seedlot_name}->{index})) {
+      $seedlot_name = $worksheet->get_cell($row,$columns{seedlot_name}->{index})->value();
     }
-    if ($worksheet->get_cell($row,10)) {
-      $num_seed_per_plot = $worksheet->get_cell($row,10)->value();
+    if ($worksheet->get_cell($row,$columns{num_seed_per_plot}->{index})) {
+      $num_seed_per_plot = $worksheet->get_cell($row,$columns{num_seed_per_plot}->{index})->value();
     }
-    if ($worksheet->get_cell($row,11)) {
-      $weight_gram_seed_per_plot = $worksheet->get_cell($row,11)->value();
+    if ($worksheet->get_cell($row,$columns{weight_gram_seed_per_plot}->{index})) {
+      $weight_gram_seed_per_plot = $worksheet->get_cell($row,$columns{weight_gram_seed_per_plot}->{index})->value();
     }
 
     #skip blank lines
@@ -246,79 +152,79 @@ sub _validate_with_plugin {
       next;
     }
 
-      #print STDERR "Check 02 ".localtime();
+    #print STDERR "Check 02 ".localtime();
 
     #plot_name must not be blank
     if (!$plot_name || $plot_name eq '' ) {
-        push @error_messages, "Cell A$row_name: plot name missing.";
+      push @error_messages, "Cell A$row_name: plot name missing.";
     }
     elsif ($plot_name =~ /\s/ ) {
-        push @error_messages, "Cell A$row_name: plot name must not contain spaces.";
+      push @error_messages, "Cell A$row_name: plot name must not contain spaces.";
     }
     elsif ($plot_name =~ /\// || $plot_name =~ /\\/) {
-        push @warning_messages, "Cell A$row_name: plot name contains slashes. Note that slashes can cause problems for third-party applications; however, plotnames can be saved with slashes.";
+      push @warning_messages, "Cell A$row_name: plot name contains slashes. Note that slashes can cause problems for third-party applications; however, plotnames can be saved with slashes.";
     }
     else {
-        $plot_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
-        #file must not contain duplicate plot names
-        if ($seen_plot_names{$plot_name}) {
-            push @error_messages, "Cell A$row_name: duplicate plot name at cell A".$seen_plot_names{$plot_name}.": $plot_name";
-        }
-        $seen_plot_names{$plot_name}=$row_name;
+      $plot_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
+      #file must not contain duplicate plot names
+      if ($seen_plot_names{$plot_name}) {
+        push @error_messages, "Cell A$row_name: duplicate plot name at cell A".$seen_plot_names{$plot_name}.": $plot_name";
+      }
+      $seen_plot_names{$plot_name}=$row_name;
     }
 
-      #print STDERR "Check 03 ".localtime();
+    #print STDERR "Check 03 ".localtime();
 
     #stock_name must not be blank and must exist in the database
     if (!$stock_name || $stock_name eq '') {
-        push @error_messages, "Cell B$row_name: entry name missing";
+      push @error_messages, "Cell B$row_name: entry name missing";
     } else {
-        $stock_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
-        $seen_entry_names{$stock_name}++;
+      $stock_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
+      $seen_entry_names{$stock_name}++;
     }
 
-      #print STDERR "Check 04 ".localtime();
+    #print STDERR "Check 04 ".localtime();
 
     #plot number must not be blank
     if (!$plot_number || $plot_number eq '') {
-        push @error_messages, "Cell C$row_name: plot number missing";
+      push @error_messages, "Cell C$row_name: plot number missing";
     }
     #plot number must be a positive integer
     if (!($plot_number =~ /^\d+?$/)) {
-        push @error_messages, "Cell C$row_name: plot number is not a positive integer: $plot_number";
+      push @error_messages, "Cell C$row_name: plot number is not a positive integer: $plot_number";
     }
     #plot number must be unique in file
     if (exists($seen_plot_numbers{$plot_number})){
-        push @error_messages, "Cell C$row_name: plot number must be unique in your file. You already used this plot number in C".$seen_plot_numbers{$plot_number};
+      push @error_messages, "Cell C$row_name: plot number must be unique in your file. You already used this plot number in C".$seen_plot_numbers{$plot_number};
     } else {
-        $seen_plot_numbers{$plot_number} = $row_name;
+      $seen_plot_numbers{$plot_number} = $row_name;
     }
 
     #block number must not be blank
     if (!$block_number || $block_number eq '') {
-        push @error_messages, "Cell D$row_name: block number missing";
+      push @error_messages, "Cell D$row_name: block number missing";
     }
     #block number must be a positive integer
     if (!($block_number =~ /^\d+?$/)) {
-        push @error_messages, "Cell D$row_name: block number is not a positive integer: $block_number";
+      push @error_messages, "Cell D$row_name: block number is not a positive integer: $block_number";
     }
     if ($is_a_control) {
       #is_a_control must be either yes, no 1, 0, or blank
       if (!($is_a_control eq "yes" || $is_a_control eq "no" || $is_a_control eq "1" ||$is_a_control eq "0" || $is_a_control eq '')) {
-          push @error_messages, "Cell E$row_name: is_a_control is not either yes, no 1, 0, or blank: $is_a_control";
+        push @error_messages, "Cell E$row_name: is_a_control is not either yes, no 1, 0, or blank: $is_a_control";
       }
     }
     if ($rep_number && !($rep_number =~ /^\d+?$/)){
-        push @error_messages, "Cell F$row_name: rep_number must be a positive integer: $rep_number";
+      push @error_messages, "Cell F$row_name: rep_number must be a positive integer: $rep_number";
     }
     if ($range_number && !($range_number =~ /^\d+?$/)){
-        push @error_messages, "Cell G$row_name: range_number must be a positive integer: $range_number";
+      push @error_messages, "Cell G$row_name: range_number must be a positive integer: $range_number";
     }
     if ($row_number && !($row_number =~ /^\d+?$/)){
-        push @error_messages, "Cell H$row_name: row_number must be a positive integer: $row_number";
+      push @error_messages, "Cell H$row_name: row_number must be a positive integer: $row_number";
     }
     if ($col_number && !($col_number =~ /^\d+?$/)){
-        push @error_messages, "Cell I$row_name: col_number must be a positive integer: $col_number";
+      push @error_messages, "Cell I$row_name: col_number must be a positive integer: $col_number";
     }
     if ($row_number && $col_number) {
       my $k = "$row_number-$col_number";
@@ -331,92 +237,92 @@ sub _validate_with_plugin {
     }
 
     if ($seedlot_name){
-        $seedlot_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
-        $seen_seedlot_names{$seedlot_name}++;
-        push @pairs, [$seedlot_name, $stock_name];
+      $seedlot_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
+      $seen_seedlot_names{$seedlot_name}++;
+      push @pairs, [$seedlot_name, $stock_name];
     }
     if (defined($num_seed_per_plot) && $num_seed_per_plot ne '' && !($num_seed_per_plot =~ /^\d+?$/)){
-        push @error_messages, "Cell K$row_name: num_seed_per_plot must be a positive integer: $num_seed_per_plot";
+      push @error_messages, "Cell K$row_name: num_seed_per_plot must be a positive integer: $num_seed_per_plot";
     }
     if (defined($weight_gram_seed_per_plot) && $weight_gram_seed_per_plot ne '' && !($weight_gram_seed_per_plot =~ /^\d+?$/)){
-        push @error_messages, "Cell L$row_name: weight_gram_seed_per_plot must be a positive integer: $weight_gram_seed_per_plot";
+      push @error_messages, "Cell L$row_name: weight_gram_seed_per_plot must be a positive integer: $weight_gram_seed_per_plot";
     }
 
-    my $treatment_col = 12;
     foreach my $treatment_name (@treatment_names){
-        if($worksheet->get_cell($row,$treatment_col)){
-            my $apply_treatment = $worksheet->get_cell($row,$treatment_col)->value();
-            if ( ($apply_treatment ne '' ) && defined($apply_treatment) && $apply_treatment ne '1'){
-                push @error_messages, "Treatment value in row $row_name should be either 1 or empty";
-            }
+      my $treatment_col = $columns{$treatment_name}->{index};
+      if($worksheet->get_cell($row,$treatment_col)){
+        my $apply_treatment = $worksheet->get_cell($row,$treatment_col)->value();
+        if ( ($apply_treatment ne '' ) && defined($apply_treatment) && $apply_treatment ne '1'){
+          push @error_messages, "Treatment value in row $row_name should be either 1 or empty";
         }
-        $treatment_col++;
+      }
+      $treatment_col++;
     }
 
   }
 
-    my @entry_names = keys %seen_entry_names;
-    my $entry_name_validator = CXGN::List::Validate->new();
-    my @entry_names_missing = @{$entry_name_validator->validate($schema,'accessions_or_crosses_or_familynames',\@entry_names)->{'missing'}};
+  my @entry_names = keys %seen_entry_names;
+  my $entry_name_validator = CXGN::List::Validate->new();
+  my @entry_names_missing = @{$entry_name_validator->validate($schema,'accessions_or_crosses_or_familynames',\@entry_names)->{'missing'}};
 
-    if (scalar(@entry_names_missing) > 0) {
-        $errors{'missing_stocks'} = \@entry_names_missing;
-        push @error_messages, "The following entry names are not in the database as uniquenames or synonyms: ".join(',',@entry_names_missing);
+  if (scalar(@entry_names_missing) > 0) {
+    $errors{'missing_stocks'} = \@entry_names_missing;
+    push @error_messages, "The following entry names are not in the database as uniquenames or synonyms: ".join(',',@entry_names_missing);
+  }
+
+
+  my @seedlot_names = keys %seen_seedlot_names;
+  if (scalar(@seedlot_names)>0){
+    my $seedlot_validator = CXGN::List::Validate->new();
+    my @seedlots_missing = @{$seedlot_validator->validate($schema,'seedlots',\@seedlot_names)->{'missing'}};
+
+    if (scalar(@seedlots_missing) > 0) {
+      $errors{'missing_seedlots'} = \@seedlots_missing;
+      push @error_messages, "The following seedlots are not in the database or are marked as discarded: ".join(',',@seedlots_missing);
     }
 
-
-    my @seedlot_names = keys %seen_seedlot_names;
-    if (scalar(@seedlot_names)>0){
-        my $seedlot_validator = CXGN::List::Validate->new();
-        my @seedlots_missing = @{$seedlot_validator->validate($schema,'seedlots',\@seedlot_names)->{'missing'}};
-
-        if (scalar(@seedlots_missing) > 0) {
-            $errors{'missing_seedlots'} = \@seedlots_missing;
-            push @error_messages, "The following seedlots are not in the database or are marked as discarded: ".join(',',@seedlots_missing);
-        }
-
-        my $return = CXGN::Stock::Seedlot->verify_seedlot_accessions_crosses($schema, \@pairs);
-        if (exists($return->{error})){
-            push @error_messages, $return->{error};
-        }
+    my $return = CXGN::Stock::Seedlot->verify_seedlot_accessions_crosses($schema, \@pairs);
+    if (exists($return->{error})){
+      push @error_messages, $return->{error};
     }
+  }
 
-    my $plot_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
-    my @plots = keys %seen_plot_names;
-    my $rs = $schema->resultset("Stock::Stock")->search({
-        'type_id' => $plot_type_id,
-        'is_obsolete' => { '!=' => 't' },
-        'uniquename' => { -in => \@plots }
-    });
-    while (my $r=$rs->next){
-        push @error_messages, "Cell A".$seen_plot_names{$r->uniquename}.": plot name already exists: ".$r->uniquename;
+  my $plot_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
+  my @plots = keys %seen_plot_names;
+  my $rs = $schema->resultset("Stock::Stock")->search({
+    'type_id' => $plot_type_id,
+    'is_obsolete' => { '!=' => 't' },
+    'uniquename' => { -in => \@plots }
+  });
+  while (my $r=$rs->next){
+    push @error_messages, "Cell A".$seen_plot_names{$r->uniquename}.": plot name already exists: ".$r->uniquename;
+  }
+
+  # check for multiple plots at the same position
+  foreach my $key (keys %seen_plot_keys) {
+    my $plots = $seen_plot_keys{$key};
+    my $count = scalar(@{$plots});
+    if ( $count > 1 ) {
+      my @pos = split('-', $key);
+      push @warning_messages, "More than 1 plot is assigned to the position row=" . $pos[0] . " col=" . $pos[1] . " plots=" . join(',', @$plots);
     }
+  }
 
-    # check for multiple plots at the same position
-    foreach my $key (keys %seen_plot_keys) {
-        my $plots = $seen_plot_keys{$key};
-        my $count = scalar(@{$plots});
-        if ( $count > 1 ) {
-            my @pos = split('-', $key);
-            push @warning_messages, "More than 1 plot is assigned to the position row=" . $pos[0] . " col=" . $pos[1] . " plots=" . join(',', @$plots);
-        }
-    }
+  if (scalar(@warning_messages) >= 1) {
+    $warnings{'warning_messages'} = \@warning_messages;
+    $self->_set_parse_warnings(\%warnings);
+  }
 
-    if (scalar(@warning_messages) >= 1) {
-        $warnings{'warning_messages'} = \@warning_messages;
-        $self->_set_parse_warnings(\%warnings);
-    }
+  #store any errors found in the parsed file to parse_errors accessor
+  if (scalar(@error_messages) >= 1) {
+    $errors{'error_messages'} = \@error_messages;
+    $self->_set_parse_errors(\%errors);
+    return;
+  }
 
-    #store any errors found in the parsed file to parse_errors accessor
-    if (scalar(@error_messages) >= 1) {
-        $errors{'error_messages'} = \@error_messages;
-        $self->_set_parse_errors(\%errors);
-        return;
-    }
+  print STDERR "Check 3.1.3 ".localtime();
 
-    print STDERR "Check 3.1.3 ".localtime();
-
-    return 1; #returns true if validation is passed
+  return 1; #returns true if validation is passed
 
 }
 
@@ -451,35 +357,42 @@ sub _parse_with_plugin {
   my ( $row_min, $row_max ) = $worksheet->row_range();
   my ( $col_min, $col_max ) = $worksheet->col_range();
 
-  my @treatment_names;
-  for (12 .. $col_max){
-      if ($worksheet->get_cell(0,$_)){
-          push @treatment_names, $worksheet->get_cell(0,$_)->value();
-      }
+  # Add required stock column depending on selected trial stock type
+  my @req_cols = @REQUIRED_COLUMNS;
+  my $stock_column_name = 'accession_name';
+  if ($trial_stock_type eq 'family_name') {
+    $stock_column_name = 'family_name';
+  } elsif ($trial_stock_type eq 'cross') {
+    $stock_column_name = 'cross_unique_id';
   }
+  push @req_cols, $stock_column_name;
+
+  my $headers = _parse_headers($worksheet, \@req_cols, \@OPTIONAL_COLUMNS);
+  my %columns = %{$headers->{columns}};
+  my @treatment_names = @{$headers->{treatments}};
 
   my %seen_stock_names;
   for my $row ( 1 .. $row_max ) {
-      my $stock_name;
-      if ($worksheet->get_cell($row,1)) {
-          $stock_name = $worksheet->get_cell($row,1)->value();
-          $stock_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
-          $seen_stock_names{$stock_name}++;
-      }
+    my $stock_name;
+    if ($worksheet->get_cell($row,$columns{$stock_column_name}->{index})) {
+      $stock_name = $worksheet->get_cell($row,$columns{$stock_column_name}->{index})->value();
+      $stock_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
+      $seen_stock_names{$stock_name}++;
+    }
   }
   my $accession_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
   my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
 
   my @stocks = keys %seen_stock_names;
   my $stock_synonym_rs = $schema->resultset("Stock::Stock")->search({
-      'me.is_obsolete' => { '!=' => 't' },
-      'stockprops.value' => { -in => \@stocks},
-      'me.type_id' => $accession_cvterm_id,
-      'stockprops.type_id' => $synonym_cvterm_id
+    'me.is_obsolete' => { '!=' => 't' },
+    'stockprops.value' => { -in => \@stocks},
+    'me.type_id' => $accession_cvterm_id,
+    'stockprops.type_id' => $synonym_cvterm_id
   },{join => 'stockprops', '+select'=>['stockprops.value'], '+as'=>['synonym']});
   my %stock_synonyms_lookup;
   while (my $r=$stock_synonym_rs->next){
-      $stock_synonyms_lookup{$r->get_column('synonym')}->{$r->uniquename} = $r->stock_id;
+    $stock_synonyms_lookup{$r->get_column('synonym')}->{$r->uniquename} = $r->stock_id;
   }
 
   for my $row ( 1 .. $row_max ) {
@@ -496,46 +409,46 @@ sub _parse_with_plugin {
     my $num_seed_per_plot = 0;
     my $weight_gram_seed_per_plot = 0;
 
-    if ($worksheet->get_cell($row,0)) {
-      $plot_name = $worksheet->get_cell($row,0)->value();
+    if ($worksheet->get_cell($row,$columns{plot_name}->{index})) {
+      $plot_name = $worksheet->get_cell($row,$columns{plot_name}->{index})->value();
     }
     $plot_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
-    if ($worksheet->get_cell($row,1)) {
-      $stock_name = $worksheet->get_cell($row,1)->value();
+    if ($worksheet->get_cell($row,$columns{$stock_column_name}->{index})) {
+      $stock_name = $worksheet->get_cell($row,$columns{$stock_column_name}->{index})->value();
     }
     $stock_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
-    if ($worksheet->get_cell($row,2)) {
-      $plot_number =  $worksheet->get_cell($row,2)->value();
+    if ($worksheet->get_cell($row,$columns{plot_number}->{index})) {
+      $plot_number =  $worksheet->get_cell($row,$columns{plot_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,3)) {
-      $block_number =  $worksheet->get_cell($row,3)->value();
+    if ($worksheet->get_cell($row,$columns{block_number}->{index})) {
+      $block_number =  $worksheet->get_cell($row,$columns{block_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,4)) {
-      $is_a_control =  $worksheet->get_cell($row,4)->value();
+    if ($worksheet->get_cell($row,$columns{is_a_control}->{index})) {
+      $is_a_control =  $worksheet->get_cell($row,$columns{is_a_control}->{index})->value();
     }
-    if ($worksheet->get_cell($row,5)) {
-      $rep_number =  $worksheet->get_cell($row,5)->value();
+    if ($worksheet->get_cell($row,$columns{rep_number}->{index})) {
+      $rep_number =  $worksheet->get_cell($row,$columns{rep_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,6)) {
-      $range_number =  $worksheet->get_cell($row,6)->value();
+    if ($worksheet->get_cell($row,$columns{range_number}->{index})) {
+      $range_number =  $worksheet->get_cell($row,$columns{range_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,7)) {
-	     $row_number = $worksheet->get_cell($row, 7)->value();
+    if ($worksheet->get_cell($row,$columns{row_number}->{index})) {
+      $row_number = $worksheet->get_cell($row, $columns{row_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,8)) {
-	     $col_number = $worksheet->get_cell($row, 8)->value();
+    if ($worksheet->get_cell($row,$columns{col_number}->{index})) {
+      $col_number = $worksheet->get_cell($row, $columns{col_number}->{index})->value();
     }
-    if ($worksheet->get_cell($row,9)) {
-        $seedlot_name = $worksheet->get_cell($row, 9)->value();
+    if ($worksheet->get_cell($row,$columns{seedlot_name}->{index})) {
+      $seedlot_name = $worksheet->get_cell($row, $columns{seedlot_name}->{index})->value();
     }
     if ($seedlot_name){
-        $seedlot_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
+      $seedlot_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
     }
-    if ($worksheet->get_cell($row,10)) {
-        $num_seed_per_plot = $worksheet->get_cell($row, 10)->value();
+    if ($worksheet->get_cell($row,$columns{num_seed_per_plot}->{index})) {
+      $num_seed_per_plot = $worksheet->get_cell($row, $columns{num_seed_per_plot}->{index})->value();
     }
-    if ($worksheet->get_cell($row,11)) {
-        $weight_gram_seed_per_plot = $worksheet->get_cell($row, 11)->value();
+    if ($worksheet->get_cell($row,$columns{weight_gram_seed_per_plot}->{index})) {
+      $weight_gram_seed_per_plot = $worksheet->get_cell($row, $columns{weight_gram_seed_per_plot}->{index})->value();
     }
 
     #skip blank lines
@@ -543,22 +456,22 @@ sub _parse_with_plugin {
       next;
     }
 
-    my $treatment_col = 12;
     foreach my $treatment_name (@treatment_names){
-        if($worksheet->get_cell($row,$treatment_col)){
-            if($worksheet->get_cell($row,$treatment_col)->value()){
-                push @{$design{treatments}->{$treatment_name}{new_treatment_stocks}}, $plot_name;
-            }
+      my $treatment_col = $columns{$treatment_name}->{index};
+      if($worksheet->get_cell($row,$treatment_col)){
+        if($worksheet->get_cell($row,$treatment_col)->value()){
+          push @{$design{treatments}->{$treatment_name}{new_treatment_stocks}}, $plot_name;
         }
-        $treatment_col++;
+      }
+      $treatment_col++;
     }
 
     if ($stock_synonyms_lookup{$stock_name}){
-        my @stock_names = keys %{$stock_synonyms_lookup{$stock_name}};
-        if (scalar(@stock_names)>1){
-            print STDERR "There is more than one uniquename for this synonym $stock_name. this should not happen!\n";
-        }
-        $stock_name = $stock_names[0];
+      my @stock_names = keys %{$stock_synonyms_lookup{$stock_name}};
+      if (scalar(@stock_names)>1){
+        print STDERR "There is more than one uniquename for this synonym $stock_name. this should not happen!\n";
+      }
+      $stock_name = $stock_names[0];
     }
 
     my $key = $row;
@@ -578,15 +491,15 @@ sub _parse_with_plugin {
       $design{$key}->{range_number} = $range_number;
     }
     if ($row_number) {
-	     $design{$key}->{row_number} = $row_number;
+      $design{$key}->{row_number} = $row_number;
     }
     if ($col_number) {
-	     $design{$key}->{col_number} = $col_number;
+      $design{$key}->{col_number} = $col_number;
     }
     if ($seedlot_name){
-        $design{$key}->{seedlot_name} = $seedlot_name;
-        $design{$key}->{num_seed_per_plot} = $num_seed_per_plot;
-        $design{$key}->{weight_gram_seed_per_plot} = $weight_gram_seed_per_plot;
+      $design{$key}->{seedlot_name} = $seedlot_name;
+      $design{$key}->{num_seed_per_plot} = $num_seed_per_plot;
+      $design{$key}->{weight_gram_seed_per_plot} = $weight_gram_seed_per_plot;
     }
 
   }
@@ -595,6 +508,49 @@ sub _parse_with_plugin {
 
   return 1;
 
+}
+
+
+sub _parse_headers {
+  my $worksheet = shift;
+  my $req_cols = shift;
+  my $opt_cols = shift;
+  my ( $col_min, $col_max ) = $worksheet->col_range();
+  my %columns;
+  my @treatments;
+  my @errors;
+
+  for ( $col_min .. $col_max ) {
+    if ( $worksheet->get_cell(0,$_) ) {
+      my $header = $worksheet->get_cell(0,$_)->value();
+      $header =~ s/^\s+|\s+$//g;
+      my $is_required = !!grep( /^$header$/, @$req_cols );
+      my $is_optional = !!grep( /^$header$/, @$opt_cols );
+      my $is_treatment = !grep( /^$header$/, @$req_cols ) && !grep( /^$header$/, @$opt_cols );
+      $columns{$header} = {
+        header => $header,
+        index => $_,
+        is_required => $is_required,
+        is_optional => $is_optional,
+        is_treatment => $is_treatment
+      };
+      if ( $is_treatment ) {
+        push(@treatments, $header);
+      }
+    }
+  }
+
+  foreach (@$req_cols) {
+    if ( !exists $columns{$_} ) {
+      push(@errors, "Required column $_ is missing from the file!");
+    }
+  }
+
+  return {
+    columns => \%columns,
+    treatments => \@treatments,
+    errors => \@errors
+  }
 }
 
 

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
@@ -284,7 +284,6 @@ sub _validate_with_plugin {
           push @error_messages, "Treatment value in row $row_name should be either 1 or empty";
         }
       }
-      $treatment_col++;
     }
 
   }
@@ -497,7 +496,6 @@ sub _parse_with_plugin {
           push @{$design{treatments}->{$treatment_name}{new_treatment_stocks}}, $plot_name;
         }
       }
-      $treatment_col++;
     }
 
     if ($stock_synonyms_lookup{$stock_name}){

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
@@ -94,6 +94,10 @@ sub _validate_with_plugin {
 
   my @pairs;
   my %seen_plot_numbers;
+  my %seen_entry_numbers = (
+    by_num => {},
+    by_acc => {}
+  );
   for my $row ( 1 .. $row_max ) {
     #print STDERR "Check 01 ".localtime();
     my $row_name = $row+1;
@@ -109,6 +113,7 @@ sub _validate_with_plugin {
     my $range_number;
     my $row_number;
     my $col_number;
+    my $entry_number;
 
     if ($worksheet->get_cell($row,$columns{plot_name}->{index})) {
       $plot_name = $worksheet->get_cell($row,$columns{plot_name}->{index})->value();
@@ -146,6 +151,9 @@ sub _validate_with_plugin {
     if ($worksheet->get_cell($row,$columns{weight_gram_seed_per_plot}->{index})) {
       $weight_gram_seed_per_plot = $worksheet->get_cell($row,$columns{weight_gram_seed_per_plot}->{index})->value();
     }
+    if ($worksheet->get_cell($row,$columns{entry_number}->{index})) {
+      $entry_number = $worksheet->get_cell($row,$columns{entry_number}->{index})->value();
+    }
 
     #skip blank lines
     if (!$plot_name && !$stock_name && !$plot_number && !$block_number) {
@@ -156,19 +164,19 @@ sub _validate_with_plugin {
 
     #plot_name must not be blank
     if (!$plot_name || $plot_name eq '' ) {
-      push @error_messages, "Cell A$row_name: plot name missing.";
+      push @error_messages, "Row $row_name: plot name missing.";
     }
     elsif ($plot_name =~ /\s/ ) {
-      push @error_messages, "Cell A$row_name: plot name must not contain spaces.";
+      push @error_messages, "Row $row_name: plot name must not contain spaces.";
     }
     elsif ($plot_name =~ /\// || $plot_name =~ /\\/) {
-      push @warning_messages, "Cell A$row_name: plot name contains slashes. Note that slashes can cause problems for third-party applications; however, plotnames can be saved with slashes.";
+      push @warning_messages, "Row $row_name: plot name contains slashes. Note that slashes can cause problems for third-party applications; however, plotnames can be saved with slashes.";
     }
     else {
       $plot_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
       #file must not contain duplicate plot names
       if ($seen_plot_names{$plot_name}) {
-        push @error_messages, "Cell A$row_name: duplicate plot name at cell A".$seen_plot_names{$plot_name}.": $plot_name";
+        push @error_messages, "Row $row_name: duplicate plot name at cell A".$seen_plot_names{$plot_name}.": $plot_name";
       }
       $seen_plot_names{$plot_name}=$row_name;
     }
@@ -177,7 +185,7 @@ sub _validate_with_plugin {
 
     #stock_name must not be blank and must exist in the database
     if (!$stock_name || $stock_name eq '') {
-      push @error_messages, "Cell B$row_name: entry name missing";
+      push @error_messages, "Row $row_name: entry name missing";
     } else {
       $stock_name =~ s/^\s+|\s+$//g; #trim whitespace from front and end...
       $seen_entry_names{$stock_name}++;
@@ -187,44 +195,44 @@ sub _validate_with_plugin {
 
     #plot number must not be blank
     if (!$plot_number || $plot_number eq '') {
-      push @error_messages, "Cell C$row_name: plot number missing";
+      push @error_messages, "Row $row_name: plot number missing";
     }
     #plot number must be a positive integer
     if (!($plot_number =~ /^\d+?$/)) {
-      push @error_messages, "Cell C$row_name: plot number is not a positive integer: $plot_number";
+      push @error_messages, "Row $row_name: plot number is not a positive integer: $plot_number";
     }
     #plot number must be unique in file
     if (exists($seen_plot_numbers{$plot_number})){
-      push @error_messages, "Cell C$row_name: plot number must be unique in your file. You already used this plot number in C".$seen_plot_numbers{$plot_number};
+      push @error_messages, "Row $row_name: plot number must be unique in your file. You already used this plot number in C".$seen_plot_numbers{$plot_number};
     } else {
       $seen_plot_numbers{$plot_number} = $row_name;
     }
 
     #block number must not be blank
     if (!$block_number || $block_number eq '') {
-      push @error_messages, "Cell D$row_name: block number missing";
+      push @error_messages, "Row $row_name: block number missing";
     }
     #block number must be a positive integer
     if (!($block_number =~ /^\d+?$/)) {
-      push @error_messages, "Cell D$row_name: block number is not a positive integer: $block_number";
+      push @error_messages, "Row $row_name: block number is not a positive integer: $block_number";
     }
     if ($is_a_control) {
       #is_a_control must be either yes, no 1, 0, or blank
       if (!($is_a_control eq "yes" || $is_a_control eq "no" || $is_a_control eq "1" ||$is_a_control eq "0" || $is_a_control eq '')) {
-        push @error_messages, "Cell E$row_name: is_a_control is not either yes, no 1, 0, or blank: $is_a_control";
+        push @error_messages, "Row $row_name: is_a_control is not either yes, no 1, 0, or blank: $is_a_control";
       }
     }
     if ($rep_number && !($rep_number =~ /^\d+?$/)){
-      push @error_messages, "Cell F$row_name: rep_number must be a positive integer: $rep_number";
+      push @error_messages, "Row $row_name: rep_number must be a positive integer: $rep_number";
     }
     if ($range_number && !($range_number =~ /^\d+?$/)){
-      push @error_messages, "Cell G$row_name: range_number must be a positive integer: $range_number";
+      push @error_messages, "Row $row_name: range_number must be a positive integer: $range_number";
     }
     if ($row_number && !($row_number =~ /^\d+?$/)){
-      push @error_messages, "Cell H$row_name: row_number must be a positive integer: $row_number";
+      push @error_messages, "Row $row_name: row_number must be a positive integer: $row_number";
     }
     if ($col_number && !($col_number =~ /^\d+?$/)){
-      push @error_messages, "Cell I$row_name: col_number must be a positive integer: $col_number";
+      push @error_messages, "Row $row_name: col_number must be a positive integer: $col_number";
     }
     if ($row_number && $col_number) {
       my $k = "$row_number-$col_number";
@@ -242,10 +250,30 @@ sub _validate_with_plugin {
       push @pairs, [$seedlot_name, $stock_name];
     }
     if (defined($num_seed_per_plot) && $num_seed_per_plot ne '' && !($num_seed_per_plot =~ /^\d+?$/)){
-      push @error_messages, "Cell K$row_name: num_seed_per_plot must be a positive integer: $num_seed_per_plot";
+      push @error_messages, "Row $row_name: num_seed_per_plot must be a positive integer: $num_seed_per_plot";
     }
     if (defined($weight_gram_seed_per_plot) && $weight_gram_seed_per_plot ne '' && !($weight_gram_seed_per_plot =~ /^\d+?$/)){
-      push @error_messages, "Cell L$row_name: weight_gram_seed_per_plot must be a positive integer: $weight_gram_seed_per_plot";
+      push @error_messages, "Row $row_name: weight_gram_seed_per_plot must be a positive integer: $weight_gram_seed_per_plot";
+    }
+
+    ## ENTRY NUMBER CHECK
+    if ($entry_number) {
+      my $ex_acc = $seen_entry_numbers{by_num}->{$entry_number};
+      my $ex_en = $seen_entry_numbers{by_acc}->{$stock_name};
+      if ( $ex_acc ) {
+        if ( $ex_acc ne $stock_name ) {
+          push @error_messages, "Row $row_name: entry number $entry_number has already been assigned to a different stock ($ex_acc).";
+        }
+      }
+      elsif ( $ex_en ) {
+        if ( $ex_en ne $entry_number ) {
+          push @error_messages, "Row $row_name: stock $stock_name has already been assigned a different entry number ($ex_en).";
+        }
+      }
+      else {
+        $seen_entry_numbers{by_num}->{$entry_number} = $stock_name;
+        $seen_entry_numbers{by_acc}->{$stock_name} = $entry_number;
+      }
     }
 
     foreach my $treatment_name (@treatment_names){
@@ -295,7 +323,7 @@ sub _validate_with_plugin {
     'uniquename' => { -in => \@plots }
   });
   while (my $r=$rs->next){
-    push @error_messages, "Cell A".$seen_plot_names{$r->uniquename}.": plot name already exists: ".$r->uniquename;
+    push @error_messages, "Row ".$seen_plot_names{$r->uniquename}.": plot name already exists: ".$r->uniquename;
   }
 
   # check for multiple plots at the same position
@@ -395,6 +423,8 @@ sub _parse_with_plugin {
     $stock_synonyms_lookup{$r->get_column('synonym')}->{$r->uniquename} = $r->stock_id;
   }
 
+  my %seen_entry_numbers;
+
   for my $row ( 1 .. $row_max ) {
     my $plot_name;
     my $stock_name;
@@ -408,6 +438,7 @@ sub _parse_with_plugin {
     my $seedlot_name;
     my $num_seed_per_plot = 0;
     my $weight_gram_seed_per_plot = 0;
+    my $entry_number;
 
     if ($worksheet->get_cell($row,$columns{plot_name}->{index})) {
       $plot_name = $worksheet->get_cell($row,$columns{plot_name}->{index})->value();
@@ -450,6 +481,9 @@ sub _parse_with_plugin {
     if ($worksheet->get_cell($row,$columns{weight_gram_seed_per_plot}->{index})) {
       $weight_gram_seed_per_plot = $worksheet->get_cell($row, $columns{weight_gram_seed_per_plot}->{index})->value();
     }
+    if ($worksheet->get_cell($row,$columns{entry_number}->{index})) {
+      $entry_number = $worksheet->get_cell($row, $columns{entry_number}->{index})->value();
+    }
 
     #skip blank lines
     if (!$plot_name && !$stock_name && !$plot_number && !$block_number) {
@@ -472,6 +506,10 @@ sub _parse_with_plugin {
         print STDERR "There is more than one uniquename for this synonym $stock_name. this should not happen!\n";
       }
       $stock_name = $stock_names[0];
+    }
+
+    if ($entry_number) {
+      $seen_entry_numbers{$stock_name} = $entry_number;
     }
 
     my $key = $row;
@@ -504,7 +542,11 @@ sub _parse_with_plugin {
 
   }
   #print STDERR Dumper \%design;
-  $self->_set_parsed_data(\%design);
+  my %parsed_data = (
+    design => \%design,
+    entry_numbers => \%seen_entry_numbers
+  );
+  $self->_set_parsed_data(\%parsed_data);
 
   return 1;
 

--- a/lib/CXGN/Trial/TrialDesignStore/PhenotypingTrial.pm
+++ b/lib/CXGN/Trial/TrialDesignStore/PhenotypingTrial.pm
@@ -72,7 +72,7 @@ sub validate_design {
             next;
         }
         if (!exists($design{$stock}->{plot_number})) {
-            $error .= "Property: plot_number is required for stock" . $stock;
+            $error .= "Property: plot_number is required for stock " . $stock;
         }
 
         foreach my $property (keys %{$design{$stock}}){

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -659,6 +659,7 @@ $design_types => ()
                     <li>seedlot_name (the seedlot from where the planted seed originated. Must exist in the database)</li>
                     <li>num_seed_per_plot (number seeds per plot. Seed is transferred from seedlot mentioned in seedlot_name. Numeric)</li>
                     <li>weight_gram_seed_per_plot (weight in gram of seeds in plot. seed is transferred from seedlot mentioned in seedlot name. Numeric)</li>
+                    <li>entry_number (a trial-level entry number assigned to the stock. Numeric)</li>
                     </ul>
 
                     <b>Treatments:</b>
@@ -761,6 +762,7 @@ $design_types => ()
                     <li>seedlot_name (the seedlot from where the planted seed originated. must exist in the database)</li>
                     <li>num_seed_per_plot (number seeds per plot. seed is transferred from seedlot mentioned in seedlot_name. numeric)</li>
                     <li>weight_gram_seed_per_plot (weight in gram of seeds in plot. seed is transferred from seedlot mentioned in seedlot name. numeric)</li>
+                    <li>entry_number (a trial-level entry number assigned to the stock. Numeric)</li>
                     </ul>
 
                     <b>Treatments:</b>

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -573,11 +573,12 @@ $design_types => ()
                                         <td>seedlot_name</td>
                                         <td>num_seed_per_plot</td>
                                         <td>weight_gram_seed_per_plot</td>
+                                        <td>entry_number</td>
                                     </tr>
                                 </tbody>
                             </table>
                             <b>Header as a string:</b><br/>
-                            <p>plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot</p>
+                            <p>plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot,entry_number</p>
                         </div>
                     </&>
 
@@ -603,11 +604,12 @@ $design_types => ()
                                         <td>seedlot_name</td>
                                         <td>num_seed_per_plot</td>
                                         <td>weight_gram_seed_per_plot</td>
+                                        <td>entry_number</td>
                                     </tr>
                                 </tbody>
                             </table>
                             <b>Header as a string:</b><br/>
-                            <p>plot_name,cross_unique_id,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot</p>
+                            <p>plot_name,cross_unique_id,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot,entry_number</p>
                         </div>
                     </&>
 
@@ -633,11 +635,12 @@ $design_types => ()
                                         <td>seedlot_name</td>
                                         <td>num_seed_per_plot</td>
                                         <td>weight_gram_seed_per_plot</td>
+                                        <td>entry_number</td>
                                     </tr>
                                 </tbody>
                             </table>
                             <b>Header as a string:</b><br/>
-                            <p>plot_name,family_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot</p>
+                            <p>plot_name,family_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot,entry_number</p>
                         </div>
                     </&>
 
@@ -666,6 +669,9 @@ $design_types => ()
                     <ul>
                     <li>treatment columns (additional column(s) that specify the name of a treatment (e.g. inoculated, drought, etc). The value for each plot should be 1 if the treatment was applied or empty.)</li>
                     </ul>
+
+                    <hr />
+                    <p>Only the required fields are necessary to include in the upload template.  You may add any additional optional fields.  The fields can be in any order.</p>
                 </div>
             </div>
             <div class="modal-footer">
@@ -723,12 +729,13 @@ $design_types => ()
                                 <td>seedlot_name</td>
                                 <td>num_seed_per_plot</td>
                                 <td>weight_gram_seed_per_plot</td>
+                                <td>entry_number</td>
                             </tr>
                         </tbody>
                     </table>
 
                     <b>Header as a string:</b><br/>
-                    <p>trial_name,breeding_program,location,year,transplanting_date,design_type,description,trial_type,plot_width,plot_length,field_size,planting_date,harvest_date,plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot</p>
+                    <p>trial_name,breeding_program,location,year,transplanting_date,design_type,description,trial_type,plot_width,plot_length,field_size,planting_date,harvest_date,plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot,entry_number</p>
 
                     <b> Required fields:</b>
                     <ul>
@@ -769,6 +776,9 @@ $design_types => ()
                     <ul>
                     <li>treatment columns (additional column(s) that specify the name of a treatment (e.g. inoculated, drought, etc). the value for each plot should be 1 if the treatment was applied or empty if not applied.)</li>
                     </ul>
+
+                    <hr />
+                    <p>Only the required fields are necessary to include in the upload template.  You may add any additional optional fields.  The fields can be in any order.</p>
 
                 </div>
             </div>

--- a/t/unit_fixture/CXGN/Trial/ParseUpload.t
+++ b/t/unit_fixture/CXGN/Trial/ParseUpload.t
@@ -45,9 +45,8 @@ for my $extension ("xls", "xlsx") {
     $results = $p->parse();
     $errors = $p->get_parse_errors();
     #print STDERR Dumper $errors;
-    ok($errors->{'error_messages'}->[0], 'Cell J1: seedlot_name is missing from the header. (Header is required, but values are optional)');
-    ok($errors->{'error_messages'}->[1], 'Cell K1: num_seed_per_plot is missing from the header. (Header is required, but values are optional)');
-    ok(scalar(@{$errors->{'error_messages'}}) == 4, 'check that accessions not in db and file missing seedlot_name and num_seed_per_plot and weight_gram_seed_per_plot headers');
+    ok($errors->{'error_messages'}->[0] =~ /The following entry names are not in the database as uniquenames or synonyms/, 'check that accessions not in db');
+    ok(scalar(@{$errors->{'error_messages'}}) == 1, 'check that accessions not in db');
     ok(scalar(@{$errors->{'missing_stocks'}}) == 8, 'check that accessions not in db');
 
     $p = CXGN::Trial::ParseUpload->new({ filename => "t/data/genotype_trial_upload/CASSAVA_GS_74Template_messed_up_trial_name.csv", chado_schema => $f->bcs_schema() });

--- a/t/unit_fixture/CXGN/Uploading/TrialUpload.t
+++ b/t/unit_fixture/CXGN/Uploading/TrialUpload.t
@@ -270,7 +270,8 @@ for my $extension ("xls", "xlsx") {
 	#parse uploaded file with wrong plugin
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $file_name);
 	$parser->load_plugin('TrialExcelFormat');
-	$parsed_data = $parser->parse()->{'design'};
+	my $rtn = $parser->parse();
+	$parsed_data = $rtn->{'design'};
 	ok(!$parsed_data, "Check if parse validate excel fails for igd parser");
 	ok($parser->has_parse_errors(), "Check that parser errors occur");
 
@@ -549,7 +550,8 @@ for my $extension ("xls", "xlsx") {
 	#parse uploaded file with appropriate plugin
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $archived_filename_with_path);
 	$parser->load_plugin('TrialExcelFormat');
-	$parsed_data = $parser->parse()->{'design'};
+	$rtn = $parser->parse();
+	$parsed_data = $rtn->{'design'};
 	ok($parsed_data, "Check if parse validate excel file works");
 	ok(!$parser->has_parse_errors(), "Check that parse returns no errors");
 
@@ -1247,7 +1249,8 @@ for my $extension ("xls", "xlsx") {
 
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $management_factor_archived_filename_with_path);
 	$parser->load_plugin('TrialExcelFormat');
-	$parsed_data = $parser->parse()->{'design'};
+	$rtn = $parser->parse();
+	$parsed_data = $rtn->{'design'};
 	ok($parsed_data, "Check if parse validate excel file works");
 	ok(!$parser->has_parse_errors(), "Check that parse returns no errors");
 

--- a/t/unit_fixture/CXGN/Uploading/TrialUpload.t
+++ b/t/unit_fixture/CXGN/Uploading/TrialUpload.t
@@ -89,7 +89,7 @@ for my $extension ("xls", "xlsx") {
 	#parse uploaded file with appropriate plugin
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $archived_filename_with_path);
 	$parser->load_plugin('TrialExcelFormat');
-	$parsed_data = $parser->parse();
+	$parsed_data = $parser->parse()->{'design'};
 	ok($parsed_data, "Check if parse validate excel file works");
 	ok(!$parser->has_parse_errors(), "Check that parse returns no errors");
 
@@ -270,7 +270,7 @@ for my $extension ("xls", "xlsx") {
 	#parse uploaded file with wrong plugin
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $file_name);
 	$parser->load_plugin('TrialExcelFormat');
-	$parsed_data = $parser->parse();
+	$parsed_data = $parser->parse()->{'design'};
 	ok(!$parsed_data, "Check if parse validate excel fails for igd parser");
 	ok($parser->has_parse_errors(), "Check that parser errors occur");
 
@@ -549,7 +549,7 @@ for my $extension ("xls", "xlsx") {
 	#parse uploaded file with appropriate plugin
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $archived_filename_with_path);
 	$parser->load_plugin('TrialExcelFormat');
-	$parsed_data = $parser->parse();
+	$parsed_data = $parser->parse()->{'design'};
 	ok($parsed_data, "Check if parse validate excel file works");
 	ok(!$parser->has_parse_errors(), "Check that parse returns no errors");
 
@@ -1247,7 +1247,7 @@ for my $extension ("xls", "xlsx") {
 
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $management_factor_archived_filename_with_path);
 	$parser->load_plugin('TrialExcelFormat');
-	$parsed_data = $parser->parse();
+	$parsed_data = $parser->parse()->{'design'};
 	ok($parsed_data, "Check if parse validate excel file works");
 	ok(!$parser->has_parse_errors(), "Check that parse returns no errors");
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This updates the trial upload templates to allow for flexible column headers:
- only the required columns need to be included
- optional columns can be added as needed
- columns can be in any order

It also adds support for an additional `entry_number` column which will assign entry numbers to accessions for the trial.  (Entry numbers were previously added with PR #3770 as a separate upload).

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
