### PR TITLE
Label Designer: add synonyms

### DIFF
--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -675,7 +675,7 @@ function updateFields(data_type, source_id, data_level){
 
     jQuery.ajax({
         url: '/tools/label_designer/retrieve_longest_fields',
-        timeout: 60000,
+        timeout: 300000,
         method: 'POST',
         data: {
             data_type: data_type,

--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -109,6 +109,29 @@ my %ADDITIONAL_LIST_DATA = (
             }
 
             return \%values;
+        },
+
+        'accession synonyms' => sub {
+            my ($c, $schema, $dbh, $list_id, $list_item_ids, $list_item_names, $list_item_db_ids) = @_;
+            my %values;
+            my $type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
+
+            my $rs = $schema->resultset("Stock::Stockprop")->search({
+                'me.stock_id' => { in => $list_item_db_ids },
+                'me.type_id' => $type_id
+            });
+            while ( my $row = $rs->next() ) {
+                my $accession_id = $row->stock_id();
+                my $synonym = $row->value();
+                for my $index (0 .. $#$list_item_db_ids ) {
+                    if ( $list_item_db_ids->[$index] eq $accession_id ) {
+                        my $id = $list_item_ids->[$index];
+                        $values{$id} = $values{$id} ? $values{$id} . ", " . $synonym : $synonym;
+                    }
+                }
+            }
+
+            return \%values;
         }
 
     },
@@ -731,11 +754,11 @@ sub get_trial_design {
     my $trial_ids = shift;
     my $type = shift;
     my %selected_columns = (
-        plate => {genotyping_project_name=>1,genotyping_facility=>1,trial_name=>1,acquisition_date=>1,exported_tissue_sample_name=>1,tissue_sample_name=>1,well_A01=>1,row_number=>1,col_number=>1,source_observation_unit_name=>1,accession_name=>1,accession_id=>1,pedigree=>1,dna_person=>1,notes=>1,tissue_type=>1,extraction=>1,concentration=>1,volume=>1,is_blank=>1,year=>1,location_name=>1},
-        plots => {plot_name=>1,plot_id=>1,accession_name=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,rep_number=>1,range_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1},
-        plants => {plant_name=>1,plant_id=>1,subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,range_number=>1,rep_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,plant_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1},
-        subplots => {subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,rep_number=>1,range_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1},
-        field_trial_tissue_samples => {tissue_sample_name=>1,tissue_sample_id=>1,plant_name=>1,plant_id=>1,subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,range_number=>1,rep_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,plant_number=>1,tissue_sample_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1}
+        plate => {genotyping_project_name=>1,genotyping_facility=>1,trial_name=>1,acquisition_date=>1,exported_tissue_sample_name=>1,tissue_sample_name=>1,well_A01=>1,row_number=>1,col_number=>1,source_observation_unit_name=>1,accession_name=>1,synonyms=>1,accession_id=>1,pedigree=>1,dna_person=>1,notes=>1,tissue_type=>1,extraction=>1,concentration=>1,volume=>1,is_blank=>1,year=>1,location_name=>1},
+        plots => {plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,rep_number=>1,range_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1},
+        plants => {plant_name=>1,plant_id=>1,subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,range_number=>1,rep_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,plant_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1},
+        subplots => {subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,rep_number=>1,range_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1},
+        field_trial_tissue_samples => {tissue_sample_name=>1,tissue_sample_id=>1,plant_name=>1,plant_id=>1,subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,range_number=>1,rep_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,plant_number=>1,tissue_sample_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1}
     );
     my %unique_identifier = (
         plate => 'tissue_sample_name',

--- a/t/lib/SGN/Test/WWW/WebDriver.pm
+++ b/t/lib/SGN/Test/WWW/WebDriver.pm
@@ -202,7 +202,26 @@ sub download_linked_file {
     system("wget --header \"Cookie: sgn_session_id=$token\" --directory-prefix=/tmp $href");
 
 
-}    
+}
+
+
+sub wait_for_working_dialog {
+    my $self = shift;
+    my $max = shift || 300;
+
+    sleep(3);
+
+    my $is_hidden = 0;
+    my $count = 0;
+    print STDERR "... waiting for working dialog ...\n";
+    while ( !$is_hidden && $count < $max ) {
+        my $wd = $self->find_element("working_modal", "id");
+        $is_hidden = $wd->is_hidden();
+        $count++;
+        sleep(1);
+    }
+    print STDERR "... working dialog dismissed ...\n";
+}
 
 1;
    

--- a/t/selenium2/tools/label_designer.t
+++ b/t/selenium2/tools/label_designer.t
@@ -35,9 +35,8 @@ $t->while_logged_in_as("submitter", sub {
         '//select[@id="label_designer_data_level"]/option[@value="plots"]',
         "xpath",
         "select a data level")->click();
-    sleep(1);
 
-    sleep(12);
+    $t->wait_for_working_dialog();
 
     $t->driver->find_element("select_datasource_button","id", "click next")->click();
 
@@ -241,7 +240,7 @@ $t->while_logged_in_as("submitter", sub {
         "xpath",
         "select a data level")->click();
 
-    sleep(12);
+    $t->wait_for_working_dialog();
 
     $t->driver->find_element("select_datasource_button","id", "click next")->click();
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds accession synonyms as a possible label property when the data source is a list of accessions, a single field trial, or a list of field trials.

It also adds the `wait_for_working_dialog` function to the `SGN::Test::WWW::WebDriver` class that can be used to pause a selenium test to wait for the working dialog to be dismissed (rather than setting an arbitrary sleep time).

Fixes #4964 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
