### PR TITLE
Generic Excel File Parser: fix cell value assignment

### DIFF
--- a/lib/CXGN/File/Parse/Plugin/Excel.pm
+++ b/lib/CXGN/File/Parse/Plugin/Excel.pm
@@ -66,7 +66,7 @@ sub parse {
     for my $col ( 0 .. $col_max ) {
       my $hv = $rtn{columns}->[$col];
       my $c = $worksheet->get_cell($row, $col);
-      my $v = $c->value() if $c;
+      my $v = $c ? $c->value() : undef;
       $v = $super->clean_value($v, $hv);
       $row_info{$hv} = $v;
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes a bad bug in the generic excel file parser that could result in a previous column's value being assigned to another column!


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
