### PR TITLE
upgrade packages to fix warnings

### DIFF
--- a/js/build.webpack.config.js
+++ b/js/build.webpack.config.js
@@ -40,7 +40,7 @@ module.exports = {
                         sourceType: "unambiguous",
                         presets: [['@babel/preset-env',{
                           "useBuiltIns": "usage",
-			  "corejs": "3.38"
+			  "corejs": "3"
                         }]]
                     }
                 },{

--- a/js/build.webpack.config.js
+++ b/js/build.webpack.config.js
@@ -39,8 +39,8 @@ module.exports = {
                     options: {
                         sourceType: "unambiguous",
                         presets: [['@babel/preset-env',{
-                          "useBuiltIns": "usage",
-			  "corejs": "3"
+                            "useBuiltIns": "usage",
+			                "corejs": "3"
                         }]]
                     }
                 },{

--- a/js/build.webpack.config.js
+++ b/js/build.webpack.config.js
@@ -39,7 +39,8 @@ module.exports = {
                     options: {
                         sourceType: "unambiguous",
                         presets: [['@babel/preset-env',{
-                          useBuiltIns: 'usage'
+                          "useBuiltIns": "usage",
+			  "corejs": "3.38"
                         }]]
                     }
                 },{

--- a/js/package.json
+++ b/js/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.3.3",
-    "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.3.1",
     "babel-loader": "^8.0.5",
     "deepmerge": "^2.2.1",
@@ -24,7 +23,7 @@
     "loader-utils": "^1.2.3",
     "nock": "^10.0.6",
     "node-fetch": "^2.3.0",
-    "requirejs": "2.3.6",
+    "requirejs": "2.3.7",
     "save-svg-as-png": "^1.4.17",
     "source-map-support": "^0.5.10",
     "tape": "^4.10.1",
@@ -40,7 +39,9 @@
     "d3-path": "^1.0.9",
     "d3-sankey": "^0.12.3",
     "d3-shape": "^1.3.7",
-    "internmap": "^1.0.0"
+    "internmap": "^1.0.0",
+    "core-js": "^3.38",
+    "regenerator": "latest"
   },
   "engines": {
     "node": ">=10.6.0",

--- a/js/package.json
+++ b/js/package.json
@@ -14,9 +14,9 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.3.3",
-    "@babel/preset-env": "^7.3.1",
-    "babel-loader": "^8.0.5",
+    "@babel/core": "^7",
+    "@babel/preset-env": "^7",
+    "babel-loader": "^8",
     "deepmerge": "^2.2.1",
     "del": "^3.0.0",
     "jsdom": "^16",
@@ -40,7 +40,7 @@
     "d3-sankey": "^0.12.3",
     "d3-shape": "^1.3.7",
     "internmap": "^1.0.0",
-    "core-js": "^3.38",
+    "core-js": "^3",
     "regenerator": "latest"
   },
   "engines": {


### PR DESCRIPTION
dependabot "requirejs" vulnerability - update version

core-js@2 no longer maintained, used by babel
deprecated core-js@2.6.12: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. 

babel/polyfill deprecated - function replaced by core-js@3
deprecated @babel/polyfill@7.12.1: 🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
