### PR TITLE
wizard add marker filter

### DIFF
--- a/js/source/entries/wizard.js
+++ b/js/source/entries/wizard.js
@@ -176,7 +176,7 @@ export function WizardSetup(main_id) {
     var dat = new WizardDatasets(d3.select(main_id).select(".wizard-datasets").node(), wiz);
 
     var lo = new CXGN.List();
-    jQuery('#wizard-download-genotypes-marker-set-list-id').html(lo.listSelect('wizard-download-genotypes-marker-set-list-id', ['markers'], 'Select a markerset', 'refresh', undefined));
+    jQuery('#wizard-download-genotypes-marker-set-list-id').html(lo.listSelect('wizard-download-genotypes-marker-set-list-id', ['markers'], 'Select a list', 'refresh', undefined));
 
     return {
         wizard: wiz,

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -1147,15 +1147,22 @@ sub download_gbs_action : Path('/breeders/download_gbs_action') {
     $return_only_first_genotypeprop_for_stock = $c->req->param('include_duplicate_genotypes') eq 'true' ? 0 : 1;
     my $marker_set_list_id = $c->req->param('marker_set_list_id');
 
+    my $o;
     my @marker_name_list;
     if ($marker_set_list_id) {
         my $list = CXGN::List->new({ dbh => $schema->storage->dbh, list_id => $marker_set_list_id });
         my $elements = $list->elements();
 
         foreach my $e (@$elements) {
-            my $o = decode_json $e;
-            if (exists($o->{marker_name})) {
-                push @marker_name_list, $o->{marker_name};
+            eval {
+                $o = decode_json($e);
+            };
+            if ($@) {    #simple list
+                push @marker_name_list, $e;
+            } else {    #json list
+                if (exists($o->{marker_name})) {
+                    push @marker_name_list, $o->{marker_name};
+                }
             }
         }
     }

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -214,7 +214,7 @@ $dataset_id => undef
                 </tr>
                 <tr>
                     <td colspan="6">
-                        <span>Markerset Filter</span>
+                        <span>Marker / Markerset Filter</span>
                         <select class="wizard-download-genotypes-marker-set-list-id form-control input-sm" id="wizard-download-genotypes-marker-set-list-id"></select>
                     </td>
                     <td colspan="6">


### PR DESCRIPTION
Wizard currently filters genotype data by markerset
These changes allow it to also filter by list of markers
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
