### PR TITLE
Native Pheno Search: include missing data when trait is selected

### DIFF
--- a/lib/CXGN/Phenotypes/Search/Native.pm
+++ b/lib/CXGN/Phenotypes/Search/Native.pm
@@ -375,7 +375,7 @@ sub search {
     }
     if ($self->trait_list && scalar(@{$self->trait_list})>0) {
         my $trait_sql = _sql_from_arrayref($self->trait_list);
-        push @where_clause, "cvterm.cvterm_id in ($trait_sql)";
+        push @where_clause, "(cvterm.cvterm_id in ($trait_sql) OR cvterm.cvterm_id IS NULL)";
     }
     if ($self->location_list && scalar(@{$self->location_list})>0) {
         my $arrayref = $self->location_list;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This updates the Native phenotype search to include all rows when one or more traits are selected.  Before, if a trait was used in the filter, the search would only include rows that had an observed value for that trait.  Now, rows without a value for that trait will also be included (which is what the MatView search returns).

Fixes #5084 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
