### PR TITLE
Trial Detail Page: preserve line breaks in trial description

### DIFF
--- a/mason/breeders_toolbox/trial/trial_details.mas
+++ b/mason/breeders_toolbox/trial/trial_details.mas
@@ -161,13 +161,11 @@ $latest_trial_activity => undef
 
             <tr><td><b>Description</b></td>
                 <td>
-                    <div id="trial_description">
 % if ($trial_description) {
-%  print "$trial_description";
+%  print "<div id='trial_description' style='white-space: pre-wrap;'>$trial_description</div>";
 % } else {
-%  print "<span class='text-danger'>[No Description]</span>";
+%  print "<div id='trial_description'><span class='text-danger'>[No Description]</span></div>";
 % }
-                    </div>
                 </td>
             </tr>
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This preserves line breaks in the trial description box on the trial detail page


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
