### PR TITLE
Fix plants being allocated incorrectly in greenhouse/nursery trial design

### DIFF
--- a/lib/CXGN/Trial/TrialDesign/Plugin/greenhouse.pm
+++ b/lib/CXGN/Trial/TrialDesign/Plugin/greenhouse.pm
@@ -8,7 +8,7 @@ sub create_design {
     my $order = 1;
     my %greenhouse_design;
     my @num_plants = @{ $self->get_greenhouse_num_plants() };
-    my @accession_list = sort @{ $self->get_stock_list() };
+    my @accession_list = @{ $self->get_stock_list() };
     my $trial_name = $self->get_trial_name;
     my %num_accession_hash;
     @num_accession_hash{@accession_list} = @num_plants;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
This removes a sort on the stock list that is causing plants in greenhouse trials to be allocated to the wrong stocks during trials design.

<!-- If there are relevant issues, link them here: -->
Closes #5080

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
