### PR TITLE
fix kinship and cluster result load from result url

### DIFF
--- a/js/source/legacy/solGS/cluster.js
+++ b/js/source/legacy/solGS/cluster.js
@@ -826,9 +826,7 @@ jQuery.fn.doesExist = function () {
 
 jQuery(document).ready(function () {
   var url = location.pathname;
-  console.log(`url: ${url}`)
-  console.log(`url: ${url.match(/pca\/analysis/)}`)
-
+ 
   if (url.match(/cluster\/analysis/)) {
     var canvas = solGS.cluster.canvas;
     var clusterMsgDiv = solGS.cluster.clusterMsgDiv;

--- a/js/source/legacy/solGS/cluster.js
+++ b/js/source/legacy/solGS/cluster.js
@@ -1063,16 +1063,9 @@ jQuery.fn.doesExist = function () {
 
 jQuery(document).ready(function () {
   var url = location.pathname;
-<<<<<<< HEAD
  
   if (url.match(/cluster\/analysis/)) {
     var canvas = solGS.cluster.canvas;
-=======
-  var canvas = solGS.cluster.canvas;
-
-  if (url.match(/cluster\/analysis/)) {
-    solGS.cluster.populateClusterMenu();
->>>>>>> master
     var clusterMsgDiv = solGS.cluster.clusterMsgDiv;
 
     var clusterArgs = solGS.cluster.getClusterArgsFromUrl();

--- a/js/source/legacy/solGS/cluster.js
+++ b/js/source/legacy/solGS/cluster.js
@@ -826,9 +826,10 @@ jQuery.fn.doesExist = function () {
 
 jQuery(document).ready(function () {
   var url = location.pathname;
+  console.log(`url: ${url}`)
+  console.log(`url: ${url.match(/pca\/analysis/)}`)
 
   if (url.match(/cluster\/analysis/)) {
-    solGS.cluster.populateClusterMenu();
     var canvas = solGS.cluster.canvas;
     var clusterMsgDiv = solGS.cluster.clusterMsgDiv;
 

--- a/js/source/legacy/solGS/kinship.js
+++ b/js/source/legacy/solGS/kinship.js
@@ -385,13 +385,10 @@ jQuery(document).ready(function () {
     var runKinshipBtnId = e.target.id;
     if (runKinshipBtnId.match(/run_kinship/)) {
       var kinshipArgs = solGS.kinship.getKinshipArgs();
-      console.log(`kinshipArgs: ${JSON.stringify(kinshipArgs)}`)
       var kinshipPopId = kinshipArgs.kinship_pop_id;
       if (!kinshipPopId) {
         kinshipArgs = solGS.kinship.getSelectedPopKinshipArgs(runKinshipBtnId);
       }
-
-      console.log(`kinshipArgs: ${JSON.stringify(kinshipArgs)}`)
 
       kinshipPopId = kinshipArgs.kinship_pop_id;
       var protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("kinship_div");
@@ -415,7 +412,7 @@ jQuery(document).ready(function () {
         .checkCachedKinship(kinshipUrl, kinshipArgs)
         .done(function (res) {
           if (res.data) {
-            jQuery(this.kinshipMsgDiv).html("Generating heatmap... please wait...").show();
+            jQuery(kinshipMsgDiv).html("Generating heatmap... please wait...").show();
 
             kinshipPlotDivId = `${kinshipPlotDivId}_${res.kinship_file_id}`;
 
@@ -494,7 +491,7 @@ jQuery(document).ready(function () {
                         }
                       })
                       .fail(function () {
-                        jQuery(this.kinshipMsgDiv)
+                        jQuery(kinshipMsgDiv)
                           .html("Error occured running the kinship.")
                           .show()
                           .fadeOut(8400);
@@ -530,13 +527,31 @@ jQuery(document).ready(function () {
 
   if (url.match(/kinship\/analysis/)) {
     var args = solGS.kinship.getKinshipArgsFromUrl();
+    console.log(`kinsip url args: ${JSON.stringify(args)}`)
     if (args.kinship_pop_id) {
       if (args.data_structure) {
         args["kinship_pop_id"] = args.data_structure + "_" + args.kinship_pop_id;
       }
-      solGS.kinship.checkCachedKinship(url, args);
-    }
+      solGS.kinship.checkCachedKinship(url, args).done(function (res) {
+        if (res.data) {
+          var kinshipMsgDiv = solGS.kinship.kinshipMsgDiv;
+          var canvas = solGS.kinship.canvas;
+
+          jQuery(kinshipMsgDiv).html("Generating heatmap... please wait...").show();
+          jQuery(`${canvas} .multi-spinner-container`).show();
+
+          var kinshipPlotDivId = solGS.kinship.kinshipPlotDivPrefix;
+          kinshipPlotDivId = `${kinshipPlotDivId}_${res.kinship_file_id}`;
+
+          var links = solGS.kinship.addDowloandLinks(res);
+          solGS.heatmap.plot(res.data, canvas, kinshipPlotDivId, links);
+
+          jQuery(`${canvas} .multi-spinner-container`).hide();
+          jQuery(kinshipMsgDiv).empty();
+        }
+    })
   }
+}
 });
 
 jQuery(document).ready(function () {

--- a/js/source/legacy/solGS/kinship.js
+++ b/js/source/legacy/solGS/kinship.js
@@ -204,7 +204,6 @@ solGS.kinship = {
 
   displayKinshipPopsTable: function (tableId, data) {
 
-    console.log(`displayKinshipPopsTable data: ${data}`)
     var table = jQuery(`#${tableId}`).DataTable({
       'searching': true,
       'ordering': true,
@@ -527,7 +526,6 @@ jQuery(document).ready(function () {
 
   if (url.match(/kinship\/analysis/)) {
     var args = solGS.kinship.getKinshipArgsFromUrl();
-    console.log(`kinsip url args: ${JSON.stringify(args)}`)
     if (args.kinship_pop_id) {
       if (args.data_structure) {
         args["kinship_pop_id"] = args.data_structure + "_" + args.kinship_pop_id;
@@ -558,8 +556,8 @@ jQuery(document).ready(function () {
   var kinshipCanvas = solGS.kinship.canvas;
   jQuery(kinshipCanvas).on("click", "a", function (e) {
     var buttonId = e.target.id;
-    var kinPlotId = buttonId.replace(/download_/, "");
-    saveSvgAsPng(document.getElementById("#" + kinPlotId), kinPlotId + ".png", { scale: 1 });
+    var kinshipPlotId = buttonId.replace(/download_/, "");
+    saveSvgAsPng(document.getElementById("#" + kinshipPlotId), kinshipPlotId + ".png", { scale: 1 });
   });
 });
 

--- a/lib/SGN/Controller/solGS/Feedback.pm
+++ b/lib/SGN/Controller/solGS/Feedback.pm
@@ -32,7 +32,7 @@ sub message_content {
     
     my $msg = "<p>Your $job_type job is submitted.</p>"
       . "<p>You will receive an email when it is completed,  " 
-      . "which may take a few hours. If the email is not in your inbox, "
+      . "which may take upto a few hours. If the email is not in your inbox, "
       . "please check also your spam folder.</p>"
       . "<p>Alternatively, you can also check the status of the job in $profile_link."
       . "<p>$back_link</p>";

--- a/lib/SGN/Controller/solGS/Feedback.pm
+++ b/lib/SGN/Controller/solGS/Feedback.pm
@@ -32,7 +32,7 @@ sub message_content {
     
     my $msg = "<p>Your $job_type job is submitted.</p>"
       . "<p>You will receive an email when it is completed,  " 
-      . "which may take upto a few hours. If the email is not in your inbox, "
+      . "which may take up to a few hours. If the email is not in your inbox, "
       . "please check also your spam folder.</p>"
       . "<p>Alternatively, you can also check the status of the job in $profile_link."
       . "<p>$back_link</p>";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
-- fixes loading issue for kinship and cluster plots from results url. Users following the link to results page from the email sent to them had to click run analysis again to view the output plot. Now, results are automatically loaded.


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
