### PR TITLE
fix an issue in the stock merge function

### DIFF
--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -1981,7 +1981,7 @@ sub merge {
             print STDERR "Moving stock_dbxref relationships from $other_stock_id to stock ".$self->stock_id()."\n";
         }
         else {
-            print STDERR "Not moving stock_dbxref because it alredy exists for that stock (".$self->stock_id().")\n";
+            print STDERR "Not moving stock_dbxref because it already exists for that stock (".$self->stock_id().")\n";
         }
     }
 

--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -746,7 +746,7 @@ sub exists_in_database {
 	    return 0;
 	}
     }
-    return undef;
+    return;
 }
 
 
@@ -769,7 +769,7 @@ sub get_organism {
     if ($bcs_stock) {
         return $bcs_stock->organism;
     }
-    return undef;
+    return;
 }
 
 
@@ -791,7 +791,7 @@ sub get_species {
         return $organism->species;
     }
     else {
-	return undef;
+	return;
     }
 }
 
@@ -813,7 +813,7 @@ sub get_genus {
         return $organism->genus;
     }
     else {
-	return undef;
+	return;
     }
 }
 
@@ -2106,7 +2106,7 @@ sub merge {
     Other stock deleted: $other_stock_deleted.
 COUNTS
 
-	return undef;
+	return;
 }
 
 =head2 delete


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
When two stocks have the same dbxref (in the table stock_dbxref) then the transfer of the dbxrefs to the other stock will violate a unique constraint on that table. The fix includes a check if they have the same dbxrefs and if present, skips the merge of the dbxrefs 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
