### PR TITLE
Create pheno files: show error message if no trait list is selected

### DIFF
--- a/mason/breeders_toolbox/trial/create_datacollector_dialog.mas
+++ b/mason/breeders_toolbox/trial/create_datacollector_dialog.mas
@@ -69,6 +69,10 @@ function create_DataCollector() {
     if (! trait_list_id == "") {
         trait_list = JSON.stringify(list.getList(trait_list_id));
     }
+    else {
+        alert("You must select a Trait List first");
+        return;
+    }
     var trial_stock_type = "<% $trial_stock_type %>";
 
     jQuery.ajax({

--- a/mason/breeders_toolbox/trial/create_spreadsheet_dialog.mas
+++ b/mason/breeders_toolbox/trial/create_spreadsheet_dialog.mas
@@ -180,6 +180,10 @@ function create_phenotype_spreadsheet() {
     if (! trait_list_id == "") {
         trait_list = JSON.stringify(list.getList(trait_list_id));
     }
+    else {
+        alert("You must select a Trait List first");
+        return;
+    }
 %  if ($trial_id){
         var trial_ids = [<% $trial_id %>];
 %  } else {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This improves an error message when creating a phenotype spreadsheet/datacollector file and the user hasn't selected a trait list first.

Fixes #5132 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
