### PR TITLE
Seedlot Search: fix filter by count or weight

### DIFF
--- a/lib/CXGN/Stock/Seedlot.pm
+++ b/lib/CXGN/Stock/Seedlot.pm
@@ -409,13 +409,15 @@ sub list_seedlots {
 
     if ($minimum_count || $minimum_weight || $quality || $only_good_quality || $box_name) {
         if ($minimum_count) {
-	    print STDERR "Minimum count $minimum_count\n";
-            $search_criteria{'stockprops.value' }  = { '>=' => $minimum_count };
-            $search_criteria{'stockprops.type_id' }  = $current_count_cvterm_id;
+            print STDERR "Minimum count $minimum_count\n";
+            $search_criteria{'stockprops.value'} = { '<>' => 'NA' };
+            $search_criteria{'stockprops.value::numeric'}  = { '>=' => $minimum_count };
+            $search_criteria{'stockprops.type_id'}  = $current_count_cvterm_id;
         } elsif ($minimum_weight) {
-	    print STDERR "Minimum weight $minimum_weight\n";
-            $search_criteria{'stockprops.value' }  = { '>=' => $minimum_weight };
-            $search_criteria{'stockprops.type_id' }  = $current_weight_cvterm_id;
+            print STDERR "Minimum weight $minimum_weight\n";
+            $search_criteria{'stockprops.value'} = { '<>' => 'NA' };
+            $search_criteria{'stockprops.value::numeric'}  = { '>=' => $minimum_weight };
+            $search_criteria{'stockprops.type_id'}  = $current_weight_cvterm_id;
         }
 	if ($quality) {
 	    print STDERR "Quality $quality\n";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes the Seedlot search when filtering by either count or weight by filtering out NAs and then casting the stockprop.value to numeric.

Fixes #5127 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
