### PR TITLE
VCF upload allow new markers to existing protocol

### DIFF
--- a/lib/SGN/Controller/AJAX/GenotypesVCFUpload.pm
+++ b/lib/SGN/Controller/AJAX/GenotypesVCFUpload.pm
@@ -568,9 +568,10 @@ sub upload_genotype_verify_POST : Args(0) {
                     foreach my $error ( sort @mismatch_marker_names) {
                         $marker_name_error .= $error."<br>";
                     }
-
-                    $c->stash->{rest} = { error => "These marker names in your file are not in the selected protocol. $marker_name_error"};
-                    $c->detach();
+                    if (!$accept_warnings){
+                        $c->stash->{rest} = { error => "These marker names in your file are not in the selected protocol. $marker_name_error"};
+                        $c->detach();
+		    }
                 }
 
 

--- a/mason/site/header/head.mas
+++ b/mason/site/header/head.mas
@@ -32,6 +32,7 @@
 
 <& /util/import_javascript.mas, classes => [ "jquery", "jqueryui", "sgn", "jquery.simpletooltip", "jquery.cookie", "CXGN.Effects", "CXGN.Dataset", "CXGN.Page.FormattingHelpers", "CXGN.UserPrefs", "CXGN.Page.Toolbar", "CXGN.List", "CXGN.Login", "bootstrap_min", "CXGN.BreedersToolbox.HTMLSelect", "bootstrap-toggle_min"] &>
 % if ($c->config->{production_server}) {
+    <& /util/import_javascript.mas, classes => [ "jquery.dataTables-min" ] &>
 % } else {
     <& /util/import_javascript.mas, classes => [ "jquerymigrate", "jquery.dataTables" ] &>
 % }

--- a/mason/site/header/head.mas
+++ b/mason/site/header/head.mas
@@ -32,7 +32,6 @@
 
 <& /util/import_javascript.mas, classes => [ "jquery", "jqueryui", "sgn", "jquery.simpletooltip", "jquery.cookie", "CXGN.Effects", "CXGN.Dataset", "CXGN.Page.FormattingHelpers", "CXGN.UserPrefs", "CXGN.Page.Toolbar", "CXGN.List", "CXGN.Login", "bootstrap_min", "CXGN.BreedersToolbox.HTMLSelect", "bootstrap-toggle_min"] &>
 % if ($c->config->{production_server}) {
-    <& /util/import_javascript.mas, classes => [ "jquerymigrate-min", "jquery.dataTables-min" ] &>
 % } else {
     <& /util/import_javascript.mas, classes => [ "jquerymigrate", "jquery.dataTables" ] &>
 % }

--- a/mason/site/header/head.mas
+++ b/mason/site/header/head.mas
@@ -32,7 +32,7 @@
 
 <& /util/import_javascript.mas, classes => [ "jquery", "jqueryui", "sgn", "jquery.simpletooltip", "jquery.cookie", "CXGN.Effects", "CXGN.Dataset", "CXGN.Page.FormattingHelpers", "CXGN.UserPrefs", "CXGN.Page.Toolbar", "CXGN.List", "CXGN.Login", "bootstrap_min", "CXGN.BreedersToolbox.HTMLSelect", "bootstrap-toggle_min"] &>
 % if ($c->config->{production_server}) {
-    <& /util/import_javascript.mas, classes => [ "jquery.dataTables-min" ] &>
+    <& /util/import_javascript.mas, classes => [ "jquerymigrate-min", "jquery.dataTables-min" ] &>
 % } else {
     <& /util/import_javascript.mas, classes => [ "jquerymigrate", "jquery.dataTables" ] &>
 % }


### PR DESCRIPTION
There is no code bug but there are lots of javascript warnings that led me to believe there was an error. My problem was when I tried to add a genotype project to existing protocol it failed because there was a new marker in the new project. This pull request will ignore those warnings when "Ignore any possible warnings" is selected during file upload.

I also remove the jquerymigrate module on production machines. This will eliminate many javascript warnings. The upload scripts use legacy javascript that have been deprecated for many years like js/source/legacy/jquery/iframe-post-form.js


#5111 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
