### PR TITLE
Add extra checks for non-numeric values in weight and count fields during seedlot creation

### DIFF
--- a/mason/breeders_toolbox/add_seedlot_dialogs.mas
+++ b/mason/breeders_toolbox/add_seedlot_dialogs.mas
@@ -207,7 +207,9 @@ jQuery(document).ready(function(){
         if (name == '') { alert("Please provide a name"); return; }
         else if (location == '') { alert("Please provide a location"); return; }
         else if (box_name == '') { alert("Please provide a box name"); return; }
-        else if (amount == '' && weight == '') { alert("Please provide an seed count amount or a weight in grams!"); return; }
+        else if (amount == '' && weight == '') { alert("Please provide a seed count amount or a weight in grams!"); return; }
+        else if (isNaN(amount)) { alert("If inputting a seed count amount, it must be a numeric value."); return; }
+        else if (isNaN(weight)) { alert("If inputting a weight, it must be a numeric value."); return; }
         else if (breeding_program_id == '') { alert("Please select a breeding program"); return; }
         else if (accession_uniquename == '' && cross_uniquename == '') {
             alert("Please provide an accession name or a cross unique id as the content of the seedlot."); return;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Gives user an error message if they enter non-numeric values in the seed amount or weight fields, rather than allowing the seedlot to be created.

<!-- If there are relevant issues, link them here: -->

Closes #5149

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
