### PR TITLE
add protocol checks for vcf upload using scripts

### DIFF
--- a/bin/load_genotypes_vcf_cxgn_postgres.pl
+++ b/bin/load_genotypes_vcf_cxgn_postgres.pl
@@ -68,6 +68,7 @@ Can use a transposedVCF or normal VCF
 =cut
 
 use strict;
+use warnings;
 
 use Getopt::Std;
 use Data::Dumper;
@@ -171,7 +172,7 @@ if ($opt_c eq 'VCF' && !$opt_w) {
     open (my $Fout, ">", $opt_o) || die "Can't open file $opt_o\n";
     open (my $F, "<", $file) or die "Can't open file $file \n";
     my @outline;
-    my $lastcol;
+    my $lastcol = 0;
     while (<$F>) {
         if ($_ =~ m/^\##/) {
             print $Fout $_;
@@ -245,7 +246,7 @@ if ($protocol_id){
 
 my $organism_q = "SELECT organism_id FROM organism WHERE species = ?";
 my @found_organisms;
-my $h = $schema->storage->dbh()->prepare($organism_q);
+$h = $schema->storage->dbh()->prepare($organism_q);
 $h->execute($organism_species);
 while (my ($organism_id) = $h->fetchrow_array()){
     push @found_organisms, $organism_id;
@@ -341,7 +342,7 @@ if (scalar(keys %$genotype_info) > 0) {
         die;
     }
     if (scalar(@{$verified_errors->{warning_messages}}) > 0){
-        my $warning_string = join ', ', @{$verified_errors->{warning_messages}};
+        my $warning_string = join "\n", @{$verified_errors->{warning_messages}};
         if (!$opt_A){
             print STDERR Dumper $warning_string;
             print STDERR "You can accept these warnings and continue with store if you use -A\n";
@@ -376,12 +377,9 @@ if (scalar(keys %$genotype_info) > 0) {
         }
 
         if (scalar(@mismatch_marker_names) > 0){
-            my $marker_name_error;
-            $marker_name_error .= "<br>";
             foreach my $error ( sort @mismatch_marker_names) {
-                $marker_name_error .= "$error\n";
- 	    } 
-            print STDERR Dumper $marker_name_error;
+                print STDERR "$error\n";
+	    }
 	    print STDERR "These marker names in your file are not in the selected protocol.\n";
             die; 
         }
@@ -389,7 +387,7 @@ if (scalar(keys %$genotype_info) > 0) {
         if (scalar(@protocol_match_errors) > 0){
             my $protocol_warning;
             foreach my $match_error (@protocol_match_errors) {
-                $protocol_warning .= $match_error."<br>";
+                $protocol_warning .= "$match_error\n";
             }
             if (!$opt_A){
                 print STDERR Dumper $protocol_warning;


### PR DESCRIPTION
Add checks for protocol and markers during VCF upload.
These are the same test used in the web based upload

If new markers are loaded into an existing protocol they will not be available for download. The upload should fail if the markers are not defined.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [X] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
