### PR TITLE
Enable select all seedlots in available seedlots dialog

### DIFF
--- a/mason/tools/available_seedlots.mas
+++ b/mason/tools/available_seedlots.mas
@@ -6,7 +6,7 @@
         <th rowspan="2" style="text-align: center;">Accessions</th><th colspan="7" style="text-align: center;">Seedlots</th>
       </tr>
       <tr>
-        <th style="text-align: center;"><input id="selectallaccessions" type="checkbox">Select All</input></th>
+        <th style="text-align: center;"><input id="selectallaccessions" type="checkbox" disabled>Select All</input></th>
         <th style="text-align: center;">Breeding Program</th>
         <th style="text-align: center;">Seedlot Name</th>
         <th style="text-align: center;">Contents</th>
@@ -22,24 +22,26 @@
     var mainFormSelector = "#available-seedlots";
     var d3 = global.d3v4;
     var ex = {};
-    const selectall_checkbox = document.getElementById('selectallaccessions'); 
+
+	const selectall_checkbox = document.getElementById('selectallaccessions'); 
     const seedlot_form = document.getElementById('available-seedlots');
     function selectAllAccessions(event){
-      var seedlot_checkboxes = seedlot_form.querySelectorAll('input[type="checkbox"]:not(#selectallaccessions):not(:disabled)');
-      if (event.target.checked){
-        seedlot_checkboxes.forEach(function(checkbox){
-          checkbox.checked = true;
-        });
-      } else {
-        seedlot_checkboxes.forEach(function(checkbox){
-          checkbox.checked = false;
-        });
-      }
+		var seedlot_checkboxes = seedlot_form.querySelectorAll('input[type="checkbox"]:not(#selectallaccessions):not(:disabled)');
+		if (event.target.checked){
+			seedlot_checkboxes.forEach(function(checkbox){
+			checkbox.checked = true;
+			});
+		} else {
+			seedlot_checkboxes.forEach(function(checkbox){
+			checkbox.checked = false;
+			});
+		}
     }
     selectall_checkbox.addEventListener('change', selectAllAccessions);
 
     ex.build_table = function(accession_names, list_type){
       jQuery('#working_modal').modal('show');
+	  selectall_checkbox.setAttribute('disabled', 'true'); //Reset the checkbox if looking at a different list
       jQuery.ajax({
         type: 'POST',
         url: '/ajax/accessions/possible_seedlots',
@@ -47,6 +49,10 @@
         dataType: "json",
         success: function(response) {
           _build_table(accession_names,response.seedlots,response.synonyms);
+		  var seedlot_checkboxes = seedlot_form.querySelectorAll('input[type="checkbox"]:not(#selectallaccessions):not(:disabled)');
+		  if (seedlot_checkboxes.length > 0){
+			selectall_checkbox.removeAttribute('disabled');
+		  }
           jQuery('#working_modal').modal('hide');
         },
         error: function(response) {

--- a/mason/tools/available_seedlots.mas
+++ b/mason/tools/available_seedlots.mas
@@ -6,7 +6,7 @@
         <th rowspan="2" style="text-align: center;">Accessions</th><th colspan="7" style="text-align: center;">Seedlots</th>
       </tr>
       <tr>
-        <th style="text-align: center;"><input id="selectallaccessions" type="checkbox" disabled>Select All</input></th>
+        <th style="text-align: center;"><button id="selectallaccessions" type="button" disabled>Select/Deselect All</button></th>
         <th style="text-align: center;">Breeding Program</th>
         <th style="text-align: center;">Seedlot Name</th>
         <th style="text-align: center;">Contents</th>
@@ -23,26 +23,25 @@
     var d3 = global.d3v4;
     var ex = {};
 
-	const selectall_checkbox = document.getElementById('selectallaccessions'); 
+	const selectall_button = document.getElementById('selectallaccessions'); 
     const seedlot_form = document.getElementById('available-seedlots');
     function selectAllAccessions(event){
 		var seedlot_checkboxes = seedlot_form.querySelectorAll('input[type="checkbox"]:not(#selectallaccessions):not(:disabled)');
-		if (event.target.checked){
-			seedlot_checkboxes.forEach(function(checkbox){
-			checkbox.checked = true;
-			});
-		} else {
-			seedlot_checkboxes.forEach(function(checkbox){
-			checkbox.checked = false;
-			});
-		}
+		var any_checked = false;
+		seedlot_checkboxes.forEach(function(checkbox){
+			if (checkbox.checked == true){
+				any_checked = true;
+			}
+		});
+		seedlot_checkboxes.forEach(function(checkbox){
+			checkbox.checked = !any_checked;
+		});
     }
-    selectall_checkbox.addEventListener('change', selectAllAccessions);
+    selectall_button.addEventListener('click', selectAllAccessions);
 
     ex.build_table = function(accession_names, list_type){
       jQuery('#working_modal').modal('show');
-	  selectall_checkbox.setAttribute('disabled', 'true'); //Reset the checkbox if looking at a different list
-	  selectall_checkbox.checked = false;
+	  selectall_button.setAttribute('disabled', 'true'); //Reset the checkbox if looking at a different list
       jQuery.ajax({
         type: 'POST',
         url: '/ajax/accessions/possible_seedlots',
@@ -52,7 +51,7 @@
           _build_table(accession_names,response.seedlots,response.synonyms);
 		  var seedlot_checkboxes = seedlot_form.querySelectorAll('input[type="checkbox"]:not(#selectallaccessions):not(:disabled)');
 		  if (seedlot_checkboxes.length > 0){
-			selectall_checkbox.removeAttribute('disabled');
+			selectall_button.removeAttribute('disabled');
 		  }
           jQuery('#working_modal').modal('hide');
         },

--- a/mason/tools/available_seedlots.mas
+++ b/mason/tools/available_seedlots.mas
@@ -42,6 +42,7 @@
     ex.build_table = function(accession_names, list_type){
       jQuery('#working_modal').modal('show');
 	  selectall_checkbox.setAttribute('disabled', 'true'); //Reset the checkbox if looking at a different list
+	  selectall_checkbox.checked = false;
       jQuery.ajax({
         type: 'POST',
         url: '/ajax/accessions/possible_seedlots',

--- a/mason/tools/available_seedlots.mas
+++ b/mason/tools/available_seedlots.mas
@@ -6,7 +6,7 @@
         <th rowspan="2" style="text-align: center;">Accessions</th><th colspan="7" style="text-align: center;">Seedlots</th>
       </tr>
       <tr>
-        <th></th>
+        <th style="text-align: center;"><input id="selectallaccessions" type="checkbox">Select All</input></th>
         <th style="text-align: center;">Breeding Program</th>
         <th style="text-align: center;">Seedlot Name</th>
         <th style="text-align: center;">Contents</th>
@@ -22,6 +22,22 @@
     var mainFormSelector = "#available-seedlots";
     var d3 = global.d3v4;
     var ex = {};
+    const selectall_checkbox = document.getElementById('selectallaccessions'); 
+    const seedlot_form = document.getElementById('available-seedlots');
+    function selectAllAccessions(event){
+      var seedlot_checkboxes = seedlot_form.querySelectorAll('input[type="checkbox"]:not(#selectallaccessions):not(:disabled)');
+      if (event.target.checked){
+        seedlot_checkboxes.forEach(function(checkbox){
+          checkbox.checked = true;
+        });
+      } else {
+        seedlot_checkboxes.forEach(function(checkbox){
+          checkbox.checked = false;
+        });
+      }
+    }
+    selectall_checkbox.addEventListener('change', selectAllAccessions);
+
     ex.build_table = function(accession_names, list_type){
       jQuery('#working_modal').modal('show');
       jQuery.ajax({


### PR DESCRIPTION
…toggled, all checkboxes in the open available seedlots modal are selected/deselected. List creation works. Disabled checkboxes are ignored.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Added a javascript function to enable users to select/deselect all available seedlots in the available seedlots modal. Disabled seedlots are ignored. Works with list creation. 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
