### PR TITLE
enable photo traits with brapi

### DIFF
--- a/lib/CXGN/BrAPI/v2/Scales.pm
+++ b/lib/CXGN/BrAPI/v2/Scales.pm
@@ -432,15 +432,16 @@ sub _format_data_type {
     if ($value) {
         my %formats = (
 	    "categorical" => "Ordinal",
-            "numeric"  => "Numerical",
-            "qualitative"  => "Nominal",
-            "numerical"  => "Numerical",
-            "nominal"  => "Nominal",
+            "numeric" => "Numerical",
+            "qualitative" => "Nominal",
+            "numerical" => "Numerical",
+            "nominal" => "Nominal",
             "code" => "Code",
             "date" => "Date" ,
             "duration" => "Duration",
             "ordinal" => "Ordinal",
-            "text"=> "Text",
+            "text" => "Text",
+	    "photo" => "Photo",
         );
 
         $dataType = $formats{lc $value} ? $formats{lc $value} : $dataType;

--- a/lib/SGN/Controller/Cvterm.pm
+++ b/lib/SGN/Controller/Cvterm.pm
@@ -1,7 +1,7 @@
 
 package SGN::Controller::Cvterm;
 
-use CXGN::Chado::Cvterm; #DEPRECATE this !! 
+#use CXGN::Chado::Cvterm; #DEPRECATE this !! 
 use CXGN::Cvterm;
 
 use Moose;

--- a/mason/chado/cvterm.mas
+++ b/mason/chado/cvterm.mas
@@ -47,6 +47,7 @@ my $db_name     = $cvterm->db->name;
 my $accession   = $cvterm->accession;
 my $cvterm_name = $cvterm->name;
 my $definition  = $cvterm->definition;
+my $is_variable = $cvterm->is_variable;
 my $comment     = '' ;#$cvterm->comment;
 #$stockref->{props} (hash of arrayrefs of cvtermprops. Keys = prop name, value = prop value)
 my $editable_cvterm_props_string = $cvtermref->{editable_cvterm_props};
@@ -165,6 +166,7 @@ my $edit_privs = $curator ;
 
 % my $props_subtitle = $edit_privs ? "[<a id=\"cvterm_add_props\" href=\"javascript:cvtermprops_addPropDialog()\">Add...</a>]" : "[Add]";
 
+% if ($is_variable) { 
 <&| /page/info_section.mas, title => "Trait Properties" , collapsible=> 1, is_subsection => 1, subtitle=>$props_subtitle &>
       <& /chado/cvtermprops.mas,
        cv_name    => 'trait_property',
@@ -176,11 +178,17 @@ my $edit_privs = $curator ;
 	editable   => \@editable_cvterm_props  &>
 </&>
 
-<h4>Add this term to a list</h4>
+% }
+% else {
+    <&| /page/info_section.mas, title => "Trait Properties" , collapsible=> 1, is_collapsed => 1, is_subsection => 1, &>
+    No properties for traits. Trait properties can be set for variables only.
+    </&>
+
+%}
 
 <div id="cvterm_id" style="display:none" ><% $cvterm_name %>|<% $accession %></div>
 
-<&| /page/info_section.mas, title=>"Add to list", collapsible=>1, collapsed=>1 &>
+<&| /page/info_section.mas, title=>"Add this term to a list", collapsible=>1, collapsed=>1 &>
 <div id="paste_to_list">
 LOAD...
 </div>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Enable photo traits with brapi. Set trait_format to 'photo'.

Also, hide trait properties section for traits; only show for variables. Maybe this section should be renamed...

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
