### PR TITLE
5022 show stored analysis

### DIFF
--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -1175,7 +1175,11 @@ sub get_trials {
     }
 
     my $geolocation_type_id = SGN::Model::Cvterm->get_cvterm_row($self->schema(), 'project location', 'project_property')->cvterm_id();
-    my $q = "select distinct(project.project_id), project.name, projectprop.value from stock as accession join stock_relationship on (accession.stock_id=stock_relationship.object_id) JOIN stock as plot on (plot.stock_id=stock_relationship.subject_id) JOIN nd_experiment_stock ON (plot.stock_id=nd_experiment_stock.stock_id) JOIN nd_experiment_project USING(nd_experiment_id) JOIN project USING (project_id) LEFT JOIN projectprop ON (project.project_id=projectprop.project_id) where projectprop.type_id=$geolocation_type_id AND accession.stock_id=?;";
+    my $q = "select distinct(project.project_id), project.name, projectprop.value from stock as accession join stock_relationship on 
+	(accession.stock_id=stock_relationship.object_id) JOIN stock as plot on (plot.stock_id=stock_relationship.subject_id) 
+	JOIN nd_experiment_stock ON (plot.stock_id=nd_experiment_stock.stock_id) JOIN nd_experiment_project USING(nd_experiment_id) 
+	JOIN project USING (project_id) LEFT JOIN projectprop ON (project.project_id=projectprop.project_id) 
+	where projectprop.type_id=$geolocation_type_id AND accession.stock_id=?;";
 
     my $h = $dbh->prepare($q);
     $h->execute($self->stock_id());

--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -501,7 +501,8 @@ sub associate_ontology_POST :Args(0) {
     my $evidence_description = $c->req->param('evidence_description') || undef; # a cvterm_id
     my $evidence_with  = $c->req->param('evidence_with') || undef; # a dbxref_id (type='evidence_with' value = 'dbxref_id'
     my $logged_user = $c->user;
-    my $logged_person_id = $logged_user->get_object->get_sp_person_id if $logged_user;
+    my $logged_person_id;
+    $logged_person_id = $logged_user->get_object->get_sp_person_id if $logged_user;
 
     my $reference = $c->req->param('reference'); # a pub_id
 
@@ -673,7 +674,8 @@ sub toggle_obsolete_annotation_POST :Args(0) {
     if ($stock_cvterm_id && $c->user ) {
         my $stock_cvterm = $schema->resultset("Stock::StockCvterm")->find( { stock_cvterm_id => $stock_cvterm_id } );
         if ($stock_cvterm) {
-            my ($prop) = $stock_cvterm->stock_cvtermprops( { type_id => $obsolete_cvterm->cvterm_id } ) if $obsolete_cvterm;
+            my $prop;
+            $prop = $stock_cvterm->stock_cvtermprops( { type_id => $obsolete_cvterm->cvterm_id } ) if $obsolete_cvterm;
             if ($prop) {
                 $prop->update( { value => $obsolete } ) ;
             } else {

--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -1705,6 +1705,53 @@ sub get_stock_trials :Chained('/stock/get_stock') PathPart('datatables/trials') 
     $c->stash->{rest} = { data => \@formatted_trials };
 }
 
+=head2 action get_stock_breeding_programs()
+
+ Usage:        /stock/<stock_id>/datatables/breeding_programs
+ Desc:         retrieves breeding programs that use this stock (accession)
+ Ret:          a table in json suitable for datatables
+ Args:
+ Side Effects:
+ Example:
+
+=cut
+
+sub get_stock_breeding_programs :Chained('/stock/get_stock') PathPart('datatables/breeding_programs') Args(0) {
+    my $self = shift;
+    my $c = shift;
+
+	my @breeding_programs = $c->stash->{stock}->get_breeding_programs();
+
+    my @formatted_programs;
+    foreach my $t (@breeding_programs) {
+	push @formatted_programs, [ '<a href="/breeders/program/'.$t->[0].'">'.$t->[1].'</a>' ];
+    }
+    $c->stash->{rest} = { data => \@formatted_programs };
+}
+
+=head2 action get_stored_analyses()
+
+ Usage:        /stock/<stock_id>/datatables/stored_analyses
+ Desc:         retrieves analyses associated with the stock (accession)
+ Ret:          a table in json suitable for datatables
+ Args:
+ Side Effects:
+ Example:
+
+=cut
+
+sub get_stock_stored_analyses :Chained('/stock/get_stock') PathPart('datatables/stored_analyses') Args(0) {
+    my $self = shift;
+    my $c = shift;
+
+	my @stored_analyses = $c->stash->{stock}->get_stored_analyses();
+
+    my @formatted_analyses;
+    foreach my $t (@stored_analyses) {
+	push @formatted_analyses, [ '<a href="/analyses/'.$t->[0].'">'.$t->[1].'</a>' ];
+    }
+    $c->stash->{rest} = { data => \@formatted_analyses };
+}
 
 =head2 action get_shared_trials()
 

--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -395,8 +395,10 @@ sub display_ontologies_GET  {
                 'type.name' => 'obsolete',
             },
             { join =>  'type' } , );
+        my $unobsolete;
+        my $obsolete_link;
         if ($obsolete_prop) {
-            my $unobsolete =  qq | <input type = "button" onclick= "javascript:Tools.toggleObsoleteAnnotation('0', \'$stock_cvterm_id\',  \'/ajax/stock/toggle_obsolete_annotation\', \'/stock/$stock_id/ontologies\')" value = "unobsolete" /> | if $privileged ;
+            $unobsolete =  qq | <input type = "button" onclick= "javascript:Tools.toggleObsoleteAnnotation('0', \'$stock_cvterm_id\',  \'/ajax/stock/toggle_obsolete_annotation\', \'/stock/$stock_id/ontologies\')" value = "unobsolete" /> | if $privileged ;
 
             # generate the list of obsolete annotations
             push @obs_annot,
@@ -408,7 +410,7 @@ sub display_ontologies_GET  {
             my $ontology_details = $rel_name
                 . qq| $cvterm_link ($db_name:<a href="$url$db_accession" target="blank"> $accession</a>)<br />|;
             # build the obsolete link if the user has  editing privileges
-            my $obsolete_link =  qq | <input type = "button" onclick="javascript:Tools.toggleObsoleteAnnotation('1', \'$stock_cvterm_id\',  \'/ajax/stock/toggle_obsolete_annotation\', \'/stock/$stock_id/ontologies\')" value ="delete" /> | if $privileged ;
+            $obsolete_link =  qq | <input type = "button" onclick="javascript:Tools.toggleObsoleteAnnotation('1', \'$stock_cvterm_id\',  \'/ajax/stock/toggle_obsolete_annotation\', \'/stock/$stock_id/ontologies\')" value ="delete" /> | if $privileged ;
 
             my ($ev_with) = $props->search( {'type.name' => 'evidence_with'} , { join => 'type'  } )->single;
             my $ev_with_dbxref = $ev_with ? $schema->resultset("General::Dbxref")->find( { dbxref_id=> $ev_with->value } ) : undef;
@@ -1744,11 +1746,11 @@ sub get_stock_stored_analyses :Chained('/stock/get_stock') PathPart('datatables/
 
 sub get_shared_trials :Path('/stock/get_shared_trials') : ActionClass('REST'){
 
-sub get_shared_trials_POST :Args(1) {
+my sub get_shared_trials_POST :Args(1) {
     my ($self, $c) = @_;
     $c->stash->{rest} = { error => "Nothing here, it's a POST.." } ;
 }
-sub get_shared_trials_GET :Args(1) {
+my sub get_shared_trials_GET :Args(1) {
 
     my $self = shift;
     my $c = shift;

--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -1705,30 +1705,6 @@ sub get_stock_trials :Chained('/stock/get_stock') PathPart('datatables/trials') 
     $c->stash->{rest} = { data => \@formatted_trials };
 }
 
-=head2 action get_stock_breeding_programs()
-
- Usage:        /stock/<stock_id>/datatables/breeding_programs
- Desc:         retrieves breeding programs that use this stock (accession)
- Ret:          a table in json suitable for datatables
- Args:
- Side Effects:
- Example:
-
-=cut
-
-sub get_stock_breeding_programs :Chained('/stock/get_stock') PathPart('datatables/breeding_programs') Args(0) {
-    my $self = shift;
-    my $c = shift;
-
-	my @breeding_programs = $c->stash->{stock}->get_breeding_programs();
-
-    my @formatted_programs;
-    foreach my $t (@breeding_programs) {
-	push @formatted_programs, [ '<a href="/breeders/program/'.$t->[0].'">'.$t->[1].'</a>' ];
-    }
-    $c->stash->{rest} = { data => \@formatted_programs };
-}
-
 =head2 action get_stored_analyses()
 
  Usage:        /stock/<stock_id>/datatables/stored_analyses

--- a/mason/breeders_toolbox/accessions/find_trials_by_accessions.mas
+++ b/mason/breeders_toolbox/accessions/find_trials_by_accessions.mas
@@ -112,6 +112,7 @@ jQuery('#shared_trials_2_lists').hide();
 				data: {stock_ids: stock_ids}
 			}).done(function(data) {
 			jQuery('#trial_summary_data').DataTable({  //populate datatable
+				'destroy': true,
 				data: data.data,
 				"autoWidth": false
 			});

--- a/mason/page/detail_page_2_col_section.mas
+++ b/mason/page/detail_page_2_col_section.mas
@@ -283,7 +283,7 @@ $vendor_id => undef
                                 <& /stock/additional_info_section.mas, stock_id => $stock_id, type_name => $type_name, stockprops => $stockprops, edit_privs => $edit_privs, editable_stock_props => $editable_stock_props, editor_link => $editor_link, source_dbs => $source_dbs, locus_add_uri => $locus_add_uri, allele_div => $allele_div, is_owner => $is_owner &>
 % } #End stock_additional_info_section
 % if ($info_section_id eq 'stock_trials_section'){
-                                <& /stock/trials.mas, stock_id => $stock_id, trial_id => $trial_id, trial_name => $trial_name, name => $name, project_id => $project_id&>
+                                <& /stock/trials.mas, stock_id => $stock_id, type_name => $type_name, trial_id => $trial_id, trial_name => $trial_name, name => $name, project_id => $project_id&>
 % } #End stock_trials_section
 % if ($info_section_id eq 'stock_upload_files'){
                                 <& /stock/accession_files.mas, stock_id => $stock_id &>

--- a/mason/stock/index.mas
+++ b/mason/stock/index.mas
@@ -301,7 +301,7 @@ function jqueryStuff() {
 % }
 
 % if ($type_name eq 'accession'){
-    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, info_section_title => "<h4 style='display:inline'>Experiment Usage</h4>", info_section_subtitle => 'View experiments that this stock has been used in.', icon_class => "glyphicon glyphicon-leaf", info_section_id => "stock_trials_section" &>
+    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, type_name => $type_name, info_section_title => "<h4 style='display:inline'>Experiment Usage</h4>", info_section_subtitle => 'View experiments that this stock has been used in.', icon_class => "glyphicon glyphicon-leaf", info_section_id => "stock_trials_section" &>
 %    my $trait_assayed_buttons = $type_name eq 'plot' ? "<button class='btn btn-sm btn-primary' style='margin:3px' id='stock_download_phenotypes_button'>Download Phenotypes</button> $p_download_link <a class='btn btn-sm btn-default' style='margin:3px' target='_blank' href = '/breeders/plot_phenotyping?stock_id=$stock_id'>Direct plot phenotyping</a>" : "<button class='btn btn-sm btn-primary' style='margin:3px' id='stock_download_phenotypes_button'>Download Phenotypes</button> $p_download_link";
     <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, info_section_title => "<h4 style='display:inline'>Traits Assayed</h4>", info_section_subtitle => 'View and download phenotypic data for this stock.', icon_class => "glyphicon glyphicon-equalizer", info_section_id => "stock_traits_section", buttons_html => $trait_assayed_buttons &>
 % }

--- a/mason/stock/trials.mas
+++ b/mason/stock/trials.mas
@@ -7,7 +7,7 @@ $type_name
 
 <div class="panel panel-default">
 	<div class="panel-body panel-body-sm">
-		<b> Field Trials </b>
+		<b> Trials </b>
 		<br/> <br/>
 		<table class="table table-hover table-bordered" id="trial_summary_data">
 			<thead>
@@ -21,6 +21,7 @@ $type_name
 	</div>
 </div>
 
+% if ($type_name eq "accession") {
 <div class="panel panel-default">
 	<div class="panel-body panel-body-sm">
 		<b> Breeding Programs </b>
@@ -35,7 +36,6 @@ $type_name
 	</div>
 </div>
 
-% if ($type_name eq "accession") {
 <div class="panel panel-default">
 	<div class="panel-body panel-body-sm">
 		<b> Analyses </b>
@@ -61,6 +61,7 @@ $type_name
                 'destroy': true,
                 'ajax': '/stock/'+ <% $stock_id %> + '/datatables/trials',
             });
+% if ($type_name eq "accession") {
 			jQuery('#breeding_program_usage_data').DataTable( {
                 'destroy': true,
                 'ajax': '/stock/'+ <% $stock_id %> + '/datatables/breeding_programs',
@@ -69,6 +70,7 @@ $type_name
                 'destroy': true,
                 'ajax': '/stock/'+ <% $stock_id %> + '/datatables/stored_analyses',
             });
+% }
         });
     });
 

--- a/mason/stock/trials.mas
+++ b/mason/stock/trials.mas
@@ -4,16 +4,50 @@ $stock_id
 
 <& /util/import_javascript.mas, classes => [ 'jquery', 'jquery.dataTables' ] &>
 
-<table class="table table-hover table-bordered" id="trial_summary_data">
-<thead>
-  <tr>
-    <th>Trial name</th>
-    <th>Location</th>
-    <th>Details</th>
-  </tr>
-</thead>
+<div class="panel panel-default">
+	<div class="panel-body panel-body-sm">
+		<b> Field Trials </b>
+		<br/> <br/>
+		<table class="table table-hover table-bordered" id="trial_summary_data">
+			<thead>
+			  <tr>
+				<th>Trial name</th>
+				<th>Location</th>
+				<th>Details</th>
+			  </tr>
+			</thead>
+		</table>
+	</div>
+</div>
 
-</table>
+<div class="panel panel-default">
+	<div class="panel-body panel-body-sm">
+		<b> Breeding Programs </b>
+		<br/> <br/>
+		<table class="table table-hover table-bordered" id="breeding_program_usage_data">
+			<thead>
+			  <tr>
+				<th>Program Name</th>
+			  </tr>
+			</thead>
+		</table>
+	</div>
+</div>
+
+<div class="panel panel-default">
+	<div class="panel-body panel-body-sm">
+		<b> Analyses </b>
+		<br/> <br/>
+		<table class="table table-hover table-bordered" id="analysis_usage_data">
+			<thead>
+			  <tr>
+				<th>Analysis</th>
+				<th>Details</th>
+			  </tr>
+			</thead>
+		</table>
+	</div>
+</div>
 
 <& /util/import_css.mas, paths => ['/documents/inc/datatables/jquery.dataTables.css'] &>
 

--- a/mason/stock/trials.mas
+++ b/mason/stock/trials.mas
@@ -24,20 +24,6 @@ $type_name
 % if ($type_name eq "accession") {
 <div class="panel panel-default">
 	<div class="panel-body panel-body-sm">
-		<b> Breeding Programs </b>
-		<br/> <br/>
-		<table class="table table-hover table-bordered" id="breeding_program_usage_data">
-			<thead>
-				<tr>
-					<th>Program name</th>
-				</tr>
-			</thead>
-		</table>
-	</div>
-</div>
-
-<div class="panel panel-default">
-	<div class="panel-body panel-body-sm">
 		<b> Analyses </b>
 		<br/> <br/>
 		<table class="table table-hover table-bordered" id="analysis_usage_data">

--- a/mason/stock/trials.mas
+++ b/mason/stock/trials.mas
@@ -1,5 +1,6 @@
 <%args>
 $stock_id
+$type_name
 </%args>
 
 <& /util/import_javascript.mas, classes => [ 'jquery', 'jquery.dataTables' ] &>
@@ -26,28 +27,29 @@ $stock_id
 		<br/> <br/>
 		<table class="table table-hover table-bordered" id="breeding_program_usage_data">
 			<thead>
-			  <tr>
-				<th>Program Name</th>
-			  </tr>
+				<tr>
+					<th>Program name</th>
+				</tr>
 			</thead>
 		</table>
 	</div>
 </div>
 
+% if ($type_name eq "accession") {
 <div class="panel panel-default">
 	<div class="panel-body panel-body-sm">
 		<b> Analyses </b>
 		<br/> <br/>
 		<table class="table table-hover table-bordered" id="analysis_usage_data">
 			<thead>
-			  <tr>
-				<th>Analysis</th>
-				<th>Details</th>
-			  </tr>
+				<tr>
+					<th>Name</th>
+				</tr>
 			</thead>
 		</table>
 	</div>
 </div>
+% }
 
 <& /util/import_css.mas, paths => ['/documents/inc/datatables/jquery.dataTables.css'] &>
 
@@ -58,6 +60,14 @@ $stock_id
             jQuery('#trial_summary_data').DataTable( {
                 'destroy': true,
                 'ajax': '/stock/'+ <% $stock_id %> + '/datatables/trials',
+            });
+			jQuery('#breeding_program_usage_data').DataTable( {
+                'destroy': true,
+                'ajax': '/stock/'+ <% $stock_id %> + '/datatables/breeding_programs',
+            });
+			jQuery('#analysis_usage_data').DataTable( {
+                'destroy': true,
+                'ajax': '/stock/'+ <% $stock_id %> + '/datatables/stored_analyses',
             });
         });
     });

--- a/mason/stock/trials.mas
+++ b/mason/stock/trials.mas
@@ -48,10 +48,6 @@ $type_name
                 'ajax': '/stock/'+ <% $stock_id %> + '/datatables/trials',
             });
 % if ($type_name eq "accession") {
-			jQuery('#breeding_program_usage_data').DataTable( {
-                'destroy': true,
-                'ajax': '/stock/'+ <% $stock_id %> + '/datatables/breeding_programs',
-            });
 			jQuery('#analysis_usage_data').DataTable( {
                 'destroy': true,
                 'ajax': '/stock/'+ <% $stock_id %> + '/datatables/stored_analyses',


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Split the experiment usage table in the accessions detail page into two tables: one that shows field trials and another that shows stored analyses using this accession. Attempting to use an analysis ID to go to a trial detail page now redirects to the analysis detail page. The field trials in common table in the manage accessions page now makes stored analyses distinct. They are labeled and colored for clarity. 
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
