### PR TITLE
5183 Viewing page for deleted dataset gives server error

### DIFF
--- a/lib/SGN/Controller/Dataset.pm
+++ b/lib/SGN/Controller/Dataset.pm
@@ -16,11 +16,21 @@ sub dataset :Chained('/') Path('dataset') Args(1) {
     my $people_schema = $c->dbic_schema("CXGN::People::Schema");
     my $html = "";
     
-    my $dataset = CXGN::Dataset->new({
-        schema => $schema,
-        people_schema => $people_schema,
-        sp_dataset_id => $dataset_id
-    });
+    my $dataset;
+
+    eval {
+        $dataset = CXGN::Dataset->new({
+            schema => $schema,
+            people_schema => $people_schema,
+            sp_dataset_id => $dataset_id
+        });
+    };
+    if ($@) {
+        $c->stash->{template} = 'generic_message.mas';
+	    $c->stash->{message} = "The requested dataset does not exist or has been deleted.";
+	    return;
+    }
+    
     my $info = $dataset->get_dataset_data();
 
     my $dataset_info = {


### PR DESCRIPTION
…erver error message


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Solves issue #5183 by checking to see if missing dataset ID propagates error upward. Missing dataset ID requests are met with a message saying the dataset does not exist. 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
