### PR TITLE
fix pca analysis args parsing issue in pca results page

### DIFF
--- a/js/source/legacy/solGS/pca.js
+++ b/js/source/legacy/solGS/pca.js
@@ -901,10 +901,12 @@ jQuery(document).ready(function () {
   jQuery("#pca_div").on("click", function (e) {
     var runPcaBtnId = e.target.id;
     if (runPcaBtnId.match(/run_pca/)) {
-      var pcaArgs = solGS.pca.getPcaArgs();
-      var pcaPopId = pcaArgs.pca_pop_id;
-      if (!pcaPopId) {
+    
+      var  pcaArgs;
+      if (document.URL.match(/pca\/analysis\//)) {
         pcaArgs = solGS.pca.getSelectedPopPcaArgs(runPcaBtnId);
+      } else {
+        pcaArgs = solGS.pca.getPcaArgs();
       }
 
       pcaPopId = pcaArgs.pca_pop_id;
@@ -912,7 +914,6 @@ jQuery(document).ready(function () {
       var pcaMsgDiv = solGS.pca.pcaMsgDiv;
       var pcaUrl = solGS.pca.generatePcaUrl(pcaPopId);
       pcaArgs["analysis_page"] = pcaUrl;
-
 
       solGS.pca
         .checkCachedPca(pcaArgs)


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

-- fixes pca analysis arguments parsing issue in pca results pages. 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
