### PR TITLE
Fix server error on missing analysis ID

### DIFF
--- a/lib/SGN/Controller/Analysis.pm
+++ b/lib/SGN/Controller/Analysis.pm
@@ -42,6 +42,7 @@ sub analysis_detail :Path('/analyses') Args(1) {
     my $bcs_schema = $c->dbic_schema("Bio::Chado::Schema", undef, $user_id);
     print STDERR "Viewing analysis with id $analysis_id\n";
 
+    eval {
     my $a = CXGN::Analysis->new({
         bcs_schema => $bcs_schema,
         people_schema => $c->dbic_schema("CXGN::People::Schema", undef, $user_id),
@@ -49,10 +50,11 @@ sub analysis_detail :Path('/analyses') Args(1) {
         phenome_schema => $c->dbic_schema("CXGN::Phenome::Schema", undef, $user_id),
         trial_id => $analysis_id,
     });
+    };
 
-    if (! $a) {
+    if ($@) {
         $c->stash->{template} = '/generic_message.mas';
-        $c->stash->{message} = 'The requested analysis ID does not exist in the database.';
+        $c->stash->{message} = 'The requested analysis ID does not exist in the database or has been deleted.';
         return;
     }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Added an eval statement to catch server error when analysis_id is missing. Displays a clean info message to user. 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
