### PR TITLE
Show analyses on dataset details page

### DIFF
--- a/js/source/entries/mixedmodels.js
+++ b/js/source/entries/mixedmodels.js
@@ -11,7 +11,7 @@ export function init(main_div) {
 
     var dataset_id;
 
-    alert("WELCOME TO MIXED MODELS!");
+    // alert("WELCOME TO MIXED MODELS!");
     get_select_box("datasets", "mixed_model_dataset_select", { "checkbox_name": "mixed_model_dataset_select_checkbox" });
 
     jQuery('#mixed_model_analysis_prepare_button').removeClass('active').addClass('inactive');

--- a/lib/CXGN/Dataset.pm
+++ b/lib/CXGN/Dataset.pm
@@ -54,6 +54,7 @@ use Moose;
 use Moose::Util::TypeConstraints;
 use Data::Dumper;
 use JSON::Any;
+use JSON::XS;
 use CXGN::BreederSearch;
 use CXGN::People::Schema;
 use CXGN::Phenotypes::PhenotypeMatrix;
@@ -1283,6 +1284,50 @@ sub update_description {
             return undef;
         }
     }
+}
+
+=head2 get_child_analyses()
+
+# Retrieves the list of analyses that use this dataset. 
+
+=cut
+
+sub get_child_analyses {
+    my $self = shift;
+    my $dataset_id = $self->sp_dataset_id();
+
+    my $dbh = $self->schema->storage->dbh();
+
+    my @all_analyses = ();
+
+    my $analysis_info_type_id = SGN::Model::Cvterm->get_cvterm_row($self->schema, 'analysis_metadata_json', 'project_property')->cvterm_id();
+
+    my $analysis_q = "select DISTINCT project.name, project.project_id, analysisinfo.value FROM nd_experiment_project 
+    JOIN project USING (project_id) 
+    JOIN nd_experiment ON nd_experiment.nd_experiment_id=nd_experiment_project.nd_experiment_id
+    JOIN projectprop AS analysisinfo ON (project.project_id=analysisinfo.project_id)
+    JOIN cvterm ON cvterm.cvterm_id=nd_experiment.type_id 
+    WHERE cvterm.name='analysis_experiment' AND analysisinfo.type_id=$analysis_info_type_id;";
+    my $h = $dbh->prepare($analysis_q);
+    $h->execute();
+
+    while (my ($analysis_name, $analysis_id, $metadata_json) = $h->fetchrow_array()){
+        my $analysis_metadata = decode_json($metadata_json);
+        push @all_analyses, [
+            $analysis_name, 
+            $analysis_id,
+            $analysis_metadata->{dataset_id}
+        ];
+    }
+
+    my @html = ();
+
+    foreach my $row (@all_analyses) {
+        if ($dataset_id == $row->[2]){
+            push @html, "<a href=/analyses/".$row->[1].">".$row->[0]."</a>";
+        }
+    }
+    return join(" | ", @html);
 }
 
 

--- a/lib/CXGN/Dataset.pm
+++ b/lib/CXGN/Dataset.pm
@@ -449,7 +449,7 @@ sub set_dataset_public {
         if ($@) {
             return "An error occurred, $@";
         } else {
-            return undef;
+            return;
         }
     }
 }
@@ -475,7 +475,7 @@ sub set_dataset_private {
         if ($@) {
             return "An error occurred, $@";
         } else {
-            return undef;
+            return;
         }
     }
 }
@@ -1259,7 +1259,7 @@ sub delete {
 	if ($@) {
 	    return "An error occurred, $@";
         } else {
-	    return undef;
+	    return;
 	}
 
     }
@@ -1281,7 +1281,7 @@ sub update_description {
         if ($@) {
             return "An error occurred, $@";
         } else {
-            return undef;
+            return;
         }
     }
 }

--- a/lib/CXGN/Dataset.pm
+++ b/lib/CXGN/Dataset.pm
@@ -1300,13 +1300,9 @@ sub get_child_analyses {
 
     my $analysis_info_type_id = SGN::Model::Cvterm->get_cvterm_row($self->schema, 'analysis_metadata_json', 'project_property')->cvterm_id();
 
-    my $analysis_q = "select DISTINCT project.name, project.project_id FROM nd_experiment_project 
+    my $analysis_q = "select DISTINCT project.name, project.project_id FROM projectprop 
     JOIN project USING (project_id) 
-    JOIN nd_experiment ON nd_experiment.nd_experiment_id=nd_experiment_project.nd_experiment_id
-    JOIN projectprop AS analysisinfo ON (project.project_id=analysisinfo.project_id)
-    JOIN cvterm ON cvterm.cvterm_id=nd_experiment.type_id 
-    WHERE cvterm.name='analysis_experiment' 
-        AND analysisinfo.type_id=$analysis_info_type_id 
+    WHERE projectprop.type_id=$analysis_info_type_id 
         AND analysisinfo.value::json->>'dataset_id'=?;";
     my $h = $dbh->prepare($analysis_q);
     $h->execute($dataset_id);

--- a/lib/CXGN/Dataset.pm
+++ b/lib/CXGN/Dataset.pm
@@ -1300,7 +1300,7 @@ sub get_child_analyses {
 
     my $analysis_info_type_id = SGN::Model::Cvterm->get_cvterm_row($self->schema, 'analysis_metadata_json', 'project_property')->cvterm_id();
 
-    my $analysis_q = "select DISTINCT project.name, project.project_id, analysisinfo.value::json->>'dataset_id' FROM nd_experiment_project 
+    my $analysis_q = "select DISTINCT project.name, project.project_id FROM nd_experiment_project 
     JOIN project USING (project_id) 
     JOIN nd_experiment ON nd_experiment.nd_experiment_id=nd_experiment_project.nd_experiment_id
     JOIN projectprop AS analysisinfo ON (project.project_id=analysisinfo.project_id)
@@ -1313,10 +1313,8 @@ sub get_child_analyses {
 
     my @html = ();
 
-    while (my ($analysis_name, $analysis_id, $analysis_ds_id) = $h->fetchrow_array()){
-        if ($dataset_id == $analysis_ds_id){
-            push @html, "<a href=/analyses/".$analysis_id.">".$analysis_name."</a>";
-        }
+    while (my ($analysis_name, $analysis_id) = $h->fetchrow_array()){
+        push @html, "<a href=/analyses/".$analysis_id.">".$analysis_name."</a>";
     }
 
     return join(" | ", @html);

--- a/lib/SGN/Controller/AJAX/Dataset.pm
+++ b/lib/SGN/Controller/AJAX/Dataset.pm
@@ -356,6 +356,38 @@ sub get_dataset :Path('/ajax/dataset/get') Args(1) {
     $c->stash->{rest} = { dataset => $dataset_data };
 }
 
+sub get_child_analyses :Path('/ajax/dataset/get_child_analyses') Args(1) {
+    my $self = shift;
+    my $c = shift;
+    my $dataset_id = shift;
+
+    my $sp_person_id = $c->user() ? $c->user->get_object()->get_sp_person_id() : undef;
+
+    my $dataset = CXGN::Dataset->new(
+	{
+	    schema => $c->dbic_schema("Bio::Chado::Schema", undef, $sp_person_id),
+	    people_schema => $c->dbic_schema("CXGN::People::Schema", undef, $sp_person_id),
+	    sp_dataset_id=> $dataset_id,
+	});
+
+    my $analysis_list;
+    eval {
+        $analysis_list = $dataset->get_child_analyses();
+    };
+
+    if ($@){
+        $c->stash->{rest} = {error => "Error retrieving analyses using this dataset. $@"};
+    }
+
+    if ($analysis_list eq "") {
+        $analysis_list = "(none)";
+    }
+
+    print STDERR "Got the following list of accessions using this dataset: $analysis_list \n";
+
+    $c->stash->{rest} = { analysis_html_list => $analysis_list };
+}
+
 
 sub retrieve_dataset_dimension :Path('/ajax/dataset/retrieve') Args(2) {
     my $self = shift;

--- a/mason/analyses/analysis_details.mas
+++ b/mason/analyses/analysis_details.mas
@@ -75,10 +75,10 @@ $analysis_metadata
                 </td>
             </tr>
 
-            <tr><td><b>Dataset ID</b></td>
+            <tr><td><b>Dataset</b></td>
                 <td>
                     <div id="analysis_dataset_id">
-%  print $analysis_metadata->dataset_id;
+%  print "<a href=/dataset/".$analysis_metadata->dataset_id.">".$analysis_metadata->dataset_id."</a>";
                     </div>
                 </td>
             </tr>

--- a/mason/analyses/model_details.mas
+++ b/mason/analyses/model_details.mas
@@ -73,6 +73,7 @@ jQuery(document).ready(function(){
                 jQuery('#model_name').html("<a href=\"/analyses_model/"+response.model_info.model_id+"\">"+response.model_info.model_name+"</a>");
                 jQuery('#model_description').html(response.model_info.model_description);
                 jQuery('#model_type').html(response.model_info.model_type_name);
+                jQuery('#analysis_dataset_id').html("<a href=\"/dataset/"+response.dataset.dataset_id+"\">"+response.dataset.dataset_name+"</a>");
 
                 var model_properties_string = '';
                 for (var key in response.model_info.model_properties) {

--- a/mason/dataset/index.mas
+++ b/mason/dataset/index.mas
@@ -99,6 +99,7 @@ $dataset_contents => ''
                         </span>
 %                   }
                     <tr><td>Select Dataset in Wizard<td><% $wizard_link %>
+                    <tr><td>Analyses using this dataset<td id="dataset_analysis_usage"></td></td>
             </table>
         </div>
     </div>
@@ -249,6 +250,21 @@ $dataset_contents => ''
 
             window.open(url,'_blank');
         })
+
+        jQuery.ajax({
+            type: 'GET',
+            url: '/ajax/dataset/get_child_analyses/<% $dataset_id %>',
+            success: function(response) {
+                if (response.error){
+                    alert(response.error);
+                } else {
+                    jQuery('#dataset_analysis_usage').html(response.analysis_html_list);
+                }
+            },
+            error: function(response) {
+                alert("Error retrieving analyses using this dataset.");
+            }
+        });
     });
 
     </script>

--- a/t/selenium2/breeders/breeder_search.t
+++ b/t/selenium2/breeders/breeder_search.t
@@ -2,7 +2,7 @@ use strict;
 
 use lib 't/lib';
 
-use Test::More 'tests' => 110;
+use Test::More 'tests' => 113;
 
 use SGN::Test::WWW::WebDriver;
 use Selenium::Remote::WDKeys 'KEYS';
@@ -389,6 +389,17 @@ $t->while_logged_in_as("submitter", sub {
     ok($selected_reloaded_elements =~ /UG120001/, "Verify first column wizard, selected elements, after merging $fourth_list_name and two new elements: accession UG120001");
     ok($selected_reloaded_elements =~ /IITA-TMS-IBA011412/, "Verify first column wizard, selected elements, after merging $fourth_list_name and two new elements: accession IITA-TMS-IBA011412");
     ok($selected_reloaded_elements =~ /IITA-TMS-IBA30572/, "Verify first column wizard, selected elements, after merging $fourth_list_name and two new elements: accession IITA-TMS-IBA30572");
+
+    #  TEST WORKING MIXED MODEL AND DETAILS PAGE FOR DATASET 1
+    $t->get_ok('/search/datasets');
+    sleep(1);
+    
+    $t->find_element_ok("//a[text()='$dataset_name_1']",'xpath','checking for created dataset on dataset overview page')->click();
+    sleep(5);
+
+    my $child_analyses = $t->find_element('dataset_analysis_usage', 'id')->get_text();
+    ok($child_analyses eq "(none)", 'checking initial analysis usage');
+    sleep(1);
 
     #  DELETE DATASET
     $t->get_ok('/breeders/search');


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Stored analyses that use a dataset will now be listed on the dataset details page. Likewise, the stored analysis details page now links to the dataset details page. 

<!-- If there are relevant issues, link them here: -->
#5154 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
