### PR TITLE
Generic Single Trial Upload

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/UploadTrial.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/UploadTrial.js
@@ -124,8 +124,101 @@ jQuery(document).ready(function ($) {
     }
 
     function upload_trial_file() {
-        jQuery('#upload_trial_form').attr("action", "/ajax/trial/upload_trial_file");
-        jQuery("#upload_trial_form").submit();
+        var uploadedTrialLayoutFile = jQuery("#trial_uploaded_file").val();
+        if (uploadedTrialLayoutFile === '') {
+            alert("No file selected");
+            return;
+        }
+
+        jQuery("#working_modal").modal("show");
+        jQuery.ajax({
+            url: "/ajax/trial/upload_trial_file",
+            type: 'POST',
+            data: new FormData(jQuery("#upload_trial_form")[0]),
+            processData: false,
+            contentType: false,
+            success: function(response) {
+                jQuery("#working_modal").modal("hide");
+                trial_id = response.trial_id;
+                console.log(response);
+
+                if (response.error) {
+                    alert(response.error);
+                    return;
+                }
+                else if (response.error_string) {
+                    if (response.missing_accessions) {
+                        jQuery('#upload_trial_missing_accessions_div').show();
+                        var missing_accessions_html = "<div class='well well-sm'><h3>Add the missing accessions to a list</h3><div id='upload_trial_missing_accessions' style='display:none'></div><div id='upload_trial_add_missing_accessions'></div></div><br/>";
+                        jQuery("#upload_trial_add_missing_accessions_html").html(missing_accessions_html);
+
+                        var missing_accessions_vals = '';
+                        for (var i=0; i<response.missing_accessions.length; i++) {
+                            missing_accessions_vals = missing_accessions_vals + response.missing_accessions[i] + '\n';
+                        }
+                        jQuery("#upload_trial_missing_accessions").html(missing_accessions_vals);
+                        addToListMenu('upload_trial_add_missing_accessions', 'upload_trial_missing_accessions', {
+                            selectText: true,
+                            listType: 'accessions'
+                        });
+                    }
+                    else {
+                        jQuery('#upload_trial_missing_accessions_div').hide();
+                        var no_missing_accessions_html = '<button class="btn btn-primary" onclick="Workflow.skip(this);">There were no errors regarding missing accessions Click Here</button><br/><br/>';
+                        jQuery('#upload_trial_no_error_messages_html').html(no_missing_accessions_html);
+                        Workflow.skip('#upload_trial_missing_accessions_div', false);
+                    }
+
+                    if (response.missing_seedlots) {
+                        jQuery('#upload_trial_missing_seedlots_div').show();
+                    }
+                    else {
+                        jQuery('#upload_trial_missing_seedlots_div').hide();
+                        var no_missing_seedlot_html = '<button class="btn btn-primary" onclick="Workflow.skip(this);">There were no errors regarding missing seedlots Click Here</button><br/><br/>';
+                        jQuery('#upload_trial_no_error_messages_seedlot_html').html(no_missing_seedlot_html);
+                        Workflow.skip('#upload_trial_missing_seedlots_div', false);
+                    }
+
+                    jQuery("#upload_trial_error_display tbody").html(response.error_string);
+                    //jQuery("#upload_trial_error_display_seedlot tbody").html(response.error_string);
+                    jQuery("#upload_trial_error_display_second_try").show();
+                    jQuery("#upload_trial_error_display_second_try tbody").html(response.error_string);
+                }
+                if (response.missing_accessions) {
+                    Workflow.focus("#trial_upload_workflow", 4);
+                }
+                else if (response.missing_seedlots) {
+                    Workflow.focus("#trial_upload_workflow", 5);
+                }
+                else if (response.error_string) {
+                    Workflow.focus("#trial_upload_workflow", 6);
+                    jQuery("#upload_trial_error_display_second_try").show();
+                }
+                if (response.warnings) {
+                    warnings = response.warnings;
+                    warning_html = "<li>"+warnings.join("</li><li>")+"</li>"
+                    jQuery("#upload_trial_warning_messages").show();
+                    jQuery("#upload_trial_warning_messages").html('<b>Warnings. Fix or ignore the following warnings and try again.</b><br><br>'+warning_html);
+                    return;
+                }
+                if (response.success) {
+                    refreshTrailJsTree(0);
+                    jQuery("#upload_trial_error_display_second_try").hide();
+                    jQuery('#trial_upload_show_repeat_upload_button').hide();
+                    jQuery('[name="upload_trial_completed_message"]').html('<button class="btn btn-primary" name="upload_trial_success_complete_button">The trial was saved to the database with no errors! Congrats Click Here</button><br/><br/>');
+                    Workflow.skip('#upload_trial_missing_accessions_div', false);
+                    Workflow.skip('#upload_trial_missing_seedlots_div', false);
+                    Workflow.skip('#upload_trial_error_display_second_try', false);
+                    Workflow.focus("#trial_upload_workflow", -1); //Go to success page
+                    Workflow.check_complete("#trial_upload_workflow");
+                    add_plants_per_plot();
+                }
+            },
+            error: function() {
+                jQuery("#working_modal").modal("hide");
+                alert("There was an error uploading your trial.");
+            }
+        });
     }
 
     function upload_multiple_trial_designs_file() {
@@ -146,16 +239,15 @@ jQuery(document).ready(function ($) {
             data: new FormData(jQuery("#upload_multiple_trial_designs_form")[0]),
             processData: false,
             contentType: false,
-            success : function(response) {
+            success: function(response) {
                 jQuery("#working_modal").modal("hide");
                 if (response.warnings) {
                     warnings = response.warnings;
                     warning_html = "<li>"+warnings.join("</li><li>")+"</li>"
                     jQuery("#upload_multiple_trials_warning_messages").show();
                     jQuery("#upload_multiple_trials_warning_messages").html('<b>Warnings. Fix or ignore the following warnings and try again.</b><br><br>'+warning_html);
-                    return;
                 }
-                if (response.errors) {
+                else if (response.errors) {
                     errors = response.errors;
                     if (Array.isArray(errors)) {
                         error_html = "<li>"+errors.join("</li><li>")+"</li>";
@@ -164,22 +256,19 @@ jQuery(document).ready(function ($) {
                     }
                     jQuery("#upload_multiple_trials_error_messages").show();
                     jQuery("#upload_multiple_trials_error_messages").html('<b>Errors found. Fix the following problems and try again.</b><br><br>'+error_html);
-                    return;
                 }
-                if (response.success) {
+                else if (response.success) {
                     refreshTrailJsTree(0);
                     jQuery("#upload_multiple_trials_success_messages").show();
                     jQuery("#upload_multiple_trials_success_messages").html("Success! All trials successfully loaded.");
                     jQuery("#multiple_trial_designs_upload_submit").hide();
                     jQuery("#upload_multiple_trials_success_button").show();
-                    return;
                 }
-                if (response.background) {
+                else if (response.background) {
                     jQuery("#upload_multiple_trials_success_messages").show();
                     jQuery("#upload_multiple_trials_success_messages").html("Your file has been uploaded.  You will receive an email once the process is complete.");
                     jQuery("#multiple_trial_designs_upload_submit").hide();
                     jQuery("#upload_multiple_trials_success_button").show();
-                    return;
                 }
             },
             error: function() {
@@ -261,93 +350,6 @@ jQuery(document).ready(function ($) {
 
     jQuery("#upload_multiple_trial_designs_format_info").click( function () {
         jQuery("#multiple_trial_upload_spreadsheet_info_dialog" ).modal("show");
-    });
-
-    jQuery('#upload_trial_form').iframePostForm({
-        json: true,
-        post: function () {
-            var uploadedTrialLayoutFile = jQuery("#trial_uploaded_file").val();
-            jQuery('#working_modal').modal("show");
-            if (uploadedTrialLayoutFile === '') {
-                jQuery('#working_modal').modal("hide");
-                alert("No file selected");
-                return;
-            }
-        },
-        complete: function (response) {
-            trial_id = response.trial_id;
-            console.log(response);
-
-            jQuery('#working_modal').modal("hide");
-            if (response.error) {
-                alert(response.error);
-                return;
-            }
-            else if (response.error_string) {
-
-                if (response.missing_accessions) {
-                    jQuery('#upload_trial_missing_accessions_div').show();
-                    var missing_accessions_html = "<div class='well well-sm'><h3>Add the missing accessions to a list</h3><div id='upload_trial_missing_accessions' style='display:none'></div><div id='upload_trial_add_missing_accessions'></div></div><br/>";
-                    jQuery("#upload_trial_add_missing_accessions_html").html(missing_accessions_html);
-
-                    var missing_accessions_vals = '';
-                    for(var i=0; i<response.missing_accessions.length; i++) {
-                        missing_accessions_vals = missing_accessions_vals + response.missing_accessions[i] + '\n';
-                    }
-                    jQuery("#upload_trial_missing_accessions").html(missing_accessions_vals);
-                    addToListMenu('upload_trial_add_missing_accessions', 'upload_trial_missing_accessions', {
-                        selectText: true,
-                        listType: 'accessions'
-                    });
-                } else {
-                    jQuery('#upload_trial_missing_accessions_div').hide();
-                    var no_missing_accessions_html = '<button class="btn btn-primary" onclick="Workflow.skip(this);">There were no errors regarding missing accessions Click Here</button><br/><br/>';
-                    jQuery('#upload_trial_no_error_messages_html').html(no_missing_accessions_html);
-                    Workflow.skip('#upload_trial_missing_accessions_div', false);
-                }
-
-                if (response.missing_seedlots) {
-                    jQuery('#upload_trial_missing_seedlots_div').show();
-                } else {
-                    jQuery('#upload_trial_missing_seedlots_div').hide();
-                    var no_missing_seedlot_html = '<button class="btn btn-primary" onclick="Workflow.skip(this);">There were no errors regarding missing seedlots Click Here</button><br/><br/>';
-                    jQuery('#upload_trial_no_error_messages_seedlot_html').html(no_missing_seedlot_html);
-                    Workflow.skip('#upload_trial_missing_seedlots_div', false);
-                }
-
-                jQuery("#upload_trial_error_display tbody").html(response.error_string);
-                //jQuery("#upload_trial_error_display_seedlot tbody").html(response.error_string);
-                jQuery("#upload_trial_error_display_second_try").show();
-                jQuery("#upload_trial_error_display_second_try tbody").html(response.error_string);
-            }
-            if (response.missing_accessions){
-                Workflow.focus("#trial_upload_workflow", 4);
-            } else if(response.missing_seedlots){
-                Workflow.focus("#trial_upload_workflow", 5);
-            } else if(response.error_string){
-                Workflow.focus("#trial_upload_workflow", 6);
-                jQuery("#upload_trial_error_display_second_try").show();
-            }
-            if (response.warnings) {
-                warnings = response.warnings;
-                warning_html = "<li>"+warnings.join("</li><li>")+"</li>"
-                jQuery("#upload_trial_warning_messages").show();
-                jQuery("#upload_trial_warning_messages").html('<b>Warnings. Fix or ignore the following warnings and try again.</b><br><br>'+warning_html);
-                return;
-            }
-            if (response.success) {
-                refreshTrailJsTree(0);
-                jQuery("#upload_trial_error_display_second_try").hide();
-                jQuery('#trial_upload_show_repeat_upload_button').hide();
-                jQuery('[name="upload_trial_completed_message"]').html('<button class="btn btn-primary" name="upload_trial_success_complete_button">The trial was saved to the database with no errors! Congrats Click Here</button><br/><br/>');
-                Workflow.skip('#upload_trial_missing_accessions_div', false);
-                Workflow.skip('#upload_trial_missing_seedlots_div', false);
-                Workflow.skip('#upload_trial_error_display_second_try', false);
-                Workflow.focus("#trial_upload_workflow", -1); //Go to success page
-                Workflow.check_complete("#trial_upload_workflow");
-                add_plants_per_plot();
-            }
-        }
     });
 
     function toggleEmailField() {

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialExcelFormat.pm
@@ -9,6 +9,10 @@ use Data::Dumper;
 use CXGN::List::Validate;
 use CXGN::Stock::Seedlot;
 
+#
+# DEPRECATED: This plugin has been replaced by the TrialGeneric plugin
+#
+
 my @REQUIRED_COLUMNS = qw|plot_number block_number|;
 # accession_name, cross_unique_id, or family_name are required depending on the trial_stock_type
 my @OPTIONAL_COLUMNS = qw|plot_name is_a_control rep_number range_number row_number col_number seedlot_name num_seed_per_plot weight_gram_seed_per_plot entry_number|;

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialGeneric.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialGeneric.pm
@@ -1,0 +1,444 @@
+package CXGN::Trial::ParseUpload::Plugin::TrialGeneric;
+
+use Moose::Role;
+use List::MoreUtils qw(uniq);
+use CXGN::File::Parse;
+use SGN::Model::Cvterm;
+use CXGN::List::Validate;
+use CXGN::Stock::Seedlot;
+use CXGN::Trial;
+
+my @REQUIRED_COLUMNS = qw|stock_name plot_number block_number|;
+# stock_name can also be accession_name, cross_unique_id, or family_name
+my @OPTIONAL_COLUMNS = qw|plot_name is_a_control rep_number range_number row_number col_number seedlot_name num_seed_per_plot weight_gram_seed_per_plot entry_number|;
+# Any additional columns that are not required or optional will be used as a treatment
+
+sub _validate_with_plugin {
+    my $self = shift;
+    my $filename = $self->get_filename();
+    my $schema = $self->get_chado_schema();
+    my $trial_name = $self->get_trial_name();
+
+    # Encountered Error and Warning Messages
+    my %errors;
+    my @error_messages;
+    my %warnings;
+    my @warning_messages;
+    my $validator = CXGN::List::Validate->new();
+
+    # Read and parse the upload file
+    my $parser = CXGN::File::Parse->new(
+        file => $filename,
+        required_columns => \@REQUIRED_COLUMNS,
+        optional_columns => \@OPTIONAL_COLUMNS,
+        column_aliases => {
+            'stock_name' => [ 'accession_name', 'cross_unique_id', 'family_name' ]
+        }
+    );
+    my $parsed = $parser->parse();
+    my $parsed_errors = $parsed->{'errors'};
+    my $parsed_data = $parsed->{'data'};
+    my $parsed_values = $parsed->{'values'};
+    my $treatments = $parsed->{'additional_columns'};
+
+    # Return file parsing errors
+    if ( $parsed_errors && scalar(@$parsed_errors) > 0 ) {
+        $errors{'error_messages'} = $parsed_errors;
+        $self->_set_parse_errors(\%errors);
+        return;
+    }
+
+
+    # Maps of plot-level data to use in overall validation
+    my %seen_plot_numbers;      # check for a plot numbers: used only once per trial
+    my %seen_plot_names;        # check for plot names: used only once per trial
+    my %seen_plot_positions;    # check for plot row / col positions: each position only used once per trial
+    my @seedlot_pairs;          # 2D array of [seedlot_name, accession_name]
+    my %seen_entry_numbers;     # check for entry numbers: used only once per trial
+    $seen_entry_numbers{'by_num'} = {};
+    $seen_entry_numbers{'by_acc'} = {};
+
+    ##
+    ## ROW BY ROW VALIDATION
+    ## These are checks on the individual plot-level data
+    ##
+    foreach (@$parsed_data) {
+        my $data = $_;
+        my $row = $data->{'_row'};
+        my $stock_name = $data->{'stock_name'};
+        my $plot_number = $data->{'plot_number'};
+        my $block_number = $data->{'block_number'};
+        my $plot_name = $data->{'plot_name'} || _create_plot_name($trial_name, $plot_number);
+        my $trial_type = $data->{'trial_type'};
+        my $plot_width = $data->{'plot_width'};
+        my $plot_length = $data->{'plot_length'};
+        my $field_size = $data->{'field_size'};
+        my $is_a_control = $data->{'is_a_control'};
+        my $rep_number = $data->{'rep_number'};
+        my $range_number = $data->{'range_number'};
+        my $row_number = $data->{'row_number'};
+        my $col_number = $data->{'col_number'};
+        my $seedlot_name = $data->{'seedlot_name'};
+        my $num_seed_per_plot = $data->{'num_seed_per_plot'};
+        my $weight_gram_seed_per_plot = $data->{'weight_gram_seed_per_plot'};
+        my $entry_number = $data->{'entry_number'};
+
+
+        # Plot Number: must be a positive number
+        if (!($plot_number =~ /^\d+?$/)) {
+            push @error_messages, "Row $row: plot number <strong>$plot_number</strong> must be a positive integer.";
+        }
+
+        # Block Number: must be a positive integer
+        if (!($block_number =~ /^\d+?$/)) {
+            push @error_messages, "Row $row: block number <strong>$block_number</strong> must be a positive integer.";
+        }
+
+        # Rep Number: must be a positive integer, if provided
+        if ($rep_number && !($rep_number =~ /^\d+?$/)){
+            push @error_messages, "Row $row: rep_number <strong>$rep_number</strong> must be a positive integer.";
+        }
+
+        # Plot Name: cannot contain spaces, should not contain slashes
+        if ($plot_name =~ /\s/ ) {
+            push @error_messages, "Row $row: plot name <strong>$plot_name</strong> must not contain spaces.";
+        }
+        if ($plot_name =~ /\// || $plot_name =~ /\\/) {
+            push @warning_messages, "Row $row: plot name <strong>$plot_name</strong> contains slashes. Note that slashes can cause problems for third-party applications; however, plot names can be saved with slashes if you ignore warnings.";
+        }
+
+        # Plot Width / Plot Length / Field Size: must be a positive number, if provided
+        if ($plot_width && !($plot_width =~ /^([\d]*)([\.]?)([\d]+)$/)) {
+            push @error_messages, "Row $row: plot_width <strong>$plot_width</strong> must be a positive number.";
+        }
+        if ($plot_length && !($plot_length =~ /^([\d]*)([\.]?)([\d]+)$/)) {
+            push @error_messages, "Row $row: plot_length <strong>$plot_length</strong> must be a positive number.";
+        }
+        if ($field_size && !($field_size =~ /^([\d]*)([\.]?)([\d]+)$/)) {
+            push @error_messages, "Row $row: plot_width <strong>$field_size</strong> must be a positive number.";
+        }
+
+         # Is A Control: must be blank, 0, or 1, if provided
+        if ( $is_a_control && $is_a_control ne '' && $is_a_control ne '0' && $is_a_control ne '1' ) {
+            push @error_messages, "Row $row: is_a_control value of <strong>$is_a_control</strong> is invalid.  It must be blank (not a control), 0 (not a control), or 1 (is a control).";
+        }
+
+        # Range Number / Row Number / Col Number: must be a positive integer, if provided
+        if ($range_number && !($range_number =~ /^\d+?$/)) {
+            push @error_messages, "Row $row: range_number <strong>$range_number</strong> must be a positive integer.";
+        }
+        if ($row_number && !($row_number =~ /^\d+?$/)) {
+            push @error_messages, "Row $row: row_number <strong>$row_number</strong> must be a positive integer.";
+        }
+        if ($col_number && !($col_number =~ /^\d+?$/)) {
+            push @error_messages, "Row $row: col_number <strong>$col_number</strong> must be a positive integer.";
+        }
+
+        # Seedlots: add seedlot_name / accession_name to seedlot_pairs
+        # count and weight must be a positive integer
+        # return a warning if both count and weight are not provided
+        if ( $seedlot_name ) {
+            push @seedlot_pairs, [$seedlot_name, $stock_name];
+            if ( $num_seed_per_plot && $num_seed_per_plot ne '' && !($num_seed_per_plot =~ /^\d+?$/) ) {
+                push @error_messages, "Row $row: num_seed_per_plot <strong>$num_seed_per_plot</strong> must be a positive integer.";
+            }
+            if ( $weight_gram_seed_per_plot && $weight_gram_seed_per_plot ne '' && !($weight_gram_seed_per_plot =~ /^\d+?$/) ) {
+                push @error_messages, "Row $row: weight_gram_seed_per_plot <strong>$weight_gram_seed_per_plot</strong> must be a positive integer.";
+            }
+            if ( !$num_seed_per_plot && !$weight_gram_seed_per_plot ) {
+                push @warning_messages, "Row $row: this plot does not have a count or weight of seed to be used from seedlot <strong>$seedlot_name</strong>."
+            }
+        }
+
+        # Entry Number: must be a positive integer, if provided
+        if ($entry_number && !($entry_number =~ /^\d+?$/)) {
+            push @error_messages, "Row $row: entry_number <strong>$entry_number</strong> must be a positive integer.";
+        }
+
+        # Treatment Values: must be either blank, 0, or 1
+        foreach my $treatment (@$treatments) {
+            my $treatment_value = $data->{$treatment};
+            if ( $treatment_value && $treatment_value ne '' && $treatment_value ne '0' && $treatment_value ne '1' ) {
+                push @error_messages, "Row $row: Treatment value for treatment <strong>$treatment</strong> should be either 1 (applied) or empty (not applied).";
+            }
+        }
+
+
+        # Map to check for duplicated plot numbers
+        if ( $plot_number ) {
+            $seen_plot_numbers{$plot_number}++;
+        }
+
+        # Map to check for duplicated plot names
+        if ( $plot_name ) {
+            $seen_plot_names{$plot_name}++;
+        }
+
+        # Map to check for overlapping plots
+        if ( $row_number && $col_number ) {
+            my $pk = "$row_number-$col_number";
+            if ( !exists $seen_plot_positions{$pk} ) {
+                $seen_plot_positions{$pk} = [$plot_number];
+            }
+            else {
+                push @{$seen_plot_positions{$pk}}, $plot_number;
+            }
+        }
+
+        # Map to check the entry number <-> accession associations
+        # For each trial: each entry number should only be associated with one accession
+        # and each accession should only be associated with one entry number
+        if ( $entry_number ) {
+            if ( !exists $seen_entry_numbers{'by_num'}->{$entry_number} ) {
+                $seen_entry_numbers{'by_num'}->{$entry_number} = [$stock_name];
+            }
+            else {
+                push @{$seen_entry_numbers{'by_num'}->{$entry_number}}, $stock_name;
+            }
+
+            if ( !exists $seen_entry_numbers{'by_acc'}->{$stock_name} ) {
+                $seen_entry_numbers{'by_acc'}->{$stock_name} = [$entry_number];
+            }
+            else {
+                push @{$seen_entry_numbers{'by_acc'}->{$stock_name}}, $entry_number;
+            }
+        }
+    }
+
+
+    ##
+    ## OVERALL VALIDATION
+    ## These are checks on the unique values of different columns
+    ##
+
+    # Trial Name: cannot already exist in the database, cannot contain spaces, should not contain slashes
+    my @already_used_trial_names;
+    my @missing_trial_names = @{$validator->validate($schema,'trials',[$trial_name])->{'missing'}};
+    my %unused_trial_names = map { $missing_trial_names[$_] => $_ } 0..$#missing_trial_names;
+    foreach (($trial_name)) {
+        push(@already_used_trial_names, $_) unless exists $unused_trial_names{$_};
+        if ($_ =~ /\s/) {
+            push @error_messages, "trial_name <strong>$_</strong> must not contain spaces.";
+        }
+        if ($_ =~ /\// || $_ =~ /\\/) {
+            push @warning_messages, "trial_name <strong>$_</strong> contains slashes. Note that slashes can cause problems for third-party applications; however, trial names can be saved with slashes if you ignore warnings.";
+        }
+    }
+    if (scalar(@already_used_trial_names) > 0) {
+        push @error_messages, "Trial name(s) <strong>".join(', ',@already_used_trial_names)."</strong> are invalid because they are already used in the database.";
+    }
+
+    # Stock Names: must exist in the database
+    my @entry_names = @{$parsed_values->{'stock_name'}};
+    my $entry_name_validator = CXGN::List::Validate->new();
+    my @entry_names_missing = @{$entry_name_validator->validate($schema,'accessions_or_crosses_or_familynames',\@entry_names)->{'missing'}};
+    if (scalar(@entry_names_missing) > 0) {
+        $errors{'missing_stocks'} = \@entry_names_missing;
+        push @error_messages, "The following entry names are not in the database as uniquenames or synonyms: ".join(',',@entry_names_missing);
+    }
+
+    # Seedlots: names must exist in the database
+    my @seedlots_missing = @{$validator->validate($schema,'seedlots',$parsed_values->{'seedlot_name'})->{'missing'}};
+    if (scalar(@seedlots_missing) > 0) {
+        push @error_messages, "Seedlot(s) <strong>".join(',',@seedlots_missing)."</strong> are not in the database.  To use a seedlot as a seed source for a plot, the seedlot must already exist in the database.";
+    }
+
+    # Verify seedlot pairs: accession name of plot must match seedlot contents
+    if ( scalar(@seedlot_pairs) > 0 ) {
+        my $return = CXGN::Stock::Seedlot->verify_seedlot_accessions_crosses($schema, \@seedlot_pairs);
+        if (exists($return->{error})){
+            push @error_messages, $return->{error};
+        }
+    }
+
+    # Plot Names: must not exist in the database (as any stock)
+    my @plot_names = keys %seen_plot_names;
+    my @already_used_plot_names;
+    my $rs = $schema->resultset("Stock::Stock")->search({
+        'is_obsolete' => { '!=' => 't' },
+        'uniquename' => { -in => \@plot_names }
+    });
+    foreach my $r ($rs->all()) {
+        push @already_used_plot_names, $r->uniquename();
+    }
+    if (scalar(@already_used_plot_names) > 0) {
+        push @error_messages, "Plot name(s) <strong>".join(', ',@already_used_plot_names)."</strong> are invalid because they are already used in the database.";
+    }
+
+    # Check for duplicated plot numbers
+    foreach my $pk (keys %seen_plot_numbers) {
+        my $count = $seen_plot_numbers{$pk};
+        if ( $count > 1 ) {
+            push @error_messages, "Plot number <strong>$pk</strong> is used $count times.  Each plot should have a unique plot number.";
+        }
+    }
+
+    # Check for duplicated plot names
+    foreach my $pk (keys %seen_plot_names) {
+        my $count = $seen_plot_names{$pk};
+        if ( $count > 1 ) {
+            push @error_messages, "Plot name <strong>$pk</strong> is used $count times. Each plot should have a unique plot name.";
+        }
+    }
+
+    # Check for overlapping plot positions (more than one plot assigned the same row/col positions)
+    foreach my $pk (keys %seen_plot_positions) {
+        my $plots = $seen_plot_positions{$pk};
+        my $count = scalar(@$plots);
+        if ( $count > 1 ) {
+            my @pos = split('-', $pk);
+            push @warning_messages, "More than 1 plot is assigned to the position row=" . $pos[0] . " col=" . $pos[1] . " plots=" . join(',', @$plots);
+        }
+    }
+
+    # Check for entry number errors:
+    # the same accession assigned different entry numbers
+    # the same entry number assigned to different accessions
+
+    # check assignments by accessions
+    foreach my $an (keys %{$seen_entry_numbers{'by_acc'}} ) {
+        my @ens = uniq @{$seen_entry_numbers{'by_acc'}{$an}};
+        my $count = scalar(@ens);
+        if ( scalar(@ens) > 1 ) {
+            push @error_messages, "Entry Number mismatch: Accession <strong>$an</strong> has multiple entry numbers (" . join(', ', @ens) . ") assigned to it.";
+        }
+    }
+
+    # check assigments by entry number
+    foreach my $en (keys %{$seen_entry_numbers{'by_num'}} ) {
+        my @ans = uniq @{$seen_entry_numbers{'by_num'}{$en}};
+        my $count = scalar(@ans);
+        if ( scalar(@ans) > 1 ) {
+            push @error_messages, "Entry Number mismatch: Entry number <strong>$en</strong> has multiple accessions (" . join(', ', @ans) . ") assigned to it.";
+        }
+    }
+
+    # Return warnings and error messages
+    if (scalar(@warning_messages) >= 1) {
+        $warnings{'warning_messages'} = \@warning_messages;
+        $self->_set_parse_warnings(\%warnings);
+    }
+    if (scalar(@error_messages) >= 1) {
+        $errors{'error_messages'} = \@error_messages;
+        $self->_set_parse_errors(\%errors);
+        return;
+    }
+
+    $self->_set_validated_data($parsed);
+    return 1; #returns true if validation is passed
+
+}
+
+sub _parse_with_plugin {
+    my $self = shift;
+    my $schema = $self->get_chado_schema();
+    my $trial_name = $self->get_trial_name();
+    my $parsed = $self->_get_validated_data();
+    my $data = $parsed->{'data'};
+    my $values = $parsed->{'values'};
+    my $treatments = $parsed->{'additional_columns'};
+
+    # Get synonyms for accessions in data
+    my $accession_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
+    my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
+    my @accessions = @{$values->{'stock_name'}};
+    my $acc_synonym_rs = $schema->resultset("Stock::Stock")->search({
+        'me.is_obsolete' => { '!=' => 't' },
+        'stockprops.value' => { -in => \@accessions},
+        'me.type_id' => $accession_cvterm_id,
+        'stockprops.type_id' => $synonym_cvterm_id
+    },{join => 'stockprops', '+select'=>['stockprops.value'], '+as'=>['synonym']});
+
+    # Create lookup hash for synonym -> uniquename -> stock id
+    my %stock_synonyms_lookup;
+    while (my $r=$acc_synonym_rs->next){
+        $stock_synonyms_lookup{$r->get_column('synonym')}->{$r->uniquename} = $r->stock_id;
+    }
+
+    # Build trial design
+    my %design;
+    my %seen_entry_numbers;
+    foreach (@$data) {
+        my $r = $_;
+        my $row = $r->{'_row'};
+        my $stock_name = $r->{'stock_name'};
+        my $plot_number = $r->{'plot_number'};
+        my $block_number = $r->{'block_number'};
+        my $plot_name = $r->{'plot_name'} || _create_plot_name($trial_name, $plot_number);
+        my $trial_type = $r->{'trial_type'};
+        my $plot_width = $r->{'plot_width'};
+        my $plot_length = $r->{'plot_length'};
+        my $field_size = $r->{'field_size'};
+        my $is_a_control = $r->{'is_a_control'};
+        my $rep_number = $r->{'rep_number'};
+        my $range_number = $r->{'range_number'};
+        my $row_number = $r->{'row_number'};
+        my $col_number = $r->{'col_number'};
+        my $seedlot_name = $r->{'seedlot_name'};
+        my $num_seed_per_plot = $r->{'num_seed_per_plot'} || 0;
+        my $weight_gram_seed_per_plot = $r->{'weight_gram_seed_per_plot'} || 0;
+        my $entry_number = $r->{'entry_number'};
+
+        foreach my $treatment_name (@$treatments) {
+            my $treatment_value = $r->{$treatment_name};
+            if ($treatment_value) {
+                push @{$design{treatments}->{$treatment_name}{new_treatment_stocks}}, $plot_name;
+            }
+        }
+
+        if ($stock_synonyms_lookup{$stock_name}) {
+            my @stock_names = keys %{$stock_synonyms_lookup{$stock_name}};
+            if (scalar(@stock_names)>1) {
+                print STDERR "There is more than one uniquename for this synonym $stock_name. this should not happen!\n";
+            }
+            $stock_name = $stock_names[0];
+        }
+
+        if ($entry_number) {
+            $seen_entry_numbers{$stock_name} = $entry_number;
+        }
+
+        $design{$row}->{plot_name} = $plot_name;
+        $design{$row}->{stock_name} = $stock_name;
+        $design{$row}->{plot_number} = $plot_number;
+        $design{$row}->{block_number} = $block_number;
+        if ($is_a_control) {
+            $design{$row}->{is_a_control} = 1;
+        } else {
+            $design{$row}->{is_a_control} = 0;
+        }
+        if ($rep_number) {
+            $design{$row}->{rep_number} = $rep_number;
+        }
+        if ($range_number) {
+            $design{$row}->{range_number} = $range_number;
+        }
+        if ($row_number) {
+            $design{$row}->{row_number} = $row_number;
+        }
+        if ($col_number) {
+            $design{$row}->{col_number} = $col_number;
+        }
+        if ($seedlot_name){
+            $design{$row}->{seedlot_name} = $seedlot_name;
+            $design{$row}->{num_seed_per_plot} = $num_seed_per_plot;
+            $design{$row}->{weight_gram_seed_per_plot} = $weight_gram_seed_per_plot;
+        }
+    }
+
+    my %parsed_data = (
+        design => \%design,
+        entry_numbers => \%seen_entry_numbers
+    );
+    $self->_set_parsed_data(\%parsed_data);
+
+    return 1;
+}
+
+sub _create_plot_name {
+  my $trial_name = shift;
+  my $plot_number = shift;
+  return $trial_name . "-PLOT_" . $plot_number;
+}
+
+1;

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialGeneric.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialGeneric.pm
@@ -118,7 +118,7 @@ sub _validate_with_plugin {
             push @error_messages, "Row $row: plot_width <strong>$field_size</strong> must be a positive number.";
         }
 
-         # Is A Control: must be blank, 0, or 1, if provided
+        # Is A Control: must be blank, 0, or 1, if provided
         if ( $is_a_control && $is_a_control ne '' && $is_a_control ne '0' && $is_a_control ne '1' ) {
             push @error_messages, "Row $row: is_a_control value of <strong>$is_a_control</strong> is invalid.  It must be blank (not a control), 0 (not a control), or 1 (is a control).";
         }

--- a/lib/SGN/Controller/AJAX/Trial.pm
+++ b/lib/SGN/Controller/AJAX/Trial.pm
@@ -994,7 +994,7 @@ sub upload_trial_file_POST : Args(0) {
 
     #parse uploaded file with appropriate plugin
     $parser = CXGN::Trial::ParseUpload->new(chado_schema => $chado_schema, filename => $archived_filename_with_path, trial_stock_type => $trial_stock_type, trial_name => $trial_name);
-    $parser->load_plugin('TrialExcelFormat');
+    $parser->load_plugin('TrialGeneric');
     $parsed_data = $parser->parse();
 
     if (!$parsed_data) {

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -556,6 +556,7 @@ $design_types => ()
                                     <li>You an add phenotypes for the plots or plants in this trial now.</li>
                                 </ul>
                                 <br/>
+                                <div name="upload_trial_completed_message"></div>
                                 <!--center>
                                 <button class="btn btn-primary" id="upload_trial_success_complete_button">The trial was saved to the database with no errors! Congrats Click Here</button><br/><br/>
                                 </center-->

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -66,6 +66,8 @@ $design_types => ()
                                             </&>
                                             <button id="next_step_file_formatting_button" class="btn btn-primary" onclick="Workflow.complete(this); return false;">Go to Next Step</button>
                                         </center>
+                                        <br /><br />
+                                        <& /help/file_upload_type.mas, type => "Single Trial Designs", optional_column => 1 &>
                                     </div>
 
                                     <div id="multiple_tab" class="tab-pane fade">
@@ -119,7 +121,7 @@ $design_types => ()
                                             <button style="display:none" class="btn btn-primary" id="upload_multiple_trials_success_button">Reload Page</button>
                                             <br /><br />
                                         </center>
-                                        <& /help/file_upload_type.mas, type => "Trials", optional_column => 1 &>
+                                        <& /help/file_upload_type.mas, type => "Multiple Trial Designs", optional_column => 1 &>
                                     </div>
 
                                 </div>

--- a/t/data/trial/trial_layout_bad_accessions.csv
+++ b/t/data/trial/trial_layout_bad_accessions.csv
@@ -1,0 +1,9 @@
+plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number
+ba_plot_01,bad_accession1,1,1,0,1,1,1,1
+ba_plot_02,bad_accession2,2,1,0,2,1,2,1
+ba_plot_03,bad_accession3,3,1,0,1,1,3,1
+ba_plot_04,bad_accession4,4,1,1,2,1,4,1
+ba_plot_05,bad_accession5,5,2,1,1,2,1,2
+ba_plot_06,bad_accession6,6,2,0,2,2,2,2
+ba_plot_07,bad_accession7,7,2,0,1,2,3,2
+ba_plot_08,bad_accession8,8,2,0,2,2,4,2

--- a/t/data/trial/trial_layout_example.csv
+++ b/t/data/trial/trial_layout_example.csv
@@ -1,0 +1,9 @@
+plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot
+plot_name1,test_accession1,1,1,0,1,1,1,1,,,
+plot_name2,test_accession1,2,1,0,2,1,2,1,,,
+plot_name3,test_accession2,3,1,0,1,1,3,1,,,
+plot_name4,test_accession2,4,1,0,2,1,4,1,,,
+plot_name5,test_accession3,5,2,0,1,2,1,2,,,
+plot_name6,test_accession3,6,2,0,2,2,2,2,,,
+plot_name7,test_accession4,7,2,0,1,2,3,2,,,
+plot_name8,test_accession4,8,2,0,2,2,4,2,,,

--- a/t/data/trial/trial_layout_example_flexible.csv
+++ b/t/data/trial/trial_layout_example_flexible.csv
@@ -1,0 +1,9 @@
+entry_number,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number
+1,test_accession1,1,1,0,1,1,1,1
+1,test_accession1,2,1,0,2,1,2,1
+2,test_accession2,3,1,0,1,1,3,1
+2,test_accession2,4,1,0,2,1,4,1
+3,test_accession3,5,2,0,1,2,1,2
+3,test_accession3,6,2,0,2,2,2,2
+4,test_accession4,7,2,0,1,2,3,2
+4,test_accession4,8,2,0,2,2,4,2

--- a/t/data/trial/trial_layout_example_with_management_factor.csv
+++ b/t/data/trial/trial_layout_example_with_management_factor.csv
@@ -1,0 +1,9 @@
+plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot,fert_factor1,manage_factor2
+trial_management_factor_plot_name1,test_accession1,1,1,0,1,1,1,1,,,,1,
+trial_management_factor_plot_name2,test_accession1,2,1,0,2,1,2,1,,,,1,
+trial_management_factor_plot_name3,test_accession2,3,1,0,1,1,3,1,,,,1,1
+trial_management_factor_plot_name4,test_accession2,4,1,0,2,1,4,1,,,,,1
+trial_management_factor_plot_name5,test_accession3,5,2,0,1,2,1,2,,,,,1
+trial_management_factor_plot_name6,test_accession3,6,2,0,2,2,2,2,,,,1,
+trial_management_factor_plot_name7,test_accession4,7,2,0,1,2,3,2,,,,1,
+trial_management_factor_plot_name8,test_accession4,8,2,0,2,2,4,2,,,,1,

--- a/t/data/trial/trial_layout_with_seedlot_example.csv
+++ b/t/data/trial/trial_layout_with_seedlot_example.csv
@@ -1,0 +1,9 @@
+plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot
+plot_with_seedlot_name1,test_accession1,1,1,0,1,1,1,1,test_accession1_001,12,
+plot_with_seedlot_name2,test_accession1,2,1,0,2,1,2,1,test_accession1_001,12,
+plot_with_seedlot_name3,test_accession2,3,1,0,1,1,3,1,test_accession2_001,12,4
+plot_with_seedlot_name4,test_accession2,4,1,0,2,1,4,1,test_accession2_001,12,5
+plot_with_seedlot_name5,test_accession3,5,2,0,1,2,1,2,test_accession3_001,12,
+plot_with_seedlot_name6,test_accession3,6,2,0,2,2,2,2,test_accession3_001,12,
+plot_with_seedlot_name7,test_accession4,7,2,0,1,2,3,2,test_accession4_001,12,
+plot_with_seedlot_name8,test_accession4,8,2,0,2,2,4,2,test_accession4_001,12,

--- a/t/unit_fixture/CXGN/Trial/ParseUpload.t
+++ b/t/unit_fixture/CXGN/Trial/ParseUpload.t
@@ -9,7 +9,7 @@ use Data::Dumper;
 
 my $f = SGN::Test::Fixture->new();
 
-for my $extension ("xls", "xlsx") {
+for my $extension ("xls", "xlsx", "csv") {
 
     my $p = CXGN::Trial::ParseUpload->new({ filename => "t/data/genotype_trial_upload/CASSAVA_GS_74Template.csv", chado_schema => $f->bcs_schema() });
     $p->load_plugin("ParseIGDFile");
@@ -54,7 +54,14 @@ for my $extension ("xls", "xlsx") {
 
     $results = $p->parse();
     $errors = $p->get_parse_errors();
-    ok($errors->{'error_messages'}->[0] eq "No Excel data found in file", 'check that accessions not in db');
+    my $expected = {
+        'error_messages' => [
+            'Required column stock_name is missing',
+            'Required column plot_number is missing',
+            'Required column block_number is missing'
+        ]
+    };
+    is_deeply($errors, $expected, 'check file format errors');
 
     $f->clean_up_db();
 }

--- a/t/unit_fixture/CXGN/Trial/ParseUpload.t
+++ b/t/unit_fixture/CXGN/Trial/ParseUpload.t
@@ -40,7 +40,7 @@ for my $extension ("xls", "xlsx") {
     ok($errors->{'error_messages'}->[0] eq "All trial names in the trial column must be identical", "detect messed up trial name");
 
     $p = CXGN::Trial::ParseUpload->new({ filename => "t/data/trial/trial_layout_bad_accessions.$extension", chado_schema => $f->bcs_schema() });
-    $p->load_plugin("TrialExcelFormat");
+    $p->load_plugin("TrialGeneric");
 
     $results = $p->parse();
     $errors = $p->get_parse_errors();
@@ -50,7 +50,7 @@ for my $extension ("xls", "xlsx") {
     ok(scalar(@{$errors->{'missing_stocks'}}) == 8, 'check that accessions not in db');
 
     $p = CXGN::Trial::ParseUpload->new({ filename => "t/data/genotype_trial_upload/CASSAVA_GS_74Template_messed_up_trial_name.csv", chado_schema => $f->bcs_schema() });
-    $p->load_plugin("TrialExcelFormat");
+    $p->load_plugin("TrialGeneric");
 
     $results = $p->parse();
     $errors = $p->get_parse_errors();

--- a/t/unit_fixture/CXGN/Uploading/TrialUpload.t
+++ b/t/unit_fixture/CXGN/Uploading/TrialUpload.t
@@ -25,7 +25,7 @@ use Text::CSV;
 
 my $f = SGN::Test::Fixture->new();
 
-for my $extension ("xls", "xlsx") {
+for my $extension ("xls", "xlsx", "csv") {
 
 	my $c = SimulateC->new({ dbh => $f->dbh(),
 		bcs_schema               => $f->bcs_schema(),
@@ -96,7 +96,7 @@ for my $extension ("xls", "xlsx") {
 	#print STDERR Dumper $parsed_data;
 
 	my $parsed_data_check = {
-		'1' => {
+		'2' => {
 			'plot_name'    => 'plot_name1',
 			'stock_name'   => 'test_accession1',
 			'col_number'   => '1',
@@ -107,7 +107,7 @@ for my $extension ("xls", "xlsx") {
 			'row_number'   => '1',
 			'plot_number'  => '1'
 		},
-		'6' => {
+		'7' => {
 			'rep_number'   => '2',
 			'is_a_control' => 0,
 			'block_number' => '2',
@@ -118,7 +118,7 @@ for my $extension ("xls", "xlsx") {
 			'row_number'   => '2',
 			'plot_number'  => '6'
 		},
-		'7' => {
+		'8' => {
 			'range_number' => '2',
 			'row_number'   => '3',
 			'plot_number'  => '7',
@@ -129,7 +129,7 @@ for my $extension ("xls", "xlsx") {
 			'is_a_control' => 0,
 			'block_number' => '2'
 		},
-		'4' => {
+		'5' => {
 			'range_number' => '1',
 			'plot_number'  => '4',
 			'row_number'   => '4',
@@ -140,7 +140,7 @@ for my $extension ("xls", "xlsx") {
 			'col_number'   => '1',
 			'stock_name'   => 'test_accession2'
 		},
-		'8' => {
+		'9' => {
 			'range_number' => '2',
 			'row_number'   => '4',
 			'plot_number'  => '8',
@@ -151,7 +151,7 @@ for my $extension ("xls", "xlsx") {
 			'is_a_control' => 0,
 			'block_number' => '2'
 		},
-		'2' => {
+		'3' => {
 			'range_number' => '1',
 			'plot_number'  => '2',
 			'row_number'   => '2',
@@ -162,7 +162,7 @@ for my $extension ("xls", "xlsx") {
 			'rep_number'   => '2',
 			'block_number' => '1'
 		},
-		'5' => {
+		'6' => {
 			'range_number' => '2',
 			'row_number'   => '1',
 			'plot_number'  => '5',
@@ -173,7 +173,7 @@ for my $extension ("xls", "xlsx") {
 			'rep_number'   => '1',
 			'block_number' => '2'
 		},
-		'3' => {
+		'4' => {
 			'stock_name'   => 'test_accession2',
 			'col_number'   => '1',
 			'plot_name'    => 'plot_name3',
@@ -558,7 +558,7 @@ for my $extension ("xls", "xlsx") {
 	#print STDERR Dumper $parsed_data;
 
 	my $parsed_data_check = {
-		'7' => {
+		'8' => {
 			'is_a_control'              => 0,
 			'num_seed_per_plot'         => '12',
 			'block_number'              => '2',
@@ -572,7 +572,7 @@ for my $extension ("xls", "xlsx") {
 			'weight_gram_seed_per_plot' => 0,
 			'row_number'                => '3'
 		},
-		'4' => {
+		'5' => {
 			'row_number'                => '4',
 			'weight_gram_seed_per_plot' => '5',
 			'range_number'              => '1',
@@ -586,7 +586,7 @@ for my $extension ("xls", "xlsx") {
 			'plot_name'                 => 'plot_with_seedlot_name4',
 			'col_number'                => '1'
 		},
-		'1' => {
+		'2' => {
 			'row_number'                => '1',
 			'weight_gram_seed_per_plot' => 0,
 			'range_number'              => '1',
@@ -600,7 +600,7 @@ for my $extension ("xls", "xlsx") {
 			'plot_name'                 => 'plot_with_seedlot_name1',
 			'col_number'                => '1'
 		},
-		'5' => {
+		'6' => {
 			'range_number'              => '2',
 			'row_number'                => '1',
 			'weight_gram_seed_per_plot' => 0,
@@ -614,7 +614,7 @@ for my $extension ("xls", "xlsx") {
 			'num_seed_per_plot'         => '12',
 			'block_number'              => '2'
 		},
-		'2' => {
+		'3' => {
 			'block_number'              => '1',
 			'num_seed_per_plot'         => '12',
 			'is_a_control'              => 0,
@@ -628,7 +628,7 @@ for my $extension ("xls", "xlsx") {
 			'weight_gram_seed_per_plot' => 0,
 			'range_number'              => '1'
 		},
-		'3' => {
+		'4' => {
 			'weight_gram_seed_per_plot' => '4',
 			'row_number'                => '3',
 			'range_number'              => '1',
@@ -642,7 +642,7 @@ for my $extension ("xls", "xlsx") {
 			'plot_name'                 => 'plot_with_seedlot_name3',
 			'col_number'                => '1'
 		},
-		'6' => {
+		'7' => {
 			'col_number'                => '2',
 			'plot_name'                 => 'plot_with_seedlot_name6',
 			'stock_name'                => 'test_accession3',
@@ -656,7 +656,7 @@ for my $extension ("xls", "xlsx") {
 			'row_number'                => '2',
 			'weight_gram_seed_per_plot' => 0
 		},
-		'8' => {
+		'9' => {
 			'seedlot_name'              => 'test_accession4_001',
 			'plot_number'               => '8',
 			'weight_gram_seed_per_plot' => 0,
@@ -774,100 +774,103 @@ for my $extension ("xls", "xlsx") {
 	my $sgn_session_id = $response->{access_token};
 	print STDERR $sgn_session_id . "\n";
 
-	my $file = $f->config->{basepath} . "/t/data/genotype_trial_upload/genotype_trial_upload.$extension";
-	my $ua = LWP::UserAgent->new;
-	$response = $ua->post(
-		'http://localhost:3010/ajax/breeders/parsegenotypetrial',
-		Content_Type => 'form-data',
-		Content      => [
-			genotyping_trial_layout_upload => [
-				$file,
-				"genotype_trial_upload.$extension",
-				Content_Type => ($extension eq "xls") ? 'application/vnd.ms-excel' : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-			],
-			"sgn_session_id"               => $sgn_session_id,
-			"genotyping_trial_name"        => '2018TestPlate02'
-		]
-	);
+	# Genotype trial upload does not yet support CSV files
+	if ( $extension ne 'csv' ) {
+		my $file = $f->config->{basepath} . "/t/data/genotype_trial_upload/genotype_trial_upload.$extension";
+		my $ua = LWP::UserAgent->new;
+		$response = $ua->post(
+			'http://localhost:3010/ajax/breeders/parsegenotypetrial',
+			Content_Type => 'form-data',
+			Content      => [
+				genotyping_trial_layout_upload => [
+					$file,
+					"genotype_trial_upload.$extension",
+					Content_Type => ($extension eq "xls") ? 'application/vnd.ms-excel' : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+				],
+				"sgn_session_id"               => $sgn_session_id,
+				"genotyping_trial_name"        => '2018TestPlate02'
+			]
+		);
 
-	ok($response->is_success);
-	my $message = $response->decoded_content;
-	my $message_hash = decode_json $message;
+		ok($response->is_success);
+		my $message = $response->decoded_content;
+		my $message_hash = decode_json $message;
 
-	is_deeply($message_hash, {
-		'success' => '1',
-		'design'  => {
-			'A01' => {
-				'concentration'       => '5',
-				'acquisition_date'    => '2018/02/16',
-				'dna_person'          => 'nmorales',
-				'volume'              => '10',
-				'col_number'          => '1',
-				'plot_name'           => '2018TestPlate02_A01',
-				'ncbi_taxonomy_id'    => '9001',
-				'stock_name'          => 'KASESE_TP2013_885',
-				'notes'               => 'test well A01',
-				'is_blank'            => 0,
-				'extraction'          => 'CTAB',
-				'plot_number'         => 'A01',
-				'row_number'          => 'A',
-				'tissue_type'         => 'leaf',
-				'facility_identifier' => undef
-			},
-			'A03' => {
-				'notes'               => 'test well A03',
-				'is_blank'            => 0,
-				'stock_name'          => 'KASESE_TP2013_1671',
-				'ncbi_taxonomy_id'    => '9001',
-				'plot_name'           => '2018TestPlate02_A03',
-				'tissue_type'         => 'leaf',
-				'row_number'          => 'A',
-				'plot_number'         => 'A03',
-				'extraction'          => 'CTAB',
-				'volume'              => '10',
-				'dna_person'          => 'nmorales',
-				'concentration'       => '5',
-				'acquisition_date'    => '2018/02/16',
-				'col_number'          => '3',
-				'facility_identifier' => undef
-			},
-			'A02' => {
-				'extraction'          => undef,
-				'plot_number'         => 'A02',
-				'row_number'          => 'A',
-				'tissue_type'         => 'stem',
-				'stock_name'          => 'BLANK',
-				'notes'               => 'test blank',
-				'is_blank'            => 1,
-				'ncbi_taxonomy_id'    => undef,
-				'plot_name'           => '2018TestPlate02_A02',
-				'col_number'          => '2',
-				'volume'              => undef,
-				'acquisition_date'    => '2018/02/16',
-				'concentration'       => undef,
-				'dna_person'          => 'nmorales',
-				'facility_identifier' => undef
+		is_deeply($message_hash, {
+			'success' => '1',
+			'design'  => {
+				'A01' => {
+					'concentration'       => '5',
+					'acquisition_date'    => '2018/02/16',
+					'dna_person'          => 'nmorales',
+					'volume'              => '10',
+					'col_number'          => '1',
+					'plot_name'           => '2018TestPlate02_A01',
+					'ncbi_taxonomy_id'    => '9001',
+					'stock_name'          => 'KASESE_TP2013_885',
+					'notes'               => 'test well A01',
+					'is_blank'            => 0,
+					'extraction'          => 'CTAB',
+					'plot_number'         => 'A01',
+					'row_number'          => 'A',
+					'tissue_type'         => 'leaf',
+					'facility_identifier' => undef
+				},
+				'A03' => {
+					'notes'               => 'test well A03',
+					'is_blank'            => 0,
+					'stock_name'          => 'KASESE_TP2013_1671',
+					'ncbi_taxonomy_id'    => '9001',
+					'plot_name'           => '2018TestPlate02_A03',
+					'tissue_type'         => 'leaf',
+					'row_number'          => 'A',
+					'plot_number'         => 'A03',
+					'extraction'          => 'CTAB',
+					'volume'              => '10',
+					'dna_person'          => 'nmorales',
+					'concentration'       => '5',
+					'acquisition_date'    => '2018/02/16',
+					'col_number'          => '3',
+					'facility_identifier' => undef
+				},
+				'A02' => {
+					'extraction'          => undef,
+					'plot_number'         => 'A02',
+					'row_number'          => 'A',
+					'tissue_type'         => 'stem',
+					'stock_name'          => 'BLANK',
+					'notes'               => 'test blank',
+					'is_blank'            => 1,
+					'ncbi_taxonomy_id'    => undef,
+					'plot_name'           => '2018TestPlate02_A02',
+					'col_number'          => '2',
+					'volume'              => undef,
+					'acquisition_date'    => '2018/02/16',
+					'concentration'       => undef,
+					'dna_person'          => 'nmorales',
+					'facility_identifier' => undef
+				}
 			}
-		}
-	});
+		});
 
-	my $project = $c->bcs_schema()->resultset("Project::Project")->find({ name => 'test' });
-	my $location = $c->bcs_schema()->resultset("NaturalDiversity::NdGeolocation")->find({ description => 'test_location' });
+		my $project = $c->bcs_schema()->resultset("Project::Project")->find({ name => 'test' });
+		my $location = $c->bcs_schema()->resultset("NaturalDiversity::NdGeolocation")->find({ description => 'test_location' });
 
-	my $plate_data = {
-		design                     => $message_hash->{design},
-		genotyping_facility_submit => 'yes',
-		name                       => 'test_genotype_upload_trial1',
-		genotyping_project_id      => $genotyping_project_id_2,
-		sample_type                => 'DNA',
-		plate_format               => '96'
-	};
+		my $plate_data = {
+			design                     => $message_hash->{design},
+			genotyping_facility_submit => 'yes',
+			name                       => 'test_genotype_upload_trial1',
+			genotyping_project_id      => $genotyping_project_id_2,
+			sample_type                => 'DNA',
+			plate_format               => '96'
+		};
 
-	$mech->post_ok('http://localhost:3010/ajax/breeders/storegenotypetrial', [ "sgn_session_id" => $sgn_session_id, plate_data => encode_json($plate_data) ]);
-	$response = decode_json $mech->content;
-	#print STDERR Dumper $response;
+		$mech->post_ok('http://localhost:3010/ajax/breeders/storegenotypetrial', [ "sgn_session_id" => $sgn_session_id, plate_data => encode_json($plate_data) ]);
+		$response = decode_json $mech->content;
+		#print STDERR Dumper $response;
 
-	ok($response->{trial_id});
+		ok($response->{trial_id});
+	}
 
 	my $file = $f->config->{basepath} . "/t/data/genotype_trial_upload/CoordinateTemplate.csv";
 	my $ua = LWP::UserAgent->new;
@@ -1257,7 +1260,7 @@ for my $extension ("xls", "xlsx") {
 	#print STDERR Dumper $parsed_data;
 
 	my $parsed_data_check_with_management_factor = {
-		'7'          => {
+		'8'          => {
 			'plot_number'  => '7',
 			'col_number'   => '2',
 			'block_number' => '2',
@@ -1268,7 +1271,7 @@ for my $extension ("xls", "xlsx") {
 			'range_number' => '2',
 			'plot_name'    => 'trial_management_factor_plot_name7'
 		},
-		'5'          => {
+		'6'          => {
 			'col_number'   => '2',
 			'plot_number'  => '5',
 			'rep_number'   => '1',
@@ -1279,7 +1282,7 @@ for my $extension ("xls", "xlsx") {
 			'range_number' => '2',
 			'plot_name'    => 'trial_management_factor_plot_name5'
 		},
-		'3'          => {
+		'4'          => {
 			'block_number' => '1',
 			'rep_number'   => '1',
 			'plot_number'  => '3',
@@ -1290,7 +1293,7 @@ for my $extension ("xls", "xlsx") {
 			'stock_name'   => 'test_accession2',
 			'is_a_control' => 0
 		},
-		'4'          => {
+		'5'          => {
 			'stock_name'   => 'test_accession2',
 			'is_a_control' => 0,
 			'row_number'   => '4',
@@ -1301,7 +1304,7 @@ for my $extension ("xls", "xlsx") {
 			'block_number' => '1',
 			'rep_number'   => '2'
 		},
-		'8'          => {
+		'9'          => {
 			'rep_number'   => '2',
 			'block_number' => '2',
 			'plot_number'  => '8',
@@ -1312,7 +1315,7 @@ for my $extension ("xls", "xlsx") {
 			'stock_name'   => 'test_accession4',
 			'is_a_control' => 0
 		},
-		'1'          => {
+		'2'          => {
 			'block_number' => '1',
 			'rep_number'   => '1',
 			'plot_number'  => '1',
@@ -1323,7 +1326,7 @@ for my $extension ("xls", "xlsx") {
 			'range_number' => '1',
 			'row_number'   => '1'
 		},
-		'2'          => {
+		'3'          => {
 			'plot_name'    => 'trial_management_factor_plot_name2',
 			'range_number' => '1',
 			'row_number'   => '2',
@@ -1353,7 +1356,7 @@ for my $extension ("xls", "xlsx") {
 				]
 			}
 		},
-		'6'          => {
+		'7'          => {
 			'row_number'   => '2',
 			'range_number' => '2',
 			'plot_name'    => 'trial_management_factor_plot_name6',
@@ -1483,7 +1486,7 @@ for my $extension ("xls", "xlsx") {
 	ok(!$parser->has_parse_errors(), "Check that parse returns no errors");
 
 	my $parsed_data_check = {
-		'1' => {
+		'2' => {
 			'plot_name'    => 'Trial_upload_test_flexible-PLOT_1',
 			'stock_name'   => 'test_accession1',
 			'col_number'   => '1',
@@ -1494,7 +1497,7 @@ for my $extension ("xls", "xlsx") {
 			'row_number'   => '1',
 			'plot_number'  => '1'
 		},
-		'6' => {
+		'7' => {
 			'rep_number'   => '2',
 			'is_a_control' => 0,
 			'block_number' => '2',
@@ -1505,7 +1508,7 @@ for my $extension ("xls", "xlsx") {
 			'row_number'   => '2',
 			'plot_number'  => '6'
 		},
-		'7' => {
+		'8' => {
 			'range_number' => '2',
 			'row_number'   => '3',
 			'plot_number'  => '7',
@@ -1516,7 +1519,7 @@ for my $extension ("xls", "xlsx") {
 			'is_a_control' => 0,
 			'block_number' => '2'
 		},
-		'4' => {
+		'5' => {
 			'range_number' => '1',
 			'plot_number'  => '4',
 			'row_number'   => '4',
@@ -1527,7 +1530,7 @@ for my $extension ("xls", "xlsx") {
 			'col_number'   => '1',
 			'stock_name'   => 'test_accession2'
 		},
-		'8' => {
+		'9' => {
 			'range_number' => '2',
 			'row_number'   => '4',
 			'plot_number'  => '8',
@@ -1538,7 +1541,7 @@ for my $extension ("xls", "xlsx") {
 			'is_a_control' => 0,
 			'block_number' => '2'
 		},
-		'2' => {
+		'3' => {
 			'range_number' => '1',
 			'plot_number'  => '2',
 			'row_number'   => '2',
@@ -1549,7 +1552,7 @@ for my $extension ("xls", "xlsx") {
 			'rep_number'   => '2',
 			'block_number' => '1'
 		},
-		'5' => {
+		'6' => {
 			'range_number' => '2',
 			'row_number'   => '1',
 			'plot_number'  => '5',
@@ -1560,7 +1563,7 @@ for my $extension ("xls", "xlsx") {
 			'rep_number'   => '1',
 			'block_number' => '2'
 		},
-		'3' => {
+		'4' => {
 			'stock_name'   => 'test_accession2',
 			'col_number'   => '1',
 			'plot_name'    => 'Trial_upload_test_flexible-PLOT_3',

--- a/t/unit_fixture/CXGN/Uploading/TrialUpload.t
+++ b/t/unit_fixture/CXGN/Uploading/TrialUpload.t
@@ -88,7 +88,7 @@ for my $extension ("xls", "xlsx") {
 
 	#parse uploaded file with appropriate plugin
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $archived_filename_with_path);
-	$parser->load_plugin('TrialExcelFormat');
+	$parser->load_plugin('TrialGeneric');
 	$parsed_data = $parser->parse()->{'design'};
 	ok($parsed_data, "Check if parse validate excel file works");
 	ok(!$parser->has_parse_errors(), "Check that parse returns no errors");
@@ -269,7 +269,7 @@ for my $extension ("xls", "xlsx") {
 	$file_name = 't/data/genotype_trial_upload/CASSAVA_GS_74Template.csv';
 	#parse uploaded file with wrong plugin
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $file_name);
-	$parser->load_plugin('TrialExcelFormat');
+	$parser->load_plugin('TrialGeneric');
 	my $rtn = $parser->parse();
 	$parsed_data = $rtn->{'design'};
 	ok(!$parsed_data, "Check if parse validate excel fails for igd parser");
@@ -549,7 +549,7 @@ for my $extension ("xls", "xlsx") {
 
 	#parse uploaded file with appropriate plugin
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $archived_filename_with_path);
-	$parser->load_plugin('TrialExcelFormat');
+	$parser->load_plugin('TrialGeneric');
 	$rtn = $parser->parse();
 	$parsed_data = $rtn->{'design'};
 	ok($parsed_data, "Check if parse validate excel file works");
@@ -1248,7 +1248,7 @@ for my $extension ("xls", "xlsx") {
 	ok($md5_management_factor);
 
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $management_factor_archived_filename_with_path);
-	$parser->load_plugin('TrialExcelFormat');
+	$parser->load_plugin('TrialGeneric');
 	$rtn = $parser->parse();
 	$parsed_data = $rtn->{'design'};
 	ok($parsed_data, "Check if parse validate excel file works");
@@ -1475,7 +1475,7 @@ for my $extension ("xls", "xlsx") {
 
 	#parse uploaded file with appropriate plugin
 	$parser = CXGN::Trial::ParseUpload->new(chado_schema => $f->bcs_schema(), filename => $archived_filename_with_path, trial_name => $trial_name);
-	$parser->load_plugin('TrialExcelFormat');
+	$parser->load_plugin('TrialGeneric');
 	my $p = $parser->parse();
 	$parsed_data = $p->{'design'};
 	my $entry_numbers = $p->{'entry_numbers'};


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

- Add a generic file parser plugin for the Single Trial upload
- Remove the usage of the iFramePostForm plugin and use the standard jQuery ajax function instead.
- Fix the single trial upload tests (changes row indices from 0-based to 1-based)
- Add tests for CSV uploads

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
