### PR TITLE
Seedlot Trial Filter: fix query to get stocks in trial

### DIFF
--- a/lib/CXGN/Stock/Seedlot.pm
+++ b/lib/CXGN/Stock/Seedlot.pm
@@ -444,7 +444,7 @@ sub list_seedlots {
         $q .= " WHERE type_id = (SELECT cvterm_id FROM public.cvterm WHERE name = 'seed transaction')";
 
         # Subquery to get stocks (plots, etc) in requested trial
-        my $sq = "SELECT DISTINCT(stock_id) FROM public.materialized_phenoview WHERE trial_id = (SELECT project_id FROM public.project WHERE name = ?)";
+        my $sq = "SELECT DISTINCT(observationunit_stock_id) FROM public.materialized_phenotype_jsonb_table WHERE trial_name = ?";
         my @filters;
 
         # Add source transaction (plot --> seedlot)


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


This fixes a subquery in the Seedlot Trial usage filter.

It was missing stocks (plots, subplots, plants) from a trial if there were no traits observed for that stock.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
