### PR TITLE
Store Phenotypes: wrap verify & store in try/catch

### DIFF
--- a/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
+++ b/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
@@ -82,8 +82,14 @@ sub upload_phenotype_verify_POST : Args(1) {
         composable_validation_check_name=>$c->config->{composable_validation_check_name}
     );
 
-    my $warning_status;
-    my ($verified_warning, $verified_error) = $store_phenotypes->verify();
+    my ($warning_status, $verified_warning, $verified_error);
+    try {
+        ($verified_warning, $verified_error) = $store_phenotypes->verify();
+    }
+    catch {
+        $verified_error = $_;
+    };
+
     if ($verified_error) {
         push @$error_status, $verified_error;
         $c->stash->{rest} = {success => $success_status, error => $error_status };
@@ -157,7 +163,14 @@ sub upload_phenotype_store_POST : Args(1) {
     #}
     #push @$success_status, "File data verified. Plot names and trait names are valid.";
 
-    my ($stored_phenotype_error, $stored_phenotype_success) = $store_phenotypes->store();
+    my ($stored_phenotype_error, $stored_phenotype_success);
+    try {
+        ($stored_phenotype_error, $stored_phenotype_success) = $store_phenotypes->store();
+    }
+    catch {
+        $stored_phenotype_error = $_;
+    };
+
     if ($stored_phenotype_error) {
         push @$error_status, $stored_phenotype_error;
         $c->stash->{rest} = {success => $success_status, error => $error_status};


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This wraps the verify and store functions of PhenotypesUpload in a try/catch block to return uncaught error messages to the user.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
