### PR TITLE
Fix bug in graphical filtering tool add to list 

### DIFF
--- a/lib/CXGN/BrAPI/v2/ObservationUnits.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationUnits.pm
@@ -228,7 +228,7 @@ sub _search {
         ## Format position coordinates
         my $level_name = $obs_unit->{obsunit_type_name};
 
-	print STDERR "LEVEL NAME: ".Dumper(\%numbers);
+	    # print STDERR "LEVEL NAME: ".Dumper(\%numbers);
 
         my $level_order = _order($level_name) + 0;
 

--- a/mason/tools/graphicalfiltering/index.mas
+++ b/mason/tools/graphicalfiltering/index.mas
@@ -225,20 +225,35 @@
   });
 
   $('#filtered_results').on( 'draw.dt', function () {
+    var table = $("#filtered_results").DataTable();
+    var accessionColumnIndex = -1;
 
-        var names = [];
-        var data = $("#filtered_results").DataTable().context[0].aoData;
-        var displayed_rows = $("#filtered_results").DataTable().context[0].aiDisplay;
-        var names = [];
-        for (var i =0; i< displayed_rows.length; i++){
-            var displayed_index = displayed_rows[i];
-            names.push(data[displayed_index]._aFilterData[2]+'\n');
+    // Determine the correct column index for "Accession"
+    table.columns().every(function (index) {
+        var header = this.header();
+        if ($(header).text().trim() === "Accession") {
+            accessionColumnIndex = index;
         }
-        $('#graphical_filter_result_names').html(names);
-        addToListMenu('graphical_filter_results_to_list_menu', 'graphical_filter_result_names', {
-            listType: 'accessions'
-        });
     });
+
+    if (accessionColumnIndex === -1) {
+        console.error("Accession column not found.");
+        return;
+    }
+
+    var names = [];
+    var displayed_rows = table.rows({ filter: 'applied' }).indexes();
+    displayed_rows.each(function (index) {
+        var accessionName = table.cell(index, accessionColumnIndex).data();
+        names.push(accessionName + '\n');
+    });
+
+    $('#graphical_filter_result_names').html(names.join(''));
+    addToListMenu('graphical_filter_results_to_list_menu', 'graphical_filter_result_names', {
+        listType: 'accessions'
+    });
+
+  });
   
 }());
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Updates graphical filtering tool add to list feature to dynmically retrieve index of the column in the table that contains accession names.

<!-- If there are relevant issues, link them here: -->

closes #5253

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
