### PR TITLE
List Manager Improvements

### DIFF
--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -335,8 +335,10 @@ CXGN.List.prototype = {
         });
     },
 
-    renderLists: function(div) {
+    renderLists: function(div, { type, autocreated = true } = {}) {
         var lists = this.availableLists();
+        var types = this.allListTypes();
+
         var html = '';
         html = html + '<div class="well well-sm"><form class="form-horizontal"><div class="form-group form-group-sm"><label class="col-sm-3 control-label">Create New List: </label><div class="col-sm-9"><div class="input-group"><input id="add_list_input" type="text" class="form-control" placeholder="Create New List. Type New List Name Here" /><span class="input-group-btn"><button class="btn btn-primary btn-sm" type="button" id="add_list_button" value="new list">New List</button></span></div></div></div><div class="form-group form-group-sm"><label class="col-sm-3 control-label"></label><div class="col-sm-9">';
         html = html + '<input id="add_list_input_description" type="text" class="form-control" placeholder="Description For New List" /></div></div></form></div>';
@@ -346,25 +348,40 @@ CXGN.List.prototype = {
             jQuery('#'+div+'_div').html(html);
         }
 
-        html += '<div class="well well-sm"><table id="private_list_data_table" class="table table-hover table-condensed">';
+        // Add list type filter
+        html += "<div class='well'>";
+        html += "<div style='display: flex; flex-wrap: wrap; align-items: baseline; column-gap: 15px; margin-bottom: 15px'>";
+        html += "<p style='white-space: nowrap'><strong>Filter Lists by Type</strong>:</p>";
+        html += "<select id='render_lists_type' class='form-control' style='max-width: 200px'>";
+        html += "<option value=''>Any</option>";
+        for ( let i = 0; i < types.length; i++ ) {
+            let selected = type && type === types[i][1] ? 'selected' : '';
+            html += "<option value='" + types[i][1] + "' " + selected + ">"+types[i][1]+"</option>";
+        }
+        html += "</select>";
+        html += "</div>";
+
+        html += '<table id="private_list_data_table" class="table table-hover table-condensed">';
         html += '<thead><tr><th>List Name</th><th>Description</th><th>Date Created</th><th>Date Modified</th><th>Count</th><th>Type</th><th>Validate</th><th>View</th><th>Delete</th><th>Download</th><th>Share</th><th>Group</th></tr></thead><tbody>';
         for (var i = 0; i < lists.length; i++) {
-            html += '<tr><td><a href="javascript:showListItems(\'list_item_dialog\','+lists[i][0]+')"><b>'+lists[i][1]+'</b></a></td>';
-            html += '<td>'+lists[i][2]+'</td>';
-            html += '<td>'+lists[i][7]+'</td>';
-            html += '<td>'+lists[i][8]+'</td>';
-            html += '<td>'+lists[i][3]+'</td>';
-            html += '<td>'+lists[i][5]+'</td>';
-            html += '<td><a onclick="javascript:validateList(\''+lists[i][0]+'\',\''+lists[i][5]+'\')"><span class="glyphicon glyphicon-ok"></span></a></td>';
-            html += '<td><a title="View" id="view_list_'+lists[i][1]+'" href="javascript:showListItems(\'list_item_dialog\','+lists[i][0]+')"><span class="glyphicon glyphicon-th-list"></span></span></td>';
-            html += '<td><a title="Delete" id="delete_list_'+lists[i][1]+'" href="javascript:deleteList('+lists[i][0]+')"><span class="glyphicon glyphicon-remove"></span></a></td>';
-            html += '<td><a target="_blank" title="Download" id="download_list_'+lists[i][1]+'" href="/list/download?list_id='+lists[i][0]+'"><span class="glyphicon glyphicon-arrow-down"></span></a></td>';
-            if (lists[i][6] == 0){
-                html += '<td><a title="Make Public" id="share_list_'+lists[i][1]+'" href="javascript:togglePublicList('+lists[i][0]+')"><span class="glyphicon glyphicon-share-alt"></span></a></td>';
-            } else if (lists[i][6] == 1){
-                html += '<td><a title="Make Private" id="share_list_'+lists[i][1]+'" href="javascript:togglePublicList('+lists[i][0]+')"><span class="glyphicon glyphicon-ban-circle"></span></a></td>';
+            if ( !type || type === lists[i][5] ) {
+                html += '<tr><td><a href="javascript:showListItems(\'list_item_dialog\','+lists[i][0]+')"><b>'+lists[i][1]+'</b></a></td>';
+                html += '<td>'+lists[i][2]+'</td>';
+                html += '<td>'+lists[i][7]+'</td>';
+                html += '<td>'+lists[i][8]+'</td>';
+                html += '<td>'+lists[i][3]+'</td>';
+                html += '<td>'+lists[i][5]+'</td>';
+                html += '<td><a onclick="javascript:validateList(\''+lists[i][0]+'\',\''+lists[i][5]+'\')"><span class="glyphicon glyphicon-ok"></span></a></td>';
+                html += '<td><a title="View" id="view_list_'+lists[i][1]+'" href="javascript:showListItems(\'list_item_dialog\','+lists[i][0]+')"><span class="glyphicon glyphicon-th-list"></span></span></td>';
+                html += '<td><a title="Delete" id="delete_list_'+lists[i][1]+'" href="javascript:deleteList('+lists[i][0]+')"><span class="glyphicon glyphicon-remove"></span></a></td>';
+                html += '<td><a target="_blank" title="Download" id="download_list_'+lists[i][1]+'" href="/list/download?list_id='+lists[i][0]+'"><span class="glyphicon glyphicon-arrow-down"></span></a></td>';
+                if (lists[i][6] == 0){
+                    html += '<td><a title="Make Public" id="share_list_'+lists[i][1]+'" href="javascript:togglePublicList('+lists[i][0]+')"><span class="glyphicon glyphicon-share-alt"></span></a></td>';
+                } else if (lists[i][6] == 1){
+                    html += '<td><a title="Make Private" id="share_list_'+lists[i][1]+'" href="javascript:togglePublicList('+lists[i][0]+')"><span class="glyphicon glyphicon-ban-circle"></span></a></td>';
+                }
+                html += '<td><input type="checkbox" id="list_select_checkbox_'+lists[i][0]+'" name="list_select_checkbox" value="'+lists[i][0]+'"/></td></tr>';
             }
-            html += '<td><input type="checkbox" id="list_select_checkbox_'+lists[i][0]+'" name="list_select_checkbox" value="'+lists[i][0]+'"/></td></tr>';
         }
         html = html + '</tbody></table></div>';
         html += '<div id="list_group_select_action"></div>';
@@ -412,6 +429,12 @@ CXGN.List.prototype = {
                 list_group_select_action_html += '</div></div>';
             }
             jQuery("#list_group_select_action").html(list_group_select_action_html);
+        });
+
+        jQuery("#render_lists_type").on("change", function() {
+            var type = $(this).val();
+            var lo = new CXGN.List();
+            lo.renderLists('list_dialog', { type });
         });
     },
 

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -353,11 +353,17 @@ CXGN.List.prototype = {
             jQuery('#'+div+'_div').html(html);
         }
 
-        // Add list type filter
+        // List Table Container
         html += "<div class='well'>";
-        html += "<div style='display: flex; flex-wrap: wrap; align-items: baseline; column-gap: 15px; margin-bottom: 15px'>";
+
+        // Table Header
+        html += "<div style='display: flex; flex-wrap: wrap; column-gap: 30px; justify-content: space-between; margin-bottom: 15px'>";
+
+        // Filter Container
+        html += "<div style='display: flex; flex-direction: column; row-gap: 15px'>"
 
         // Filter by List Type
+        html += "<div style='display: flex; align-items: baseline; column-gap: 15px;'>"
         html += "<p style='white-space: nowrap'><strong>Filter Lists by Type</strong>:</p>";
         html += "<select id='render_lists_type' class='render_lists_filter form-control' style='max-width: 200px'>";
         html += "<option value=''>Any</option>";
@@ -366,16 +372,25 @@ CXGN.List.prototype = {
             html += "<option value='" + types[i][1] + "' " + selected + ">"+types[i][1]+"</option>";
         }
         html += "</select>";
-
-        html += "<div style='width: 30px'></div>";
+        html += "</div>";
 
         // Autocreated filter
+        html += "<div style='display: flex; align-items: baseline; column-gap: 15px;'>";
         html += "<p style='white-space: nowrap'><strong>Include Autocreated Lists</strong>:</p>";
         let checked = autocreated ? 'checked' : ''
         html += "<input id='render_lists_autocreated' class='render_lists_filter' type='checkbox' " + checked + " />";
-
         html += "</div>";
 
+        // End Filter Container
+        html += "</div>";
+
+        // Multiple List Container
+        html += "<div id='list_group_select_action' style='flex-grow: 1; width: min-content; min-width: 500px;'></div>";
+
+        // End Header
+        html += "</div>";
+
+        // List Table
         html += '<table id="private_list_data_table" class="table table-hover table-condensed">';
         html += '<thead><tr><th>List Name</th><th>Description</th><th>Date Created</th><th>Date Modified</th><th>Count</th><th>Type</th><th>Validate</th><th>View</th><th>Delete</th><th>Download</th><th>Share</th><th>Group</th></tr></thead><tbody>';
         for (var i = 0; i < lists.length; i++) {
@@ -399,9 +414,7 @@ CXGN.List.prototype = {
             }
         }
         html += '</tbody></table>';
-        html += '<p style="color: #999; margin-top: 15px;">Select multiple lists by checking them in the <strong>Group</strong> column to delete them all, make them all public/private, or combine the list items into a new list.</p>';
         html += '</div>';
-        html += '<div id="list_group_select_action"></div>';
 
         jQuery('#'+div+'_div').html(html);
 
@@ -430,46 +443,49 @@ CXGN.List.prototype = {
             lo.renderPublicLists('public_list_dialog_div');
         });
 
-        jQuery('body').on("click", "input[name='list_select_checkbox']", function() {
+        function render_selected_lists_container() {
             var total=jQuery("input[name='list_select_checkbox']:checked").length;
             var list_group_select_action_html='';
-            if (total == 0) {
-                list_group_select_action_html += '';
-            } else {
+            if (total > 1) {
                 var selected = [];
                 jQuery("input[name='list_select_checkbox']:checked").each(function() {
                     selected.push(jQuery(this).attr('value'));
                 });
 
-                list_group_select_action_html = '<hr><div class="well well-sm" style="padding: 20px">';
-                if (total > 0) {
-                    list_group_select_action_html += '<div class="row">';
-                    list_group_select_action_html += '<div class="col-sm-4"><p><strong>Modify Selected Lists:</strong></p></div>';
-                    list_group_select_action_html += '<div class="col-sm-8">';
-                    list_group_select_action_html += '<a id="delete_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:deleteSelectedListGroup(['+selected+'])">Delete</a>&nbsp;<a id="make_public_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:makePublicSelectedListGroup(['+selected+'])">Make Public</a>&nbsp;<a id="make_private_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:makePrivateSelectedListGroup(['+selected+'])">Make Private</a>';
-                    list_group_select_action_html += '</div>';  // end column
-                    list_group_select_action_html += '</div>';  // end row
-                }
-                if (total > 1) {
-                    var unionIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 256 256"><path fill="currentColor" d="M172.91 83.09a78 78 0 1 0-89.82 89.82a78 78 0 1 0 89.82-89.82M226 160a65 65 0 0 1-.62 8.9l-53.76-53.77A77.8 77.8 0 0 0 174 96v-.49A66.1 66.1 0 0 1 226 160M45.31 53.79l55.5 55.5a77.9 77.9 0 0 0-12 19L34 73.48a66 66 0 0 1 11.31-19.69m88.92 96l-28-28a66.5 66.5 0 0 1 15.52-15.52l28 28a66.5 66.5 0 0 1-15.52 15.48ZM162 96a65.6 65.6 0 0 1-6 27.49L132.51 100A65.6 65.6 0 0 1 160 94h1.95c.05.7.05 1.35.05 2m-52.71 4.81l-55.5-55.5A66 66 0 0 1 73.48 34l54.8 54.81a77.9 77.9 0 0 0-18.99 12M94 160a65.6 65.6 0 0 1 6-27.49L123.49 156A65.6 65.6 0 0 1 96 162c-.65 0-1.3 0-2-.05zm52.71-4.81l55.5 55.5A66 66 0 0 1 182.52 222l-54.8-54.81a77.9 77.9 0 0 0 18.99-12m8.48-8.48a77.9 77.9 0 0 0 12-19L222 182.52a66 66 0 0 1-11.35 19.69Zm5.3-64.7H160a77.8 77.8 0 0 0-19.13 2.38L87.1 30.62A65 65 0 0 1 96 30a66.1 66.1 0 0 1 64.49 52ZM30 96a65 65 0 0 1 .62-8.9l53.76 53.77A77.8 77.8 0 0 0 82 160v.49A66.1 66.1 0 0 1 30 96m65.51 78H96a77.8 77.8 0 0 0 19.13-2.38l53.77 53.76a65 65 0 0 1-8.9.62a66.1 66.1 0 0 1-64.49-52"/></svg>';
-                    var intersectionIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 256 256"><path fill="currentColor" d="M174.63 81.37a80 80 0 1 0-93.26 93.26a80 80 0 1 0 93.26-93.26M100.69 136L120 155.31A63.5 63.5 0 0 1 96 160a63.5 63.5 0 0 1 4.69-24m33.75 11.13l-25.57-25.57a64.7 64.7 0 0 1 12.69-12.69l25.57 25.57a64.7 64.7 0 0 1-12.69 12.69M155.31 120L136 100.69A63.5 63.5 0 0 1 160 96a63.5 63.5 0 0 1-4.69 24M32 96a64 64 0 0 1 126-16a80.08 80.08 0 0 0-77.95 78A64.11 64.11 0 0 1 32 96m128 128a64.11 64.11 0 0 1-62-48a80.08 80.08 0 0 0 78-78a64 64 0 0 1-16 126"/></svg>';
+                // Delete / Public / Private Functions
+                list_group_select_action_html += '<div class="row">';
+                list_group_select_action_html += '<div class="col-sm-4"><p><strong>Modify Selected Lists:</strong></p></div>';
+                list_group_select_action_html += '<div class="col-sm-8">';
+                list_group_select_action_html += '<a id="delete_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:deleteSelectedListGroup(['+selected+'])">Delete</a>&nbsp;<a id="make_public_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:makePublicSelectedListGroup(['+selected+'])">Make Public</a>&nbsp;<a id="make_private_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:makePrivateSelectedListGroup(['+selected+'])">Make Private</a>';
+                list_group_select_action_html += '</div>';  // end column
+                list_group_select_action_html += '</div>';  // end row
 
-                    list_group_select_action_html += '<div class="row" style="margin-top: 15px">';
-                    list_group_select_action_html += '<div class="col-sm-4"><p><strong>Combine List Items From Selected Lists to a New List:</strong></p></div>';
-                    list_group_select_action_html += '<div class="col-sm-8">';
-                    list_group_select_action_html += '<div class="input-group input-group-sm">'
-                    list_group_select_action_html += '<input type="text" class="form-control" id="new_combined_list_name" placeholder="New List Name"><span class="input-group-btn">';
-                    list_group_select_action_html += '<button id="combine_selected_list_group_union" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'union\')">' + unionIcon + 'Union</button>';
-                    list_group_select_action_html += '<button id="combine_selected_list_group_intersection" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'intersection\')">' + intersectionIcon + 'Intersection</button>';
-                    list_group_select_action_html += '</input></span>';
-                    list_group_select_action_html += '</div>';  // End input group
-                    list_group_select_action_html += '</div>';  // end column
-                    list_group_select_action_html += '</div>';  // end row
-                }
-                list_group_select_action_html += '</div>'; // End well
+                // Union / Intersection Icons
+                var unionIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 256 256"><path fill="currentColor" d="M172.91 83.09a78 78 0 1 0-89.82 89.82a78 78 0 1 0 89.82-89.82M226 160a65 65 0 0 1-.62 8.9l-53.76-53.77A77.8 77.8 0 0 0 174 96v-.49A66.1 66.1 0 0 1 226 160M45.31 53.79l55.5 55.5a77.9 77.9 0 0 0-12 19L34 73.48a66 66 0 0 1 11.31-19.69m88.92 96l-28-28a66.5 66.5 0 0 1 15.52-15.52l28 28a66.5 66.5 0 0 1-15.52 15.48ZM162 96a65.6 65.6 0 0 1-6 27.49L132.51 100A65.6 65.6 0 0 1 160 94h1.95c.05.7.05 1.35.05 2m-52.71 4.81l-55.5-55.5A66 66 0 0 1 73.48 34l54.8 54.81a77.9 77.9 0 0 0-18.99 12M94 160a65.6 65.6 0 0 1 6-27.49L123.49 156A65.6 65.6 0 0 1 96 162c-.65 0-1.3 0-2-.05zm52.71-4.81l55.5 55.5A66 66 0 0 1 182.52 222l-54.8-54.81a77.9 77.9 0 0 0 18.99-12m8.48-8.48a77.9 77.9 0 0 0 12-19L222 182.52a66 66 0 0 1-11.35 19.69Zm5.3-64.7H160a77.8 77.8 0 0 0-19.13 2.38L87.1 30.62A65 65 0 0 1 96 30a66.1 66.1 0 0 1 64.49 52ZM30 96a65 65 0 0 1 .62-8.9l53.76 53.77A77.8 77.8 0 0 0 82 160v.49A66.1 66.1 0 0 1 30 96m65.51 78H96a77.8 77.8 0 0 0 19.13-2.38l53.77 53.76a65 65 0 0 1-8.9.62a66.1 66.1 0 0 1-64.49-52"/></svg>';
+                var intersectionIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 256 256"><path fill="currentColor" d="M174.63 81.37a80 80 0 1 0-93.26 93.26a80 80 0 1 0 93.26-93.26M100.69 136L120 155.31A63.5 63.5 0 0 1 96 160a63.5 63.5 0 0 1 4.69-24m33.75 11.13l-25.57-25.57a64.7 64.7 0 0 1 12.69-12.69l25.57 25.57a64.7 64.7 0 0 1-12.69 12.69M155.31 120L136 100.69A63.5 63.5 0 0 1 160 96a63.5 63.5 0 0 1-4.69 24M32 96a64 64 0 0 1 126-16a80.08 80.08 0 0 0-77.95 78A64.11 64.11 0 0 1 32 96m128 128a64.11 64.11 0 0 1-62-48a80.08 80.08 0 0 0 78-78a64 64 0 0 1-16 126"/></svg>';
+
+                // Union / Intersection Functions
+                list_group_select_action_html += '<div class="row" style="margin-top: 15px">';
+                list_group_select_action_html += '<div class="col-sm-4"><p><strong>Combine List Items From Selected Lists to a New List:</strong></p></div>';
+                list_group_select_action_html += '<div class="col-sm-8">';
+                list_group_select_action_html += '<div class="input-group input-group-sm">'
+                list_group_select_action_html += '<input type="text" class="form-control" id="new_combined_list_name" placeholder="New List Name"><span class="input-group-btn">';
+                list_group_select_action_html += '<button id="combine_selected_list_group_union" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'union\')">' + unionIcon + 'Union</button>';
+                list_group_select_action_html += '<button id="combine_selected_list_group_intersection" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'intersection\')">' + intersectionIcon + 'Intersection</button>';
+                list_group_select_action_html += '</input></span>';
+                list_group_select_action_html += '</div>';  // End input group
+                list_group_select_action_html += '</div>';  // end column
+                list_group_select_action_html += '</div>';  // end row
+            }
+            else {
+                list_group_select_action_html += '<div style="width: 100%; text-align: right">';
+                list_group_select_action_html += '<p><em>Select 2 or more lists in the <strong>Group</strong> column to modify or combine them</em></p>';
+                list_group_select_action_html += '</div>';
             }
             jQuery("#list_group_select_action").html(list_group_select_action_html);
-        });
+        }
+        jQuery('body').on("click", "input[name='list_select_checkbox']", render_selected_lists_container);
+        render_selected_lists_container();
 
         jQuery(".render_lists_filter").on("change", function() {
             render_lists_page = 0;

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -1819,12 +1819,6 @@ function combineSelectedListGroup(list_ids, type = 'union') {
         }
         if ( list_types.length > 1 && !confirm('Are you sure you want to combine these list types: ' + list_types.join(', ')) ) return;
 
-        // Create new list
-        var new_list_id = lo.newList(list_name);
-        if ( list_types.length === 1 ) {
-            lo.setListType(new_list_id, list_types[0]);
-        }
-
         // Combine list items
         var arrayItems = [];
 
@@ -1854,8 +1848,15 @@ function combineSelectedListGroup(list_ids, type = 'union') {
 
         // Get unique set of items
         arrayItems = [...new Set(arrayItems)];
+        if ( !arrayItems || arrayItems.length === 0 ) {
+            return alert("The selected lists don't have any list items in common.  New list not created.");
+        }
 
         // Add combined items to new list
+        var new_list_id = lo.newList(list_name);
+        if ( list_types.length === 1 ) {
+            lo.setListType(new_list_id, list_types[0]);
+        }
         lo.addBulk(new_list_id, arrayItems);
         lo.renderLists('list_dialog');
         alert("Added " + arrayItems.length + " items to the new List " + list_name);

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -383,8 +383,8 @@ CXGN.List.prototype = {
                 console.log(lists[i][2]);
                 html += '<tr><td><a href="javascript:showListItems(\'list_item_dialog\','+lists[i][0]+')"><b>'+lists[i][1]+'</b></a></td>';
                 html += '<td>'+(lists[i][2] ? lists[i][2] : '')+'</td>';
-                html += '<td>'+(lists[i][7] ? new Date(lists[i][7]).toLocaleString() : '')+'</td>';
-                html += '<td>'+(lists[i][8] ? new Date(lists[i][8]).toLocaleString() : '')+'</td>';
+                html += '<td>'+(lists[i][7] ? new Date(lists[i][7]).toLocaleDateString() : '')+'</td>';
+                html += '<td>'+(lists[i][8] ? new Date(lists[i][8]).toLocaleDateString() : '')+'</td>';
                 html += '<td>'+(lists[i][3] ? lists[i][3] : '0')+'</td>';
                 html += '<td>'+(lists[i][5] ? lists[i][5] : '&lt;NOT SET&gt;')+'</td>';
                 html += '<td><a onclick="javascript:validateList(\''+lists[i][0]+'\',\''+lists[i][5]+'\')"><span class="glyphicon glyphicon-ok"></span></a></td>';
@@ -431,7 +431,7 @@ CXGN.List.prototype = {
             lo.renderPublicLists('public_list_dialog_div');
         });
 
-        jQuery("input[name='list_select_checkbox']").click(function() {
+        jQuery('body').on("click", "input[name='list_select_checkbox']", function() {
             var total=jQuery("input[name='list_select_checkbox']:checked").length;
             var list_group_select_action_html='';
             if (total == 0) {

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -380,7 +380,6 @@ CXGN.List.prototype = {
         html += '<thead><tr><th>List Name</th><th>Description</th><th>Date Created</th><th>Date Modified</th><th>Count</th><th>Type</th><th>Validate</th><th>View</th><th>Delete</th><th>Download</th><th>Share</th><th>Group</th></tr></thead><tbody>';
         for (var i = 0; i < lists.length; i++) {
             if ( (!type || type === lists[i][5]) && (autocreated || !(lists[i][2] || '').startsWith("Autocreated")) ) {
-                console.log(lists[i][2]);
                 html += '<tr><td><a href="javascript:showListItems(\'list_item_dialog\','+lists[i][0]+')"><b>'+lists[i][1]+'</b></a></td>';
                 html += '<td>'+(lists[i][2] ? lists[i][2] : '')+'</td>';
                 html += '<td>'+(lists[i][7] ? new Date(lists[i][7]).toLocaleDateString() : '')+'</td>';

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -395,7 +395,9 @@ CXGN.List.prototype = {
                 html += '<td><input type="checkbox" id="list_select_checkbox_'+lists[i][0]+'" name="list_select_checkbox" value="'+lists[i][0]+'"/></td></tr>';
             }
         }
-        html = html + '</tbody></table></div>';
+        html += '</tbody></table>';
+        html += '<p style="color: #999; margin-top: 15px;">Select multiple lists by checking them in the <strong>Group</strong> column to delete them all, make them all public/private, or combine the list items into a new list.</p>';
+        html += '</div>';
         html += '<div id="list_group_select_action"></div>';
 
         jQuery('#'+div+'_div').html(html);
@@ -432,13 +434,32 @@ CXGN.List.prototype = {
                     selected.push(jQuery(this).attr('value'));
                 });
 
-                list_group_select_action_html = '<hr><div class="row well well-sm"><div class="col-sm-4">For Selected Lists:</div><div class="col-sm-8">';
-                if (total == 1) {
+                list_group_select_action_html = '<hr><div class="well well-sm" style="padding: 20px">';
+                if (total > 0) {
+                    list_group_select_action_html += '<div class="row">';
+                    list_group_select_action_html += '<div class="col-sm-4"><p><strong>Modify Selected Lists:</strong></p></div>';
+                    list_group_select_action_html += '<div class="col-sm-8">';
                     list_group_select_action_html += '<a id="delete_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:deleteSelectedListGroup(['+selected+'])">Delete</a>&nbsp;<a id="make_public_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:makePublicSelectedListGroup(['+selected+'])">Make Public</a>&nbsp;<a id="make_private_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:makePrivateSelectedListGroup(['+selected+'])">Make Private</a>';
-                } else if (total > 1) {
-                    list_group_select_action_html += '<a id="delete_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:deleteSelectedListGroup(['+selected+'])">Delete</a>&nbsp;<a id="make_public_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:makePublicSelectedListGroup(['+selected+'])">Make Public</a>&nbsp;<a id="make_private_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:makePrivateSelectedListGroup(['+selected+'])">Make Private</a><br/><br/><div class="input-group input-group-sm"><input type="text" class="form-control" id="new_combined_list_name" placeholder="New List Name"><span class="input-group-btn"><a id="combine_selected_list_group" class="btn btn-primary btn-sm" style="color:white" href="javascript:combineSelectedListGroup(['+selected+'])">Combine</a></span></div>';
+                    list_group_select_action_html += '</div>';  // end column
+                    list_group_select_action_html += '</div>';  // end row
                 }
-                list_group_select_action_html += '</div></div>';
+                if (total > 1) {
+                    var unionIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 256 256"><path fill="currentColor" d="M172.91 83.09a78 78 0 1 0-89.82 89.82a78 78 0 1 0 89.82-89.82M226 160a65 65 0 0 1-.62 8.9l-53.76-53.77A77.8 77.8 0 0 0 174 96v-.49A66.1 66.1 0 0 1 226 160M45.31 53.79l55.5 55.5a77.9 77.9 0 0 0-12 19L34 73.48a66 66 0 0 1 11.31-19.69m88.92 96l-28-28a66.5 66.5 0 0 1 15.52-15.52l28 28a66.5 66.5 0 0 1-15.52 15.48ZM162 96a65.6 65.6 0 0 1-6 27.49L132.51 100A65.6 65.6 0 0 1 160 94h1.95c.05.7.05 1.35.05 2m-52.71 4.81l-55.5-55.5A66 66 0 0 1 73.48 34l54.8 54.81a77.9 77.9 0 0 0-18.99 12M94 160a65.6 65.6 0 0 1 6-27.49L123.49 156A65.6 65.6 0 0 1 96 162c-.65 0-1.3 0-2-.05zm52.71-4.81l55.5 55.5A66 66 0 0 1 182.52 222l-54.8-54.81a77.9 77.9 0 0 0 18.99-12m8.48-8.48a77.9 77.9 0 0 0 12-19L222 182.52a66 66 0 0 1-11.35 19.69Zm5.3-64.7H160a77.8 77.8 0 0 0-19.13 2.38L87.1 30.62A65 65 0 0 1 96 30a66.1 66.1 0 0 1 64.49 52ZM30 96a65 65 0 0 1 .62-8.9l53.76 53.77A77.8 77.8 0 0 0 82 160v.49A66.1 66.1 0 0 1 30 96m65.51 78H96a77.8 77.8 0 0 0 19.13-2.38l53.77 53.76a65 65 0 0 1-8.9.62a66.1 66.1 0 0 1-64.49-52"/></svg>';
+                    var intersectionIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 256 256"><path fill="currentColor" d="M174.63 81.37a80 80 0 1 0-93.26 93.26a80 80 0 1 0 93.26-93.26M100.69 136L120 155.31A63.5 63.5 0 0 1 96 160a63.5 63.5 0 0 1 4.69-24m33.75 11.13l-25.57-25.57a64.7 64.7 0 0 1 12.69-12.69l25.57 25.57a64.7 64.7 0 0 1-12.69 12.69M155.31 120L136 100.69A63.5 63.5 0 0 1 160 96a63.5 63.5 0 0 1-4.69 24M32 96a64 64 0 0 1 126-16a80.08 80.08 0 0 0-77.95 78A64.11 64.11 0 0 1 32 96m128 128a64.11 64.11 0 0 1-62-48a80.08 80.08 0 0 0 78-78a64 64 0 0 1-16 126"/></svg>';
+
+                    list_group_select_action_html += '<div class="row" style="margin-top: 15px">';
+                    list_group_select_action_html += '<div class="col-sm-4"><p><strong>Combine List Items From Selected Lists to a New List:</strong></p></div>';
+                    list_group_select_action_html += '<div class="col-sm-8">';
+                    list_group_select_action_html += '<div class="input-group input-group-sm">'
+                    list_group_select_action_html += '<input type="text" class="form-control" id="new_combined_list_name" placeholder="New List Name"><span class="input-group-btn">';
+                    list_group_select_action_html += '<button id="combine_selected_list_group" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'union\')">' + unionIcon + 'Union</button>';
+                    list_group_select_action_html += '<button id="combine_selected_list_group" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'intersection\')">' + intersectionIcon + 'Intersection</button>';
+                    list_group_select_action_html += '</input></span>';
+                    list_group_select_action_html += '</div>';  // End input group
+                    list_group_select_action_html += '</div>';  // end column
+                    list_group_select_action_html += '</div>';  // end row
+                }
+                list_group_select_action_html += '</div>'; // End well
             }
             jQuery("#list_group_select_action").html(list_group_select_action_html);
         });
@@ -1755,36 +1776,68 @@ function makePrivateSelectedListGroup(list_ids) {
     }
 }
 
-function combineSelectedListGroup(list_ids) {
+/**
+ * Combine the items from the selected lists and create a new list
+ * The items can be combined either using a union method or intersection method
+ * @param {Array[Integer]} list_ids Array of List IDs of Lists to combine
+ * @param {String} type Method of combining lists (either 'union' or 'intersection', union is default)
+ */
+function combineSelectedListGroup(list_ids, type = 'union') {
     var arrayLength = list_ids.length;
     var list_name = jQuery('#new_combined_list_name').val();
-    if (confirm('Combine selected lists into a new list called '+list_name+'?')) {
-        var arrayItems = [];
+    if ( !list_name || list_name === '' ) return alert("You must enter a new list name first");
+
+    if ( confirm('Combine selected lists into a new list called '+list_name+'?') ) {
         var lo = new CXGN.List();
-        var first_list_type = lo.getListType(list_ids[0]);
-        var same_list_types = true;
-        for (var i=0; i<arrayLength; i++) {
+
+        // Check if the selected lists are the same list type
+        var list_types = [];
+        for ( var i=0; i<arrayLength; i++ ) {
             var list_type = lo.getListType(list_ids[i]);
-            if (list_type != first_list_type) {
-                same_list_types = false;
-                if (!confirm('Are you sure you want to combine these list types: '+first_list_type+' and '+list_type)) {
-                    return;
+            if ( !list_types.includes(list_type) ) list_types.push(list_type);
+        }
+        if ( list_types.length > 1 && !confirm('Are you sure you want to combine these list types: ' + list_types.join(', ')) ) return;
+
+        // Create new list
+        var new_list_id = lo.newList(list_name);
+        if ( list_types.length === 1 ) {
+            lo.setListType(new_list_id, list_types[0]);
+        }
+
+        // Combine list items
+        var arrayItems = [];
+
+        // INTERSECTION
+        if ( type === 'intersection' ) {
+            var allListItems = [];
+            for ( var i=0; i<arrayLength; i++ ) {
+                list = lo.getListData(list_ids[i]);
+                var listItems = [];
+                for ( var j=0; j<list.elements.length; j++ ) {
+                    listItems.push(list.elements[j][1]);
+                }
+                allListItems.push(listItems);
+            }
+            arrayItems = allListItems.reduce((result, array) => result.filter(value => array.includes(value)));
+        }
+
+        // UNION
+        else {
+            for ( var i=0; i<arrayLength; i++ ) {
+                list = lo.getListData(list_ids[i]);
+                for ( var j=0; j<list.elements.length; j++ ) {
+                    arrayItems.push(list.elements[j][1]);
                 }
             }
         }
-        var new_list_id = lo.newList(list_name);
-        if (same_list_types == true) {
-            lo.setListType(new_list_id, first_list_type);
-        }
-        for (var i=0; i<arrayLength; i++) {
-            list = lo.getListData(list_ids[i]);
-            var numElements = list.elements.length;
-            for (var j=0; j<numElements; j++) {
-                arrayItems.push(list.elements[j][1]);
-            }
-        }
+
+        // Get unique set of items
+        arrayItems = [...new Set(arrayItems)];
+
+        // Add combined items to new list
         lo.addBulk(new_list_id, arrayItems);
         lo.renderLists('list_dialog');
+        alert("Added " + arrayItems.length + " items to the new List " + list_name);
     }
 }
 

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -459,8 +459,8 @@ CXGN.List.prototype = {
                     list_group_select_action_html += '<div class="col-sm-8">';
                     list_group_select_action_html += '<div class="input-group input-group-sm">'
                     list_group_select_action_html += '<input type="text" class="form-control" id="new_combined_list_name" placeholder="New List Name"><span class="input-group-btn">';
-                    list_group_select_action_html += '<button id="combine_selected_list_group" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'union\')">' + unionIcon + 'Union</button>';
-                    list_group_select_action_html += '<button id="combine_selected_list_group" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'intersection\')">' + intersectionIcon + 'Intersection</button>';
+                    list_group_select_action_html += '<button id="combine_selected_list_group_union" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'union\')">' + unionIcon + 'Union</button>';
+                    list_group_select_action_html += '<button id="combine_selected_list_group_intersection" class="btn btn-primary btn-sm" style="color:white; display: inline-flex; align-items: center; gap: 5px;" onclick="javascript:combineSelectedListGroup(['+selected+'], \'intersection\')">' + intersectionIcon + 'Intersection</button>';
                     list_group_select_action_html += '</input></span>';
                     list_group_select_action_html += '</div>';  // End input group
                     list_group_select_action_html += '</div>';  // end column

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -54,6 +54,8 @@ CXGN.List = function () {
 
 
 
+// User preference for displaying autocreated lists
+const default_render_lists_autocreated = localStorage.getItem("render_lists_autocreated") === 'true';
 
 
 CXGN.List.prototype = {
@@ -335,7 +337,7 @@ CXGN.List.prototype = {
         });
     },
 
-    renderLists: function(div, { type, autocreated = true } = {}) {
+    renderLists: function(div, { type, autocreated = default_render_lists_autocreated } = {}) {
         var lists = this.availableLists();
         var types = this.allListTypes();
 
@@ -351,20 +353,30 @@ CXGN.List.prototype = {
         // Add list type filter
         html += "<div class='well'>";
         html += "<div style='display: flex; flex-wrap: wrap; align-items: baseline; column-gap: 15px; margin-bottom: 15px'>";
+
+        // Filter by List Type
         html += "<p style='white-space: nowrap'><strong>Filter Lists by Type</strong>:</p>";
-        html += "<select id='render_lists_type' class='form-control' style='max-width: 200px'>";
+        html += "<select id='render_lists_type' class='render_lists_filter form-control' style='max-width: 200px'>";
         html += "<option value=''>Any</option>";
         for ( let i = 0; i < types.length; i++ ) {
             let selected = type && type === types[i][1] ? 'selected' : '';
             html += "<option value='" + types[i][1] + "' " + selected + ">"+types[i][1]+"</option>";
         }
         html += "</select>";
+
+        html += "<div style='width: 30px'></div>";
+
+        // Autocreated filter
+        html += "<p style='white-space: nowrap'><strong>Include Autocreated Lists</strong>:</p>";
+        let checked = autocreated ? 'checked' : ''
+        html += "<input id='render_lists_autocreated' class='render_lists_filter' type='checkbox' " + checked + " />";
+
         html += "</div>";
 
         html += '<table id="private_list_data_table" class="table table-hover table-condensed">';
         html += '<thead><tr><th>List Name</th><th>Description</th><th>Date Created</th><th>Date Modified</th><th>Count</th><th>Type</th><th>Validate</th><th>View</th><th>Delete</th><th>Download</th><th>Share</th><th>Group</th></tr></thead><tbody>';
         for (var i = 0; i < lists.length; i++) {
-            if ( !type || type === lists[i][5] ) {
+            if ( (!type || type === lists[i][5]) && (autocreated || !(lists[i][2] || '').startsWith("Autocreated")) ) {
                 html += '<tr><td><a href="javascript:showListItems(\'list_item_dialog\','+lists[i][0]+')"><b>'+lists[i][1]+'</b></a></td>';
                 html += '<td>'+lists[i][2]+'</td>';
                 html += '<td>'+lists[i][7]+'</td>';
@@ -431,10 +443,12 @@ CXGN.List.prototype = {
             jQuery("#list_group_select_action").html(list_group_select_action_html);
         });
 
-        jQuery("#render_lists_type").on("change", function() {
-            var type = $(this).val();
+        jQuery(".render_lists_filter").on("change", function() {
+            var type = jQuery('#render_lists_type').val();
+            var autocreated = jQuery("#render_lists_autocreated").is(":checked");
+            localStorage?.setItem("render_lists_autocreated", autocreated);
             var lo = new CXGN.List();
-            lo.renderLists('list_dialog', { type });
+            lo.renderLists('list_dialog', { type, autocreated });
         });
     },
 

--- a/mason/site/list.mas
+++ b/mason/site/list.mas
@@ -10,8 +10,7 @@
       </div>
       <div class="modal-body">
         <div class="container-fluid">
-	  <div id="list_dialog_div">
-	  </div>
+          <div id="list_dialog_div"></div>
         </div>
       </div>
       <div class="modal-footer">
@@ -31,8 +30,7 @@
       </div>
       <div class="modal-body">
         <div class="container-fluid">
-	  <div id="public_list_dialog_div">
-	  </div>
+          <div id="public_list_dialog_div"></div>
         </div>
       </div>
       <div class="modal-footer">
@@ -51,8 +49,7 @@
       </div>
       <div class="modal-body">
         <div class="container-fluid">
-	  <div id="list_item_dialog_div">
-	  </div>
+          <div id="list_item_dialog_div"></div>
         </div>
       </div>
       <div class="modal-footer">
@@ -64,166 +61,154 @@
 
 
 <div class="modal fade" id="validate_accession_error_display" name="validate_accession_error_display" tabindex="-1" role="dialog" aria-labelledby="listValidationErrorDialog">
-    <div class="modal-dialog modal-lg" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title" id="listValidationErrorDialog">List Validation Report: Failed</h4>
-            </div>
-            <div class="modal-body">
-              <div class="container-fluid">
-		<div id='validate_stock_missing_accessions_html' style='display:none'></div>
-	      </div>
-	      <div id='validate_stock_add_missing_accessions_for_list' style='display:none'></div>
-              <div class="well">
-		
-                <h3>Elements not found:</h3>
-
-		<div id="elements_not_found_stats"></div>
-
-		<table id="missing_accessions_table" style="margin:0pt">
-		</table><br />
-					
-                <div id="validate_stock_add_missing_accessions">
-                </div>
-
-		<div class='well well-sm'><h3>Optional: Add Missing Accessions to A List</h3>
-		  <div id='validate_stock_add_missing_accessions_for_list_div'></div>
-		  <div id='stocks_with_wrong_case'></div>
-		</div>
-		
-		<div id="validate_stock_missing_accessions"></div>
-		
-		<div id="adjust_case_div">
-		  <h3>Mismatched case</h3>
-		  <table id="wrong_case_table" style="margin:0pt">
-		  </table>
-		  <br />
-		  
-		</div>
-		
-		<div id="wrong_case_message_div"></div>
-		<br />
-		
-		<button class="btn btn-default" id="adjust_case_action_button" disabled>Adjust Case</button>
-		<br /><br />
-		<div>
-		  Click the Adjust Case button to align the case in the list with what is in the database.
-		</div>
-		
-		<h3>Multiple mismatched case</h3>
-		<div id="multiple_case_match_message_div">
-		  <br />
-		  Items listed here have mulitple case mismatches and must be fixed manually. If accessions need to be merged, contact the database directly.
-		</div>
-		
-		<table id="multiple_wrong_case_table" style="margin:0pt">
-		</table>
-		
-		<div id="multiple_case_match_div"><br /><br /></div>
-		
-		<h3>List elements matching a synonym</h3>
-		<div id="synonym_matches_div">
-		  
-		  <table id="element_matches_synonym"  style="margin:0pt">
-		  </table>
-		  <br />
-		  <button class="btn btn-default" id="replace_synonyms_with_uniquenames_button">Replace synonyms with corresponding DB name</button>
-		  
-		</div>
-		
-		<div id="synonym_message"></div>
-		<br />
-		
-		<h3>Multiple synonym matches</h3>
-		<div id="multiple_synonym_matches_div">
-		  <table id="element_matches_multiple_synonyms_table" style="margin:0pt">
-		  </table>
-		  
-		  Multiple synonym matches have to be resolved manually. Contact database administrators if necessary.
-		</div>
-              </div>
-            </div>
-	</div>
-	
-        <div class="modal-footer">
-          <button id="close_missing_accessions_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="listValidationErrorDialog">List Validation Report: Failed</h4>
+      </div>
+      <div class="modal-body">
+        <div class="container-fluid">
+          <div id='validate_stock_missing_accessions_html' style='display:none'></div>
         </div>
+        <div id='validate_stock_add_missing_accessions_for_list' style='display:none'></div>
+        <div class="well">
+          <h3>Elements not found:</h3>
+          <div id="elements_not_found_stats"></div>
+          <table id="missing_accessions_table" style="margin:0pt"></table>
+          <br />
+          <div id="validate_stock_add_missing_accessions"></div>
+
+          <div class='well well-sm'>
+            <h3>Optional: Add Missing Accessions to A List</h3>
+            <div id='validate_stock_add_missing_accessions_for_list_div'></div>
+            <div id='stocks_with_wrong_case'></div>
+          </div>
+
+          <div id="validate_stock_missing_accessions"></div>
+
+          <div id="adjust_case_div">
+            <h3>Mismatched case</h3>
+            <table id="wrong_case_table" style="margin:0pt"></table>
+            <br />
+          </div>
+
+          <div id="wrong_case_message_div"></div>
+          <br />
+
+          <button class="btn btn-default" id="adjust_case_action_button" disabled>Adjust Case</button>
+          <br /><br />
+          <div>
+            Click the Adjust Case button to align the case in the list with what is in the database.
+          </div>
+
+          <h3>Multiple mismatched case</h3>
+          <div id="multiple_case_match_message_div">
+            <br />
+            Items listed here have mulitple case mismatches and must be fixed manually. If accessions need to be merged, contact the database directly.
+          </div>
+
+          <table id="multiple_wrong_case_table" style="margin:0pt"></table>
+
+          <div id="multiple_case_match_div"><br /><br /></div>
+
+          <h3>List elements matching a synonym</h3>
+          <div id="synonym_matches_div">
+
+            <table id="element_matches_synonym"  style="margin:0pt"></table>
+            <br />
+            <button class="btn btn-default" id="replace_synonyms_with_uniquenames_button">Replace synonyms with corresponding DB name</button>
+
+          </div>
+
+          <div id="synonym_message"></div>
+          <br />
+
+          <h3>Multiple synonym matches</h3>
+          <div id="multiple_synonym_matches_div">
+            <table id="element_matches_multiple_synonyms_table" style="margin:0pt"></table>
+            Multiple synonym matches have to be resolved manually. Contact database administrators if necessary.
+          </div>
+        </div>
+      </div>
     </div>
+
+    <div class="modal-footer">
+      <button id="close_missing_accessions_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+    </div>
+  </div>
 </div>
 
 
 <div class="modal fade" id="fuzzy_search_result_display" name="fuzzy_search_result_display" tabindex="-1" role="dialog" aria-labelledby="fuzzySearchResultDialog">
-    <div class="modal-dialog modal-xl" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title" id="fuzzySearchResultDialog">Fuzzy Search Results</h4>
-            </div>
-            <div class="modal-body">
-                <div class="container-fluid">
-                    <div id="fuzzy_search_result_display_html">
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button id="download_fuzzy_search_result" type="button" class="btn btn-primary" onclick="javascript:downloadFuzzyResponse()" >Download</button>
-                <button id="close_fuzzy_search_result_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-            </div>
+  <div class="modal-dialog modal-xl" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="fuzzySearchResultDialog">Fuzzy Search Results</h4>
+      </div>
+      <div class="modal-body">
+        <div class="container-fluid">
+          <div id="fuzzy_search_result_display_html"></div>
         </div>
+      </div>
+      <div class="modal-footer">
+        <button id="download_fuzzy_search_result" type="button" class="btn btn-primary" onclick="javascript:downloadFuzzyResponse()" >Download</button>
+        <button id="close_fuzzy_search_result_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="modal fade" id="synonym_search_result_display" name="synonym_search_result_display" tabindex="-1" role="dialog" aria-labelledby="synonymSearchResultDialog">
-    <div class="modal-dialog modal-lg" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title" id="synonymSearchResultDialog">Synonym Search Results</h4>
-            </div>
-            <div class="modal-body">
-                <div class="container-fluid">
-                    <div id="synonym_search_result_display_html">
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-              <form id="new-list-from-unames" class="form-inline" style="float:left">
-                <label>Create a New List from Unique Names:</label>
-                <input name="name" type="text" class="form-control" placeholder="List Name...">
-                <button class="btn btn-primary" type="submit">Save</button>
-              </form>
-              <form class="form-inline" style="float:right">
-                <button id="close_fuzzy_search_result_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-              </form>
-            </div>
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="synonymSearchResultDialog">Synonym Search Results</h4>
+      </div>
+      <div class="modal-body">
+        <div class="container-fluid">
+          <div id="synonym_search_result_display_html"></div>
         </div>
+      </div>
+      <div class="modal-footer">
+        <form id="new-list-from-unames" class="form-inline" style="float:left">
+          <label>Create a New List from Unique Names:</label>
+          <input name="name" type="text" class="form-control" placeholder="List Name...">
+          <button class="btn btn-primary" type="submit">Save</button>
+        </form>
+        <form class="form-inline" style="float:right">
+          <button id="close_fuzzy_search_result_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </form>
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="modal fade" id="availible_seedlots_modal" name="availible_seedlots_modal" tabindex="-1" role="dialog" aria-labelledby="availible_seedlots_modal">
-    <div class="modal-dialog modal-xl" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4>Available Seedlots</h4>
-            </div>
-            <div class="modal-body">
-                <div class="container-fluid">
-                    <& /tools/available_seedlots.mas &>
-                </div>
-            </div>
-            <div class="modal-footer">
-              <form id="new-list-from-seedlots" class="form-inline" style="float:left">
-                <label>Create a New List from Selected Seedlots:</label>
-                <input name="name" type="text" class="form-control" placeholder="List Name...">
-                <button class="btn btn-primary" type="submit">Save</button>
-              </form>
-              <form class="form-inline" style="float:right">
-                <a href="/breeders/seedlots/" class="btn btn-primary">Manage Seedlots</a>
-                <button id="close_availible_seedlots_modal" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-              </form>
-            </div>
+  <div class="modal-dialog modal-xl" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4>Available Seedlots</h4>
+      </div>
+      <div class="modal-body">
+        <div class="container-fluid">
+          <& /tools/available_seedlots.mas &>
         </div>
+      </div>
+      <div class="modal-footer">
+        <form id="new-list-from-seedlots" class="form-inline" style="float:left">
+          <label>Create a New List from Selected Seedlots:</label>
+          <input name="name" type="text" class="form-control" placeholder="List Name...">
+          <button class="btn btn-primary" type="submit">Save</button>
+        </form>
+        <form class="form-inline" style="float:right">
+          <a href="/breeders/seedlots/" class="btn btn-primary">Manage Seedlots</a>
+          <button id="close_availible_seedlots_modal" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </form>
+      </div>
     </div>
+  </div>
 </div>

--- a/t/selenium2/01_list/list_groups.t
+++ b/t/selenium2/01_list/list_groups.t
@@ -62,17 +62,19 @@ $d->while_logged_in_as("submitter", sub {
 
     sleep(1);
 
-    $d->find_element_ok("list_select_checkbox_808", "id", "checkbox select list")->click();
+    ## Combine two lists using union
+
+    $d->find_element_ok("list_select_checkbox_808", "id", "checkbox select list 808")->click();
 
     sleep(1);
 
-    $d->find_element_ok("list_select_checkbox_810", "id", "checkbox select list")->click();
+    $d->find_element_ok("list_select_checkbox_810", "id", "checkbox select list 810")->click();
 
     sleep(1);
 
-    $d->find_element_ok("new_combined_list_name", "id", "combine selected list group")->send_keys("combined_list");
+    $d->find_element_ok("new_combined_list_name", "id", "name selected list group - union")->send_keys("combined_list_union");
 
-    $d->find_element_ok("combine_selected_list_group", "id", "combine selected list group")->click();
+    $d->find_element_ok("combine_selected_list_group_union", "id", "combine selected list group - union")->click();
 
     sleep(1);
 
@@ -80,15 +82,56 @@ $d->while_logged_in_as("submitter", sub {
 
     sleep(1);
 
-    $d->find_element_ok("view_list_combined_list", "id", "check view combined list");
+    ok($d->driver->get_alert_text() =~ m/Added 4 items to the new List combined_list_union/i, 'created selected list group - union');
+    $d->accept_alert_ok();
 
     sleep(1);
 
-    $d->find_element_ok("list_select_checkbox_808", "id", "checkbox select list")->click();
+    $d->find_element_ok("view_list_combined_list_union", "id", "check view combined list - union");
 
     sleep(1);
 
-    $d->find_element_ok("list_select_checkbox_810", "id", "checkbox select list")->click();
+    ## Combine two lists using intersection
+
+    $d->find_element_ok("list_select_checkbox_808", "id", "checkbox select list 808")->click();
+
+    sleep(1);
+
+    $d->find_element_ok("list_select_checkbox_4", "id", "checkbox select list 4")->click();
+
+    sleep(1);
+
+    $d->find_element_ok("new_combined_list_name", "id", "name selected list group - intersection")->send_keys("combined_list_intersection");
+
+    $d->find_element_ok("combine_selected_list_group_intersection", "id", "combine selected list group - intersection")->click();
+
+    sleep(1);
+
+    $d->accept_alert_ok();
+
+    sleep(1);
+
+    # Accept alert about mismatched list types (one list doesn't have it's type set)
+    $d->accept_alert_ok();
+
+    sleep(1);
+
+    ok($d->driver->get_alert_text() =~ m/Added 2 items to the new List combined_list_intersection/i, 'created selected list group - intersection');
+    $d->accept_alert_ok();
+
+    sleep(1);
+
+    $d->find_element_ok("view_list_combined_list_intersection", "id", "check view combined list - intersection");
+
+    sleep(1);
+
+    ## Delete list group
+
+    $d->find_element_ok("list_select_checkbox_808", "id", "checkbox select list 808")->click();
+
+    sleep(1);
+
+    $d->find_element_ok("list_select_checkbox_810", "id", "checkbox select list 810")->click();
 
     sleep(1);
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds some improvements to the List Manager Dialog:

- Add some filter options to make it easier for users to find a list they're interested in.  You can now filter by list data type and toggle the display of the autocreated accession lists (these tend to pollute the table of lists if the user has done a lot of uploads).

![Screenshot from 2025-01-08 15-20-15](https://github.com/user-attachments/assets/6e842f96-537c-4c3d-867b-aa2bd4229242)

- It retains the current page and sorting column when the table is refreshed after an event (ie, making a list public)
- Updates the function for combining 2 or more lists.  You can now combine list items from multiple lists into a new list using a union or intersection operation.

![Screenshot from 2025-01-08 15-21-02](https://github.com/user-attachments/assets/7a9df019-94a1-416d-905b-87c89db7083a)

- It also fixes a long-standing bug when selected lists in the group column after the page size has changed

Fixes #2230

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
