### PR TITLE
Topic/fix accessions results to list

### DIFF
--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -300,7 +300,6 @@ my $breeding_programs_select = simple_selectbox_html(
 <script>
 
 var stock_table;
-var stock_table_all_names = [];
 
 jQuery(document).ready(function () {
 

--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -443,8 +443,7 @@ jQuery(document).ready(function () {
     parseArgs(editable_stockprops_search);
 
     jQuery('#stock_search_results').on( 'draw.dt', function () {
-      //CHANGE THIS LINE
-      var name_links = stock_table.column(0).data();//***//
+      var name_links = stock_table.column(0).data();
       var names = [];
 
       for (var i = 0; i < name_links.length; i++) { //extract text from anchor tags

--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -261,7 +261,7 @@ my $breeding_programs_select = simple_selectbox_html(
 
     <div class="panel panel-default">
         <div class="panel-body">
-            <div id="stock_search_results_div" style="overflow:scroll" >
+            <div id="stock_search_results_div">
                 <table id="stock_search_results" width="100%" class="table table-hover table-striped">
                 <thead>
                   <tr>
@@ -300,6 +300,7 @@ my $breeding_programs_select = simple_selectbox_html(
 <script>
 
 var stock_table;
+var stock_table_all_names = [];
 
 jQuery(document).ready(function () {
 
@@ -442,7 +443,8 @@ jQuery(document).ready(function () {
     parseArgs(editable_stockprops_search);
 
     jQuery('#stock_search_results').on( 'draw.dt', function () {
-      var name_links = stock_table.column(0).data();
+      //CHANGE THIS LINE
+      var name_links = stock_table.column(0).data();//***//
       var names = [];
 
       for (var i = 0; i < name_links.length; i++) { //extract text from anchor tags
@@ -454,6 +456,8 @@ jQuery(document).ready(function () {
         listType: jQuery('#stock_type_select option:selected').text()+'s' || 'null'
       });
 
+      // jQuery('#stock_search_results').children('tbody').css('height','250px');
+      // jQuery('#stock_search_results').children('tbody').css('overflow-y','scroll');
     });
 
    jQuery('#submit_stock_search').click( function() {
@@ -555,7 +559,12 @@ function _load_stock_search_results(stock_type, editable_stockprops_search, stoc
         'ordering'  : false,
         'processing': true,
         'serverSide': true,
-        'lengthMenu': [10,20,50,100,1000,5000],
+        'lengthMenu': [
+          [10,20,50,100,1000,1000000000000000],
+          [10,20,50,100,1000,'All']
+        ],
+        'fixedFooter' : true,
+        'scrollY' : '350px',
         'ajax': { 'url':  '/ajax/search/stocks',
             'data': function(d) {
               d.any_name  = jQuery('#any_name').val();

--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -280,7 +280,7 @@ my $breeding_programs_select = simple_selectbox_html(
 
     <div class="panel panel-default">
         <div class="panel-body">
-            <&| /page/info_section.mas, title => 'Copy Results to a List', collapsible=>1, collapsed=>0, subtitle=>'<i>Copy the stock names currently showing in the search results table to a new or exisiting list</i>'&>
+            <&| /page/info_section.mas, title => 'Copy Results to a List', collapsible=>1, collapsed=>0, subtitle=>'<i>Copy the stock names currently showing in the search results table to a new or exisiting list. Use "Show All entries" to capture all results.</i>'&>
             <br>
             <div style="text-align:right" id="results_to_list_menu"></div>
             <div id="search_result_names" style="display: none;"></div>
@@ -455,9 +455,6 @@ jQuery(document).ready(function () {
       addToListMenu('results_to_list_menu', 'search_result_names', {
         listType: jQuery('#stock_type_select option:selected').text()+'s' || 'null'
       });
-
-      // jQuery('#stock_search_results').children('tbody').css('height','250px');
-      // jQuery('#stock_search_results').children('tbody').css('overflow-y','scroll');
     });
 
    jQuery('#submit_stock_search').click( function() {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes issue #5244 by adding option to show all search results. Results table is changed to scrollable to prevent page from being totally consumed by results. By showing all search results, user can store all results in a list. 

<!-- If there are relevant issues, link them here: -->
#5244 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
