### PR TITLE
declare analysis object before eval block

### DIFF
--- a/lib/SGN/Controller/Analysis.pm
+++ b/lib/SGN/Controller/Analysis.pm
@@ -42,8 +42,9 @@ sub analysis_detail :Path('/analyses') Args(1) {
     my $bcs_schema = $c->dbic_schema("Bio::Chado::Schema", undef, $user_id);
     print STDERR "Viewing analysis with id $analysis_id\n";
 
+    my $a;
     eval {
-    my $a = CXGN::Analysis->new({
+    $a = CXGN::Analysis->new({
         bcs_schema => $bcs_schema,
         people_schema => $c->dbic_schema("CXGN::People::Schema", undef, $user_id),
         metadata_schema => $c->dbic_schema("CXGN::Metadata::Schema", undef, $user_id),


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
--fixes an issue accessing analysis object instantiated in an eval block.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
