### PR TITLE
fix the download format of the Entry List xlsx file.

### DIFF
--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -4929,6 +4929,11 @@ sub delete_entry_numbers :Path('/ajax/breeders/trial_entry_numbers/delete') Args
         $c->stash->{rest} = {error_string => "You must be logged in to update trial status." };
         return;
     }
+
+    if (!$c->user()->check_roles("curator")) {
+	$c->stash->{rest} = {error_string => "Your account must have the curator role to delete entry numbers" };
+	return;
+    }
     
     my $user_id = $c->user()->get_object()->get_sp_person_id();
     my $schema = $c->dbic_schema('Bio::Chado::Schema', undef, $user_id);

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -4812,7 +4812,7 @@ sub download_entry_number_template : Path('/ajax/breeders/trial_entry_numbers/do
     my $tempfile = $c->req->param('file');
 
     $c->res->content_type('application/vnd.ms-excel');
-    $c->res->header('Content-Disposition', qq[attachment; filename="entry_number_template.xls"]);
+    $c->res->header('Content-Disposition', qq[attachment; filename="entry_number_template.xlsx"]);
     my $output = read_file($tempfile);
     $c->res->body($output);
 }

--- a/mason/breeders_toolbox/trial/trial_entry_numbers.mas
+++ b/mason/breeders_toolbox/trial/trial_entry_numbers.mas
@@ -96,7 +96,6 @@ $trial_name
             type: 'GET',
             success: function(response) {
                 if ( response && response.entry_numbers ) {
-		    alert(JSON.stringify(response.entry_numbers));
                     displayEntryNumbers(response.entry_numbers);
                 }
                 else {

--- a/mason/breeders_toolbox/trial/trial_entry_numbers.mas
+++ b/mason/breeders_toolbox/trial/trial_entry_numbers.mas
@@ -16,7 +16,10 @@ $trial_name
 </div>
 
 <button id="set_entry_numbers_template_btn" class="btn btn-default">Generate Entry Number Template</button>
+
 <button id="set_entry_numbers_upload_btn" class="btn btn-default">Upload Entry Number Template</button>
+
+<button id="delete_entry_numbers_btn" class="btn btn-default" disabled="1">Delete Entry Numbers</button>
 
 <script src="//cdn.datatables.net/plug-ins/1.11.3/sorting/natural.js" defer></script>
 <script type="text/javascript">
@@ -27,6 +30,30 @@ $trial_name
         jQuery("#set_entry_numbers_template_btn").click(function() {
             jQuery("#set_entry_numbers_template_dialog").modal("show");
         });
+
+	jQuery('#delete_entry_numbers_btn').click(function() {
+	    var yes = confirm("Are you sure you would like to remove the entry numbers from this trial? This action cannot be undone.");
+
+	    if (yes) {
+	       var p = jQuery.ajax( {
+	           type : 'async',
+	     	   url : '/ajax/breeders/trial_entry_numbers/delete',
+	     	   data: { trial_id : <% $trial_id %> },
+	       } );
+
+	       p.then( function(value) { loadEntryNumbers(); alert("Success!"); }, function(error) { alert("An error occurred deleting the entry numbers." ) } )
+ 	    }
+	});
+	
+
+	//function resetEntryNumberTable() {
+
+//	     	 alert("NOW DESTROYING TABLE!");
+//		              var table = new DataTable('#trial_entry_numbers_table');		
+  //           table.destroy();
+//	}
+
+
         jQuery("#set_entry_numbers_upload_btn").click(function() {
             jQuery("#trial_entry_numbers_upload_dialog").modal("show");
         });
@@ -69,6 +96,7 @@ $trial_name
             type: 'GET',
             success: function(response) {
                 if ( response && response.entry_numbers ) {
+		    alert(JSON.stringify(response.entry_numbers));
                     displayEntryNumbers(response.entry_numbers);
                 }
                 else {
@@ -88,6 +116,14 @@ $trial_name
             dt.rows.add(entryNumbers);
             dt.draw();
             jQuery("#trial_entry_numbers").show();
+	    jQuery('#delete_entry_numbers_btn').attr("disabled", false); 
+        }
+	else {
+	    let dt = jQuery('#trial_entry_numbers_table').DataTable();
+            dt.clear();
+            dt.rows.add(entryNumbers);
+            dt.draw();
+	    jQuery('#delete_entry_numbers_btn').attr("disabled", true);
         }
     }
 </script>

--- a/mason/breeders_toolbox/trial/trial_entry_numbers_upload_dialog.mas
+++ b/mason/breeders_toolbox/trial/trial_entry_numbers_upload_dialog.mas
@@ -93,6 +93,7 @@ jQuery(document).ready(function() {
           }
           if ( response.success === 1) {
             addSuccess("Trial entry numbers stored!");
+	    loadEntryNumbers();
           }
         }
       },


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The entry number file that can be downloaded from the trial detail page is an xlsx file, but was erroneously coded as being xls. This led to strange errors when opening the file in Excel. 

This pull request adjusts the file format to the correct xlsx format.

It also adds the ability to delete the entry numbers from the trial, for curators.

fixes #5325

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
