### PR TITLE
remove duplicate key from sgn.conf (brapi_require_login)

### DIFF
--- a/sgn.conf
+++ b/sgn.conf
@@ -436,7 +436,6 @@ hidap_enabled    0
 
 #BrAPI params
 supportedCrop    Cassava
-brapi_require_login 0
 
 #Expression Atlas Connection
 has_expression_atlas    0


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The brapi_require_login config key is duplicated in sgn.conf which may cause issues

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
