### PR TITLE
Topic/fix dead slurm job cache

### DIFF
--- a/js/source/legacy/solGS/analysisStatus.js
+++ b/js/source/legacy/solGS/analysisStatus.js
@@ -33,7 +33,8 @@ solGS.log = {
         'ordering'  : false,
         'processing': true,
         'paging'    : false,
-        'info'      : false
+        'info'      : false,
+        'destroy'   : true
         });
 
         table.rows.add(data).draw();
@@ -52,7 +53,7 @@ solGS.log = {
                     console.log(response);
                 } else {
                     alert("Jobs cleared from recent activity."); 
-                    window.location.reload();  
+                    window.location.reload();
                 }     
     	    },
             error: function(response) {
@@ -74,7 +75,7 @@ solGS.log = {
                     console.log(response);
                 } else {
                     alert("Jobs cleared from recent activity."); 
-                    window.location.reload();  
+                    window.location.reload(); 
                 } 
     	    },
             error: function(response) {

--- a/js/source/legacy/solGS/analysisStatus.js
+++ b/js/source/legacy/solGS/analysisStatus.js
@@ -38,11 +38,58 @@ solGS.log = {
 
         table.rows.add(data).draw();
 
-    }
+    },
 
+    keep_recent_jobs: function() {
+        var interval = jQuery('#keep_recent_jobs_select').val();
+        jQuery.ajax({
+            type: 'POST',
+            dataType: 'json',
+            url: '/solgs/delete/old/analyses/'+interval,
+            success: function(response) {
+                if (response.error) {
+                    alert("Encountered an error on the server: "+response.error);
+                    console.log(response);
+                } else {
+                    alert("Jobs cleared from recent activity."); 
+                    window.location.reload();  
+                }     
+    	    },
+            error: function(response) {
+                console.log(response);
+                alert("Error clearing old jobs, check console. " + response);
+                window.location.reload();
+            }
+        });
+    }, 
+
+    remove_dead_jobs: function() {
+        jQuery.ajax({
+            type: 'POST',
+            dataType: 'json',
+            url: '/solgs/delete/dead/analyses',
+            success: function(response) {
+                if (response.error) {
+                    alert("Encountered an error on the server: "+response.error);
+                    console.log(response);
+                } else {
+                    alert("Jobs cleared from recent activity."); 
+                    window.location.reload();  
+                } 
+    	    },
+            error: function(response) {
+                console.log(response);
+                alert("Error clearing dead jobs, check console. " + response);
+                window.location.reload();
+            }
+        });
+    }
 }
 
 jQuery(document).ready(function() {
 
     solGS.log.getUserAnalyses();
+
+    jQuery('#clear_dead_jobs_button').click(function(){solGS.log.remove_dead_jobs()});
+    jQuery('#clear_jobs_cache_button').click(function(){solGS.log.keep_recent_jobs()});
 });

--- a/lib/SGN/Controller/solGS/AnalysisQueue.pm
+++ b/lib/SGN/Controller/solGS/AnalysisQueue.pm
@@ -1393,7 +1393,7 @@ sub get_user_solgs_analyses {
               my $time_running = ($now - $submitted_time) / ONE_DAY;
               if ($time_running >= 2) { #two days is too long!
                 $result_page = 'NA';
-                $analysis_status = 'Dubious';
+                $analysis_status = 'Timed Out';
               } else {
                 $result_page = 'In progress...';
               }

--- a/lib/SGN/Controller/solGS/AnalysisQueue.pm
+++ b/lib/SGN/Controller/solGS/AnalysisQueue.pm
@@ -8,6 +8,8 @@ use File::Slurp qw /write_file read_file/;
 use JSON;
 use CXGN::Tools::Run;
 use Try::Tiny;
+use Time::Piece;
+use Time::Seconds;
 use Storable qw/ nstore retrieve /;
 use Carp qw/ carp confess croak /;
 use Scalar::Util 'reftype';
@@ -1271,7 +1273,15 @@ sub get_user_solgs_analyses {
                 $result_page = 'N/A';
             }
             elsif ( $analysis_status =~ /Submitted/i ) {
+              my $submitted_time = Time::Piece->strptime($submitted_on,'%m/%d/%Y %R');
+              my $now = localtime;
+              my $time_running = ($now - $submitted_time) / ONE_DAY;
+              if ($time_running >= 2) { #two days is too long!
+                $result_page = 'NA';
+                $analysis_status = 'Dubious';
+              } else {
                 $result_page = 'In progress...';
+              }
             }
             else {
                 $result_page = qq |<a href=$result_page>[ View ]</a>|;

--- a/lib/SGN/Controller/solGS/AnalysisQueue.pm
+++ b/lib/SGN/Controller/solGS/AnalysisQueue.pm
@@ -2,7 +2,7 @@ package SGN::Controller::solGS::AnalysisQueue;
 
 use Moose;
 use namespace::autoclean;
-use File::Path qw / mkpath  /;
+use File::Path qw / make_path  /;
 use File::Spec::Functions qw / catfile catdir/;
 use File::Slurp qw /write_file read_file/;
 use JSON;
@@ -607,8 +607,10 @@ sub structure_training_modeling_output {
     my $training_pop_id = $c->stash->{training_pop_id};
     my $protocol_id     = $c->stash->{genotyping_protocol_id};
 
-    my @traits_ids = @{ $c->stash->{training_traits_ids} }
-      if $c->stash->{training_traits_ids};
+    my @traits_ids;
+    if ($c->stash->{training_traits_ids}) {
+      @traits_ids = @{ $c->stash->{training_traits_ids} };
+    }
 
     my $referer = $c->req->referer;
     my $base    = $c->stash->{hostname};
@@ -833,8 +835,10 @@ sub structure_training_combined_pops_data_output {
 sub structure_selection_prediction_output {
     my ( $self, $c ) = @_;
 
-    my @traits_ids = @{ $c->stash->{training_traits_ids} }
-      if $c->stash->{training_traits_ids};
+    my @traits_ids;
+    if ($c->stash->{training_traits_ids}) {
+      @traits_ids = @{ $c->stash->{training_traits_ids} };
+    }
     my $protocol_id = $c->stash->{genotyping_protocol_id};
 
     my $referer = $c->req->referer;
@@ -984,8 +988,10 @@ sub run_analysis {
     $analysis_page =~ s/$base//;
     my $referer = $c->req->referer;
 
-    my @selected_traits = @{ $c->stash->{training_traits_ids} }
-      if $c->stash->{training_traits_ids};
+    my @selected_traits;
+    if ($c->stash->{training_traits_ids}) {
+       @selected_traits = @{ $c->stash->{training_traits_ids} };
+    }
 
     eval {
         my $modeling_pages =
@@ -1135,7 +1141,7 @@ sub run_kinship_analysis {
 
     my $analysis_page = $c->stash->{analysis_page};
 
-    if ( $analysis_page = ~/kinship\/analysis/ ) {
+    if ( $analysis_page =~ /kinship\/analysis/ ) {
         $c->controller('solGS::Kinship')->run_kinship($c);
     }
 
@@ -1146,7 +1152,7 @@ sub run_pca_analysis {
 
     my $analysis_page = $c->stash->{analysis_page};
 
-    if ( $analysis_page = ~/pca\/analysis/ ) {
+    if ( $analysis_page =~ /pca\/analysis/ ) {
         $c->controller('solGS::pca')->run_pca($c);
     }
 
@@ -1157,7 +1163,7 @@ sub run_cluster_analysis {
 
     my $analysis_page = $c->stash->{analysis_page};
 
-    if ( $analysis_page = ~/cluster\/analysis/ ) {
+    if ( $analysis_page =~ /cluster\/analysis/ ) {
         $c->controller('solGS::Cluster')->run_cluster($c);
     }
 
@@ -1417,7 +1423,11 @@ sub create_analysis_log_dir {
     my $log_dir = $c->stash->{analysis_log_dir};
 
     $log_dir = catdir( $log_dir, $user_id );
-    mkpath( $log_dir, 0, 0755 );
+    # mkpath( $log_dir, 0, 0755 );
+    make_path($log_dir,{
+      verbose => 1,
+      chmod => 0755
+    });
 
     $c->stash->{analysis_log_dir} = $log_dir;
 

--- a/lib/SGN/Controller/solGS/AnalysisQueue.pm
+++ b/lib/SGN/Controller/solGS/AnalysisQueue.pm
@@ -1426,7 +1426,7 @@ sub create_analysis_log_dir {
     # mkpath( $log_dir, 0, 0755 );
     make_path($log_dir,{
       verbose => 1,
-      chmod => 0755
+      chmod => "0755"
     });
 
     $c->stash->{analysis_log_dir} = $log_dir;

--- a/mason/solgs/jobs/log.mas
+++ b/mason/solgs/jobs/log.mas
@@ -17,6 +17,14 @@ Isaak Y Tecle (iyt2@cornell.edu)
 
 
 <div id="analysis_log_div" style="display:none">
+  <button id="clear_dead_jobs_button" class='btn btn-sm btn-primary'>Clear failed and dead jobs</button>
+  <br>
+  <button id="clear_jobs_cache_button" class='btn btn-sm btn-primary'>Clear all jobs except most recent</button> 
+  <select id="keep_x_recent_jobs_select">
+    <option>20</option>
+    <option>10</option>
+    <option>5</option>
+  </select>
   <table class="table" id="analysis_list" style="text-align: left;">
     <thead>
       <tr>

--- a/mason/solgs/jobs/log.mas
+++ b/mason/solgs/jobs/log.mas
@@ -19,11 +19,12 @@ Isaak Y Tecle (iyt2@cornell.edu)
 <div id="analysis_log_div" style="display:none">
   <button id="clear_dead_jobs_button" class='btn btn-sm btn-primary'>Clear failed and dead jobs</button>
   <br>
-  <button id="clear_jobs_cache_button" class='btn btn-sm btn-primary'>Clear all jobs except most recent</button> 
-  <select id="keep_x_recent_jobs_select">
-    <option>20</option>
-    <option>10</option>
-    <option>5</option>
+  <button id="clear_jobs_cache_button" class='btn btn-sm btn-primary'>Clear all jobs older than</button> 
+  <select id="keep_recent_jobs_select">
+    <option value='one_week'>One week</option>
+    <option value='one_month'>One month</option>
+    <option value='six_months'>Six months</option>
+    <option value='one_year'>One year</option>
   </select>
   <table class="table" id="analysis_list" style="text-align: left;">
     <thead>

--- a/mason/solgs/jobs/log.mas
+++ b/mason/solgs/jobs/log.mas
@@ -17,7 +17,7 @@ Isaak Y Tecle (iyt2@cornell.edu)
 
 
 <div id="analysis_log_div" style="display:none">
-  <button id="clear_dead_jobs_button" class='btn btn-sm btn-primary'>Clear failed and dead jobs</button>
+  <button id="clear_dead_jobs_button" class='btn btn-sm btn-primary'>Clear failed and timed out jobs</button>
   <br>
   <button id="clear_jobs_cache_button" class='btn btn-sm btn-primary'>Clear all jobs older than</button> 
   <select id="keep_recent_jobs_select">

--- a/sgn_test.conf
+++ b/sgn_test.conf
@@ -86,7 +86,7 @@ genotyping_server_token
 genotyping_server_host https://ordering-testing.diversityarrays.com
 genotyping_server_username NULL
 genotyping_server_password NULL
-default_genotyping_protocol GBS ApeKI genotyping v4
+default_genotyping_protocol "GBS ApeKI genotyping v4"
 
 <Controller::Cview>
     cview_default_map_id 1


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes #5307. Jobs in the recent jobs list on user details page will be labeled as "dubious" if it has been more than two days and status was never updated from "submitted". Also adds two buttons that allow the user to clear the analysis log of failed and dubious jobs as well as remove jobs older than a certain time interval.

<!-- If there are relevant issues, link them here: -->
#5307 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
