### PR TITLE
Personalized Homepage: replace center tag, remove unused table

### DIFF
--- a/mason/index_logged_in_user.mas
+++ b/mason/index_logged_in_user.mas
@@ -17,7 +17,7 @@ $editable_stock_props => {}
 
 </%args>
 
-<center>
+<div style="text-align: center">
 
 <h3>Welcome back <% $first_name %>!</h3>
 
@@ -79,6 +79,7 @@ Interval:&nbsp;
 
 %} # -- if ($role ne...
 
+</div>
 
 <script>
     var interval = jQuery('#interval').val()	
@@ -129,6 +130,5 @@ Interval:&nbsp;
 
 </script>
 
-<table><tr><td>
 
 <& /index.mas, schema => $schema, timestamp => $timestamp, static_content_path=> $static_content_path, phenotype_files => $phenotype_files, breeding_programs => $breeding_programs, locations => $locations, preferred_species => $preferred_species, editable_stock_props => $editable_stock_props &>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Replace the [deprecated center tag](https://www.w3schools.com/tags/tag_center.ASP) with a div and remove an unused/unclosed table.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
