### PR TITLE
Accession Upload: check for existing non-accession stocks

### DIFF
--- a/lib/CXGN/Stock/ParseUpload/Plugin/AccessionsGeneric.pm
+++ b/lib/CXGN/Stock/ParseUpload/Plugin/AccessionsGeneric.pm
@@ -104,6 +104,18 @@ sub _validate_with_plugin {
         $errors{'missing_species'} = \@species_missing;
     }
 
+    # Check for existing non-accession stocks
+    my $accession_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
+    my $accession_list = $parsed_values->{'accession_name'};
+    my $stocks_in_db_rs = $schema->resultset("Stock::Stock")->search({ uniquename => { -ilike => $accession_list }, type_id => { '<>' => $accession_type_id } });
+    my @stocks_existing;
+    while ( my $r=$stocks_in_db_rs->next ) {
+      push @stocks_existing, $r->uniquename;
+    }
+    if ( scalar(@stocks_existing) > 0 ) {
+      push @error_messages, "The following accession names are already used in the database (as different stock types): " . join(',', @stocks_existing);
+    }
+
     #store any errors found in the parsed file to parse_errors accessor
     if (scalar(@error_messages) >= 1) {
         $errors{'error_messages'} = \@error_messages;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Add a check to the Accession upload to look for existing stock names that are not an accession and return an error message if any are found.

Fixes #5371 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
