### PR TITLE
Search Wizard: multi-line filter

### DIFF
--- a/js/source/modules/wizard-search.js
+++ b/js/source/modules/wizard-search.js
@@ -258,6 +258,17 @@ export function Wizard(main_id,col_number){
     reflow(d.index);
   }).filter(d=>d.index>0).select(".wizard-lists-group").remove();
 
+  allCols.select('.wizard-search-options-contains').on("click", function(d) {
+    toggleSearchOptionsMatch(this, d, "contains");
+  });
+  allCols.select('.wizard-search-options-exact').on("click", function(d) {
+    toggleSearchOptionsMatch(this, d, "exact");
+  });
+  allCols.select('.wizard-search-options-clear').on("click", function(d) {
+    var thiscol = allCols.filter(c_d=>c_d==d);
+    thiscol.select(".wizard-search").property("value", "");
+  });
+
   allCols.select('.wizard-union-toggle-btn-any').on("click", function(d) {
     toggleMatch(this, d, "any");
   });
@@ -282,11 +293,12 @@ export function Wizard(main_id,col_number){
 
   allCols.select(".wizard-select-all").on("click",function(d){
       var s = d3.selectAll(".wizard-search").filter(function(e, i) { return i === d.index });
-      var search_txt = s ? s.property("value").replace(/\s+/g, "").toLowerCase() : undefined;
+      var search_txt = s ? s.property("value") : undefined;
+      var search_terms = search_txt ? search_txt.split(/,|\n/).map((e) => e.replace(/\s+/g, "").toLowerCase()) : undefined;
       d.items.forEach(i=>{
           var val = i.name.replace(/\s+/g, "").toLowerCase();
           if (!i.selected) {
-              i.selected = search_txt ? val.indexOf(search_txt) != -1 : true;
+              i.selected = search_terms ? search_terms.some((st) => st && st !== "" && d.filterType === 'exact' ? val === st : val.includes(st)) : true;
           }
       });
       reflow(d.index,true);
@@ -326,16 +338,12 @@ export function Wizard(main_id,col_number){
     }
   });
   allCols.select(".wizard-search").on("input",function(d){
-    var search_txt = d3.select(this).property("value").replace(/\s+/g, "")
-      .toLowerCase();
+    var search_txt = d3.select(this).property("value");
+    var search_terms = search_txt ? search_txt.split(/,|\n/).map((e) => e.replace(/\s+/g, "").toLowerCase()) : undefined;
     d.filter = (item)=>{
       var val = item.name.replace(/\s+/g, "").toLowerCase();
-      if(val.indexOf(search_txt)!=-1){
-        return true;
-      }
-      else {
-        return false;
-      }
+      var included = search_terms ? search_terms.some((st) => st && st !== "" && d.filterType === 'exact' ? val === st : val.includes(st)) : true;
+      return included;
     }
     reflow(d.index, false, true);
   });
@@ -549,6 +557,27 @@ export function Wizard(main_id,col_number){
       opts.exit().remove();
     })
   }
+
+  /**
+   * Handle the selection of a search options match toggle button
+   * @param {Element} el DOM element that was selected
+   * @param {Object} d Data propagated from selected element
+   * @param {string} type Toggle type selected ("contains", "exact")
+   */
+    function toggleSearchOptionsMatch(el, d, type) {
+      el = d3.select(el);
+      var bg = el.select(function() { return this.parentNode; });
+
+      bg.selectAll('.wizard-search-options-btn')
+        .classed('btn-primary', false)
+        .classed('btn-default', true)
+        .classed('active', false);
+      el.classed('btn-primary', true).classed('active', true);
+
+      d.filterType = type;
+
+      reflow(d.index, true);
+    }
 
   /**
    * Handle the selection of a match toggle button

--- a/js/source/modules/wizard-search.js
+++ b/js/source/modules/wizard-search.js
@@ -300,7 +300,7 @@ export function Wizard(main_id,col_number){
       d.items.forEach(i=>{
           var val = i.name.replace(/\s+/g, "").toLowerCase();
           if (!i.selected) {
-              i.selected = search_terms ? search_terms.some((st) => st && st !== "" && d.filterType === 'exact' ? val === st : val.includes(st)) : true;
+              i.selected = search_terms ? search_terms.some((st) => st && st !== "" && (d.filterType === 'exact' ? val === st : val.includes(st))) : true;
           }
       });
       reflow(d.index,true);
@@ -344,7 +344,7 @@ export function Wizard(main_id,col_number){
     var search_terms = search_txt ? search_txt.split(/,|\n/).map((e) => e.replace(/\s+/g, "").toLowerCase()) : undefined;
     d.filter = (item)=>{
       var val = item.name.replace(/\s+/g, "").toLowerCase();
-      var included = search_terms ? search_terms.some((st) => st && st !== "" && d.filterType === 'exact' ? val === st : val.includes(st)) : true;
+      var included = search_terms ? search_terms.some((st) => st && st !== "" && (d.filterType === 'exact' ? val === st : val.includes(st))) : true;
       return included;
     }
     reflow(d.index, false, true);

--- a/js/source/modules/wizard-search.js
+++ b/js/source/modules/wizard-search.js
@@ -267,6 +267,8 @@ export function Wizard(main_id,col_number){
   allCols.select('.wizard-search-options-clear').on("click", function(d) {
     var thiscol = allCols.filter(c_d=>c_d==d);
     thiscol.select(".wizard-search").property("value", "");
+    d.filter = () => true;
+    reflow(d.index, true);
   });
 
   allCols.select('.wizard-union-toggle-btn-any').on("click", function(d) {

--- a/js/source/modules/wizard-search.js
+++ b/js/source/modules/wizard-search.js
@@ -258,6 +258,10 @@ export function Wizard(main_id,col_number){
     reflow(d.index);
   }).filter(d=>d.index>0).select(".wizard-lists-group").remove();
 
+  allCols.select('.wizard-search').on("focus", function(d) {
+    var thiscol = allCols.filter(c_d=>c_d==d);
+    thiscol.select('.wizard-search-container').classed('wizard-search-container-active', true);
+  });
   allCols.select('.wizard-search-options-contains').on("click", function(d) {
     toggleSearchOptionsMatch(this, d, "contains");
   });
@@ -269,6 +273,11 @@ export function Wizard(main_id,col_number){
     thiscol.select(".wizard-search").property("value", "");
     d.filter = () => true;
     reflow(d.index, true);
+  });
+  allCols.select('.wizard-search-options-done').on("click", function(d) {
+    var thiscol = allCols.filter(c_d=>c_d==d);
+    thiscol.select('.wizard-search-container').classed('wizard-search-container-active', false);
+    d3.select(this).node().blur();
   });
 
   allCols.select('.wizard-union-toggle-btn-any').on("click", function(d) {

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -47,7 +47,7 @@ $dataset_id => undef
             </select>
           </div>
 
-          <div class="wizard-search-container panel-heading">
+          <div class="wizard-search-container">
             <textarea class="wizard-search form-control" placeholder="Search"></textarea>
             <div class="wizard-search-options">
               <div class="wizard-search-options-group btn-group" role="group">

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -39,8 +39,6 @@ $dataset_id => undef
       <div class="wizard-column">
         <div class="wizard-panel panel panel-default">
 
-          <span class="wizard-loader glyphicon glyphicon-refresh" aria-hidden="true"></span>
-
           <div class="panel-heading">
             <select class="wizard-type-select form-control input-sm form-inline">
               <option value="" disabled selected>Select Column Type</option>
@@ -49,8 +47,15 @@ $dataset_id => undef
             </select>
           </div>
 
-          <div class="panel-heading">
-            <input type="text" class="wizard-search form-control input-sm" placeholder="Search">
+          <div class="wizard-search-container panel-heading">
+            <textarea class="wizard-search form-control" placeholder="Search"></textarea>
+            <div class="wizard-search-options">
+              <div class="wizard-search-options-group btn-group" role="group">
+                <button type="button" class="btn btn-xs btn-primary active wizard-search-options-btn wizard-search-options-contains">Contains</button>
+                <button type="button" class="btn btn-xs btn-default wizard-search-options-btn wizard-search-options-exact">Exact</button>
+              </div>
+              <button type="button" class="btn btn-xs btn-default wizard-search-options-clear">Clear</button>
+            </div>
           </div>
 
           <div class="panel-body">
@@ -65,8 +70,11 @@ $dataset_id => undef
               </div>
             </div>
 
-            <ul class="wizard-list-unselected wizard-list well"></ul>
-            <ul class="wizard-list-selected wizard-list well"></ul>
+            <div style="position: relative">
+              <span class="wizard-loader glyphicon glyphicon-refresh" aria-hidden="true"></span>
+              <ul class="wizard-list-unselected wizard-list well"></ul>
+              <ul class="wizard-list-selected wizard-list well"></ul>
+            </div>
 
             <div class="wizard-btn-center wizard-union-toggle">
               <div class="btn-group wizard-union-toggle-btn-group">
@@ -641,7 +649,6 @@ $dataset_id => undef
     } else if ( selected_genotyping_projects.length >= 1 ) {
       var selected_genotyping_project = selected_genotyping_projects[0].id;
       if ( selected_genotyping_project !== SELECTED_GENOTYPING_PROJECT ) {
-        console.log("project new " + selected_genotyping_project);
         SELECTED_GENOTYPING_PROJECT = selected_genotyping_project;
         jQuery.ajax({
           url: '/ajax/genotyping_project/protocols',
@@ -661,7 +668,6 @@ $dataset_id => undef
               SELECTED_GENOTYPING_PROTOCOL = genotyping_protocol[0]["protocol_id"];
               // console.log(genotyping_protocol[0]["protocol_id"]);
               // console.log(genotyping_protocol[0]["protocol_name"]);
-              console.log("genotype protocol from project = " + SELECTED_GENOTYPING_PROTOCOL);
               if ( selected_genotyping_protocols.length < 1 ) {
                 $(".wizard-download-genotypes-info3").show();
                 $(".wizard-download-genotypes-info3").val("genotype protocol \"" + genotyping_protocol[0]["protocol_name"] + "\""); 
@@ -725,7 +731,6 @@ $dataset_id => undef
               console.log(repsonse.error);
             } else {
               SELECTED_GENOTYPING_PROTOCOL = response.default_protocol.protocol_id;
-              console.log(response.default_protocol.protocol_id);
               jQuery.ajax({
                 url: '/ajax/genotyping_protocol/num_markers',
                 method: "GET",

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -56,10 +56,10 @@ $dataset_id => undef
               </div>
               <div class="btn-group" role="group">
                 <button type="button" class="btn btn-xs btn-danger wizard-search-options-clear">
-                  &nbsp;<span class="glyphicon glyphicon-erase"></span>&nbsp;
+                  &nbsp;<span class="glyphicon glyphicon-remove" style="top: 2px"></span>&nbsp;
                 </button>
                 <button type="button" class="btn btn-xs btn-info wizard-search-options-done">
-                  &nbsp;<span class="glyphicon glyphicon-triangle-top"></span>&nbsp;
+                  &nbsp;<span class="glyphicon glyphicon-chevron-up" style="top: 2px"></span>&nbsp;
                 </button>
               </div>
             </div>

--- a/mason/breeders_toolbox/breeder_search_page.mas
+++ b/mason/breeders_toolbox/breeder_search_page.mas
@@ -54,7 +54,14 @@ $dataset_id => undef
                 <button type="button" class="btn btn-xs btn-primary active wizard-search-options-btn wizard-search-options-contains">Contains</button>
                 <button type="button" class="btn btn-xs btn-default wizard-search-options-btn wizard-search-options-exact">Exact</button>
               </div>
-              <button type="button" class="btn btn-xs btn-default wizard-search-options-clear">Clear</button>
+              <div class="btn-group" role="group">
+                <button type="button" class="btn btn-xs btn-danger wizard-search-options-clear">
+                  &nbsp;<span class="glyphicon glyphicon-erase"></span>&nbsp;
+                </button>
+                <button type="button" class="btn btn-xs btn-info wizard-search-options-done">
+                  &nbsp;<span class="glyphicon glyphicon-triangle-top"></span>&nbsp;
+                </button>
+              </div>
             </div>
           </div>
 

--- a/static/css/wizard.css
+++ b/static/css/wizard.css
@@ -31,6 +31,13 @@ ul.wizard-list li{
   display:inline-block;
 }
 
+.wizard-search-container {
+  padding: 10px 15px;
+  color: #333;
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #ddd;
+}
+
 .wizard-search {
   height: 3em !important;
   transition: height 0.25s ease-in-out;

--- a/static/css/wizard.css
+++ b/static/css/wizard.css
@@ -28,10 +28,29 @@ ul.wizard-list li{
   display:inline-block;
 }
 
+.wizard-search {
+  height: 3em !important;
+  transition: height 0.5s ease-in-out;
+}
+.wizard-search-container:focus-within > .wizard-search {
+  height: 10em !important;
+}
+.wizard-search-options {
+  display: flex;
+  justify-content: space-between;
+  height: 0;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+.wizard-search-container:focus-within > .wizard-search-options {
+  height: auto;
+  opacity: 1;
+}
+
 .wizard-loader {
   position: absolute;
   z-index: 100;
-  top: 6em;
+  top: 2em;
   left: 0;
   font-size: 2em;
   text-align: center;

--- a/static/css/wizard.css
+++ b/static/css/wizard.css
@@ -1,34 +1,34 @@
 ul.wizard-list,
 .wizard-list-item,
-ul.wizard-list li{
-  margin:0;
+ul.wizard-list li {
+  margin: 0;
   padding: 0;
   text-indent: 0;
   list-style-type: none;
-  min-width:100%;
-  position:relative;
+  min-width: 100%;
+  position: relative;
 }
 
 .btn-group.wizard-list-item {
   white-space: nowrap;
 }
 
-.wizard-btn-center{
-  text-align:center; 
-  white-space:nowrap;
+.wizard-btn-center {
+  text-align: center;
+  white-space: nowrap;
 }
 
-.wizard-btn-center *{
-  white-space:nowrap;
+.wizard-btn-center * {
+  white-space: nowrap;
 }
 
-.wizard-btn-center .btn-group{
-  display:inline-block;
+.wizard-btn-center .btn-group {
+  display: inline-block;
 }
 
-.wizard-btn-center .btn-group .btn{
+.wizard-btn-center .btn-group .btn {
   margin: 0;
-  display:inline-block;
+  display: inline-block;
 }
 
 .wizard-search-container {
@@ -43,7 +43,8 @@ ul.wizard-list li{
   transition: height 0.25s ease-in-out;
 }
 
-.wizard-search-container-active > .wizard-search, .wizard-search-container:focus-within > .wizard-search {
+.wizard-search-container-active > .wizard-search,
+.wizard-search-container:focus-within > .wizard-search {
   height: 10em !important;
 }
 
@@ -56,7 +57,8 @@ ul.wizard-list li{
   transition: opacity 0.25s ease-in-out;
 }
 
-.wizard-search-container-active > .wizard-search-options, .wizard-search-container:focus-within > .wizard-search-options {
+.wizard-search-container-active > .wizard-search-options,
+.wizard-search-container:focus-within > .wizard-search-options {
   height: auto;
   opacity: 1;
 }
@@ -84,14 +86,14 @@ ul.wizard-list li{
   }
 }
 
-ul.wizard-list{
-  height:10em;
+ul.wizard-list {
+  height: 10em;
   overflow-y: auto;
   padding: 4px;
   margin-top: 6px;
 }
 
-.wizard-panel .wizard-union-toggle{
+.wizard-panel .wizard-union-toggle {
   margin-top: 6px;
 }
 
@@ -110,29 +112,29 @@ ul.wizard-list{
   padding: 0 10px;
 }
 
-button.wizard-list-add{
-  width:2.45em;
-  z-index:100;
+button.wizard-list-add {
+  width: 2.45em;
+  z-index: 100;
 }
 
-button.wizard-list-rem{
-  width:2.45em;
-  z-index:100;
+button.wizard-list-rem {
+  width: 2.45em;
+  z-index: 100;
 }
 
-.wizard-list-name{
-  width:calc(100% - 2.45em);
+.wizard-list-name {
+  width: calc(100% - 2.45em);
 }
 
-div.wizard-panel{
+div.wizard-panel {
   min-width: 140px;
   overflow: hidden;
 }
 
-div.wizard-panel .panel-body{
-  padding:6px;
+div.wizard-panel .panel-body {
+  padding: 6px;
 }
 
-.btn.wizard-btn-tag{
+.btn.wizard-btn-tag {
   pointer-events: none;
 }

--- a/static/css/wizard.css
+++ b/static/css/wizard.css
@@ -30,19 +30,20 @@ ul.wizard-list li{
 
 .wizard-search {
   height: 3em !important;
-  transition: height 0.5s ease-in-out;
+  transition: height 0.25s ease-in-out;
 }
-.wizard-search-container:focus-within > .wizard-search {
+.wizard-search-container:focus-within > .wizard-search, .wizard-search-container-active > .wizard-search {
   height: 10em !important;
 }
 .wizard-search-options {
+  margin-top: 5px;
   display: flex;
   justify-content: space-between;
   height: 0;
   opacity: 0;
-  transition: opacity 0.5s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
 }
-.wizard-search-container:focus-within > .wizard-search-options {
+.wizard-search-container:focus-within > .wizard-search-options, .wizard-search-container-active > .wizard-search-options {
   height: auto;
   opacity: 1;
 }

--- a/static/css/wizard.css
+++ b/static/css/wizard.css
@@ -17,14 +17,17 @@ ul.wizard-list li{
   text-align:center; 
   white-space:nowrap;
 }
+
 .wizard-btn-center *{
   white-space:nowrap;
 }
+
 .wizard-btn-center .btn-group{
   display:inline-block;
 }
+
 .wizard-btn-center .btn-group .btn{
-  margin: 0px;
+  margin: 0;
   display:inline-block;
 }
 
@@ -32,9 +35,11 @@ ul.wizard-list li{
   height: 3em !important;
   transition: height 0.25s ease-in-out;
 }
-.wizard-search-container:focus-within > .wizard-search, .wizard-search-container-active > .wizard-search {
+
+.wizard-search-container-active > .wizard-search, .wizard-search-container:focus-within > .wizard-search {
   height: 10em !important;
 }
+
 .wizard-search-options {
   margin-top: 5px;
   display: flex;
@@ -43,7 +48,8 @@ ul.wizard-list li{
   opacity: 0;
   transition: opacity 0.25s ease-in-out;
 }
-.wizard-search-container:focus-within > .wizard-search-options, .wizard-search-container-active > .wizard-search-options {
+
+.wizard-search-container-active > .wizard-search-options, .wizard-search-container:focus-within > .wizard-search-options {
   height: auto;
   opacity: 1;
 }
@@ -57,35 +63,15 @@ ul.wizard-list li{
   text-align: center;
   width: 100%;
   display: block;
-  -webkit-transform-origin: 50% 47%;
-  transform-origin:50% 47%;
-  -ms-transform-origin:50% 47%;
-  -webkit-animation: wizard-loading 2s infinite linear;
-  -moz-animation: wizard-loading 2s infinite linear;
-  -o-animation: wizard-loading 2s infinite linear;
+  transform-origin: 50% 47%;
   animation: wizard-loading 2s infinite linear;
 }
 
-@-moz-keyframes wizard-loading {
-  from {
-    -moz-transform: rotate(0deg);
-  }
-  to {
-    -moz-transform: rotate(360deg);
-  }
-}
-@-webkit-keyframes wizard-loading {
-  from {
-    -webkit-transform: rotate(0deg);
-  }
-  to {
-    -webkit-transform: rotate(360deg);
-  }
-}
 @keyframes wizard-loading {
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }
@@ -97,36 +83,45 @@ ul.wizard-list{
   padding: 4px;
   margin-top: 6px;
 }
+
 .wizard-panel .wizard-union-toggle{
   margin-top: 6px;
 }
+
 .wizard-panel .wizard-union-toggle-min-group {
   max-width: 150px;
   margin: 0 auto;
   display: none;
 }
+
 .wizard-panel .wizard-union-toggle-min-group input {
   height: 22px;
 }
+
 .wizard-panel .wizard-union-toggle-min-group .input-group-btn .btn {
   height: 22px;
   padding: 0 10px;
 }
+
 button.wizard-list-add{
   width:2.45em;
   z-index:100;
 }
+
 button.wizard-list-rem{
   width:2.45em;
   z-index:100;
 }
+
 .wizard-list-name{
   width:calc(100% - 2.45em);
 }
+
 div.wizard-panel{
   min-width: 140px;
   overflow: hidden;
 }
+
 div.wizard-panel .panel-body{
   padding:6px;
 }

--- a/t/selenium2/breeders/breeder_search.t
+++ b/t/selenium2/breeders/breeder_search.t
@@ -2,7 +2,7 @@ use strict;
 
 use lib 't/lib';
 
-use Test::More 'tests' => 118;
+use Test::More 'tests' => 128;
 
 use SGN::Test::WWW::WebDriver;
 use Selenium::Remote::WDKeys 'KEYS';
@@ -18,16 +18,18 @@ $t->while_logged_in_as("submitter", sub {
     sleep(2);
 
     # COLUMN 1 WIZARD SEARCH - test list select / search - select trials
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[1]', 'xpath', 'find select column type in first column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"]/select)[1]', 'xpath', 'find select column type in first column')->click();
     sleep(1);
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[1]//option[@value="trials"]', 'xpath', 'find and select "trials" in first column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"]/select)[1]//option[@value="trials"]', 'xpath', 'find and select "trials" in first column')->click();
     sleep(1);
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"])[2]//input[contains(@class, "wizard-search")]' , 'xpath', 'find a search box and type "Kasese solgs trial"')->send_keys('Kasese solgs trial');
+    my $search_column = $t->find_element_ok('(//div[contains(@class, "wizard-column")])[1]//textarea', 'xpath', 'find a search box');
+    # $t->driver->execute_script("arguments[0].scrollIntoView(true);window.scrollBy(0,-100);", $search_column);
+    $search_column->send_keys('Kasese solgs trial');
     sleep(2);
 
     # COLUMN 1 WIZARD SEARCH - check if only "Kasese solgs trial" is in unselect panel field
     my $search_unselected = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]/ul[contains(@class, "wizard-list-unselected")]',
+        '(//div[@class="panel-body"])[1]//ul[contains(@class, "wizard-list-unselected")]',
         'xpath',
         'find a content of "unselected trials panel" to test searchbox in first column')->get_attribute('innerHTML');
 
@@ -36,34 +38,32 @@ $t->while_logged_in_as("submitter", sub {
     ok($search_unselected !~ /trial2 NaCRRI/, "Verify if unselected panel after search NOT contain: 'trial2 NaCRRI'");
 
     sleep(1);
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]//a[contains(text(), "Kasese solgs trial")]//preceding-sibling::button' , 'xpath', 'find and add "Kasese solgs trial" trial in first column with search filter active')->click();
+    $t->find_element_ok('(//div[@class="panel-body"])[1]//a[contains(text(), "Kasese solgs trial")]//preceding-sibling::button' , 'xpath', 'find and add "Kasese solgs trial" trial in first column with search filter active')->click();
 
     # COLUMN 2 WIZARD SEARCH - test list select / search - select trials
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[2]', 'xpath', 'find select column type in second column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"])[2]/select', 'xpath', 'find select column type in second column')->click();
     sleep(1);
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[2]//option[@value="traits"]', 'xpath', 'find and select "traits" in second column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"])[2]/select//option[@value="traits"]', 'xpath', 'find and select "traits" in second column')->click();
     sleep(1);
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[2]//a[contains(text(), "dry matter content percentage|CO_334:0000092")]//preceding-sibling::button' , 'xpath', 'find and add "dry matter content percentage|CO_334:0000092" trait in second column')->click();
+    $t->find_element_ok('(//div[@class="panel-body"])[2]//a[contains(text(), "dry matter content percentage|CO_334:0000092")]//preceding-sibling::button' , 'xpath', 'find and add "dry matter content percentage|CO_334:0000092" trait in second column')->click();
     sleep(1);
 
     # COLUMN 1 AND 2 - test for all / any / default values / check if numbers off possible combinations are changing
-    my $active_union_button = $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]/div[contains(@class, "wizard-union-toggle")]/div[contains(@class, "wizard-union-toggle-btn-group")]/button[contains(@class, "active")]' , 'xpath', 'find active union button in first column');
+    my $active_union_button = $t->find_element_ok('(//div[@class="panel-body"])[1]//div[contains(@class, "wizard-union-toggle")]/div[contains(@class, "wizard-union-toggle-btn-group")]/button[contains(@class, "active")]' , 'xpath', 'find active union button in first column');
     ok (lc($active_union_button->get_attribute('innerHTML')) eq "any", "default active union button for selection shall be ANY");
 
-    my $button_count_all_second_column_xpath = '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[2]/div/div[@class="btn-group"]//span[contains(@class, "wizard-count-all")]';
+    my $button_count_all_second_column_xpath = '(//div[@class="panel-body"])[2]//div[@class="btn-group"]//span[contains(@class, "wizard-count-all")]';
 
     my $button_count_all_second_column = $t->find_element_ok($button_count_all_second_column_xpath , 'xpath', 'find count traits field pointer');
     ok ($button_count_all_second_column->get_text() eq "3", "number of traits with 'ANY button' in second panel from 'Kasese solgs trial' should be 3");
 
-    my $search_column_1 = $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"])[2]//input[contains(@class, "wizard-search")]' , 'xpath', 'find search input in first column and clear it, for union test');
-    $search_column_1->send_keys(KEYS->{'control'}, 'a');
-    $search_column_1->send_keys(KEYS->{'backspace'});
+    $t->find_element_ok('(//div[contains(@class, "wizard-column")])[1]//button[contains(@class, "wizard-search-options-clear")]' , 'xpath', 'clear search input in first column, for union test')->click();
     sleep(2);
 
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]//a[contains(text(), "trial2 NaCRRI")]//preceding-sibling::button' , 'xpath', 'find and select "trial2 NaCRRI" in first column')->click();
+    $t->find_element_ok('(//div[@class="panel-body"])[1]//a[contains(text(), "trial2 NaCRRI")]//preceding-sibling::button' , 'xpath', 'find and select "trial2 NaCRRI" in first column')->click();
     sleep(1);
 
-    my $unselected_traits_second_column_xpath = '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[2]/ul[contains(@class, "wizard-list-unselected")]';
+    my $unselected_traits_second_column_xpath = '(//div[@class="panel-body"])[2]//ul[contains(@class, "wizard-list-unselected")]';
 
     my $unselected_traits_content = $t->find_element_ok($unselected_traits_second_column_xpath, 'xpath', 'find content of unselected list from second column')->get_attribute('innerHTML');
     ok ($unselected_traits_content =~ /harvest index variable|CO_334:0000015/, 'find new trait for two trials and ANY union "harvest index variable|CO_334:0000015"');
@@ -71,8 +71,8 @@ $t->while_logged_in_as("submitter", sub {
     $button_count_all_second_column = $t->find_element_ok($button_count_all_second_column_xpath , 'xpath', 'find count traits field pointer');
     ok ($button_count_all_second_column->get_text() eq "4", "number of traits with 'ANY button' in second panel from 'Kasese solgs trial' and 'trial2 NaCRRI' should be 4");
 
-    my $all_union_button = $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]/div[contains(@class, "wizard-union-toggle")]/div[contains(@class, "wizard-union-toggle-btn-group")]/button[contains(text(), "ALL")]' , 'xpath', 'find "ALL" button');
-    my $any_union_button = $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]/div[contains(@class, "wizard-union-toggle")]/div[contains(@class, "wizard-union-toggle-btn-group")]/button[contains(text(), "ANY")]' , 'xpath', 'find "ANY" button');
+    my $all_union_button = $t->find_element_ok('(//div[@class="panel-body"])[1]//div[contains(@class, "wizard-union-toggle")]/div[contains(@class, "wizard-union-toggle-btn-group")]/button[contains(text(), "ALL")]' , 'xpath', 'find "ALL" button');
+    my $any_union_button = $t->find_element_ok('(//div[@class="panel-body"])[1]//div[contains(@class, "wizard-union-toggle")]/div[contains(@class, "wizard-union-toggle-btn-group")]/button[contains(text(), "ANY")]' , 'xpath', 'find "ANY" button');
 
     $all_union_button->click();
     sleep(1);
@@ -90,15 +90,15 @@ $t->while_logged_in_as("submitter", sub {
     $unselected_traits_content = $t->find_element_ok($unselected_traits_second_column_xpath, 'xpath', 'find content of unselected list from second column"')->get_attribute('innerHTML');
     ok ($unselected_traits_content =~ /harvest index variable|CO_334:0000015/, '"harvest index variable|CO_334:0000015" trait for two trials and ANY union shall be displayed in unselected traits');
 
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]/ul[contains(@class, "wizard-list-selected wizard-list")]//a[contains(text(), "trial2 NaCRRI")]//preceding-sibling::button' , 'xpath', 'first select')->click();
+    $t->find_element_ok('(//div[@class="panel-body"])[1]//ul[contains(@class, "wizard-list-selected wizard-list")]//a[contains(text(), "trial2 NaCRRI")]//preceding-sibling::button' , 'xpath', 'first select')->click();
     sleep(1);
     $unselected_traits_content = $t->find_element_ok($unselected_traits_second_column_xpath, 'xpath', 'find content of unselected list from second column"')->get_attribute('innerHTML');
     ok ($unselected_traits_content !~ /harvest index variable|CO_334:0000015/, '"harvest index variable|CO_334:0000015" trait for one trial after "trial2 NaCRRI" removed should not be displayed in unselected traits');
 
     # COLUMN 3 WIZARD SEARCH - select years and save first dataset with 3 list
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[3]', 'xpath', 'find select column type in third column')->click();
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[3]//option[@value="years"]', 'xpath', 'find and select "years" in third column')->click();
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[3]//a[contains(text(), "2014")]//preceding-sibling::button' , 'xpath', 'find and add "2014" year in third column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"]/select)[3]', 'xpath', 'find select column type in third column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"]/select)[3]//option[@value="years"]', 'xpath', 'find and select "years" in third column')->click();
+    $t->find_element_ok('(//div[@class="panel-body"])[3]//a[contains(text(), "2014")]//preceding-sibling::button' , 'xpath', 'find and add "2014" year in third column')->click();
     sleep(1);
 
     my $dataset_name_input = $t->find_element_ok('input[placeholder="Create New Dataset"]', 'css', 'find dataset name input field');
@@ -110,14 +110,15 @@ $t->while_logged_in_as("submitter", sub {
     $dataset_name_input->send_keys($dataset_name_1);
     $t->find_element_ok('//input[@placeholder="Create New Dataset"]/parent::div//button[contains(text(), "Create")]', 'xpath', "find 'create' button and create dataset $dataset_name_1")->click;
     sleep(1);
+    ok($t->driver->get_alert_text() =~ m/Dataset another_dataset_3_columns created/i, 'Created dataset another_dataset_3_columns');
     $t->driver()->accept_alert();
 
     # COLUMN 4 WIZARD SEARCH - select accessions and save second dataset
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[4]', 'xpath', 'find select column type in fourth column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"]/select)[4]', 'xpath', 'find select column type in fourth column')->click();
     sleep(1);
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[4]//option[@value="accessions"]', 'xpath', 'find and select "accessions" in fourth column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"]/select)[4]//option[@value="accessions"]', 'xpath', 'find and select "accessions" in fourth column')->click();
     sleep(1);
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[4]//a[contains(text(), "UG120001")]//preceding-sibling::button' , 'xpath', 'find and add "UG120001" year in fourth column')->click();
+    $t->find_element_ok('(//div[@class="panel-body"])[4]//a[contains(text(), "UG120001")]//preceding-sibling::button' , 'xpath', 'find and add "UG120001" year in fourth column')->click();
     sleep(1);
 
     $dataset_name_input = $t->find_element_ok('input[placeholder="Create New Dataset"]', 'css', 'find dataset name input field and clear content');
@@ -129,84 +130,89 @@ $t->while_logged_in_as("submitter", sub {
     $dataset_name_input->send_keys($dataset_name_2);
     $t->find_element_ok('//input[@placeholder="Create New Dataset"]/parent::div//button[contains(text(), "Create")]', 'xpath', "find 'create' button and create dataset $dataset_name_2")->click();
     sleep(1);
+    ok($t->driver->get_alert_text() =~ m/Dataset another_dataset_4_columns created/i, 'Created dataset another_dataset_4_columns');
     $t->driver()->accept_alert();
     sleep(1);
 
     # SAVE A LIST FROM COLUMN 1
     my $first_list_name = "trials_list";
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[1]//input[contains(@class, "wizard-create-list-name")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[1]//input[contains(@class, "wizard-create-list-name")]',
         'xpath',
         'find a "list name" for first column and fill a name')->click();
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[1]//input[contains(@class, "wizard-create-list-name")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[1]//input[contains(@class, "wizard-create-list-name")]',
         'xpath',
         "fill '$first_list_name' as list name in first column")->send_keys($first_list_name);
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[1]//button[contains(text(), "Create")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[1]//button[contains(text(), "Create")]',
         'xpath',
         "find a 'create list' in first columns button and click")->click();
     sleep(1);
+    ok($t->driver->get_alert_text() =~ m/1 items added to list trials_list/i, 'Add 1 item to trials_list');
     $t->driver()->accept_alert();
 
     # SAVE A LIST FROM COLUMN 2
     my $second_list_name = "traits_list";
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[2]//input[contains(@class, "wizard-create-list-name")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[2]//input[contains(@class, "wizard-create-list-name")]',
         'xpath',
         'find a "list name" for second column and fill a name')->click();
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[2]//input[contains(@class, "wizard-create-list-name")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[2]//input[contains(@class, "wizard-create-list-name")]',
         'xpath',
         "fill '$second_list_name' as list name in second column")->send_keys($second_list_name);
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[2]//button[contains(text(), "Create")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[2]//button[contains(text(), "Create")]',
         'xpath',
         "find a 'create list' in second columns button and click")->click();
     sleep(1);
+    ok($t->driver->get_alert_text() =~ m/1 items added to list traits_list/i, 'Add 1 item to traits_list');
     $t->driver()->accept_alert();
 
     # SAVE A LIST FROM COLUMN 3
     my $third_list_name = "years_list";
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[3]//input[contains(@class, "wizard-create-list-name")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[3]//input[contains(@class, "wizard-create-list-name")]',
         'xpath',
         'find a "list name" for third column and fill a name')->click();
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[3]//input[contains(@class, "wizard-create-list-name")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[3]//input[contains(@class, "wizard-create-list-name")]',
         'xpath',
         "fill '$third_list_name' as list name in third column")->send_keys($third_list_name);
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[3]//button[contains(text(), "Create")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[3]//button[contains(text(), "Create")]',
         'xpath',
         "find a 'create list' in third columns button and click")->click();
     sleep(1);
+    ok($t->driver->get_alert_text() =~ m/1 items added to list years_list/i, 'added 1 item to years_list');
     $t->driver()->accept_alert();
 
     # SAVE A LIST FROM COLUMN 4
     my $fourth_list_name = "acc_list";
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[4]//input[contains(@class, "wizard-create-list-name")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[4]//input[contains(@class, "wizard-create-list-name")]',
         'xpath',
         'find a "list name" for fourth column and fill a name')->click();
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[4]//input[contains(@class, "wizard-create-list-name")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[4]//input[contains(@class, "wizard-create-list-name")]',
         'xpath',
         "fill '$fourth_list_name' as list name in fourth column")->send_keys($fourth_list_name);
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[4]//button[contains(text(), "Create")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[4]//button[contains(text(), "Create")]',
         'xpath',
         "find a 'create list' in fourth columns button and click")->click();
     sleep(1);
+    ok($t->driver->get_alert_text() =~ m/1 items added to list acc_list/i, 'added 1 item to acc_list');
     $t->driver()->accept_alert();
 
     # RELOAD PAGE AND LOAD DATASET_3_COLUMNS
@@ -232,7 +238,7 @@ $t->while_logged_in_as("submitter", sub {
 
     # unselected 1 column
     my $unselected_reloaded_elements = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]/ul[contains(@class, "wizard-list-unselected")]',
+        '(//div[@class="panel-body"])[1]//ul[contains(@class, "wizard-list-unselected")]',
         'xpath',
         "find content of unselected list from first column")->get_attribute('innerHTML');
 
@@ -241,7 +247,7 @@ $t->while_logged_in_as("submitter", sub {
 
     # selected 1 column
     my $selected_reloaded_elements = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]/ul[contains(@class, "wizard-list-selected wizard-list")]',
+        '(//div[@class="panel-body"])[1]//ul[contains(@class, "wizard-list-selected wizard-list")]',
         'xpath',
         "find content of selected list from first column")->get_attribute('innerHTML');
 
@@ -249,7 +255,7 @@ $t->while_logged_in_as("submitter", sub {
 
     # unselected 2 column
     my $unselected_reloaded_elements = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[2]/ul[contains(@class, "wizard-list-unselected")]',
+        '(//div[@class="panel-body"])[2]//ul[contains(@class, "wizard-list-unselected")]',
         'xpath',
         "find content of unselected list from second column")->get_attribute('innerHTML');
 
@@ -258,7 +264,7 @@ $t->while_logged_in_as("submitter", sub {
 
     # selected 2 column
     my $selected_reloaded_elements = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[2]/ul[contains(@class, "wizard-list-selected wizard-list")]',
+        '(//div[@class="panel-body"])[2]//ul[contains(@class, "wizard-list-selected wizard-list")]',
         'xpath',
         "find content of selected list from second column")->get_attribute('innerHTML');
 
@@ -266,7 +272,7 @@ $t->while_logged_in_as("submitter", sub {
 
     # selected 3 column
     my $selected_reloaded_elements = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[3]/ul[contains(@class, "wizard-list-selected wizard-list")]',
+        '(//div[@class="panel-body"])[3]//ul[contains(@class, "wizard-list-selected wizard-list")]',
         'xpath',
         "find content of selected list from third column")->get_attribute('innerHTML');
 
@@ -296,7 +302,7 @@ $t->while_logged_in_as("submitter", sub {
 
     # unselected 4 column
     my $unselected_reloaded_elements = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[4]/ul[contains(@class, "wizard-list-unselected")]',
+        '(//div[@class="panel-body"])[4]//ul[contains(@class, "wizard-list-unselected")]',
         'xpath',
         "find content of unselected list from fourth column")->get_attribute('innerHTML');
 
@@ -306,7 +312,7 @@ $t->while_logged_in_as("submitter", sub {
 
     # selected 4 column
     my $selected_reloaded_elements = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[4]/ul[contains(@class, "wizard-list-selected wizard-list")]',
+        '(//div[@class="panel-body"])[4]//ul[contains(@class, "wizard-list-selected wizard-list")]',
         'xpath',
         "find content of selected list from fourth column")->get_attribute('innerHTML');
 
@@ -317,53 +323,55 @@ $t->while_logged_in_as("submitter", sub {
     sleep(2);
 
     # RELOAD PAGE AND LOAD A LIST OF TRAILS
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[1]', 'xpath', 'find select column type in first column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"]/select)[1]', 'xpath', 'find select column type in first column')->click();
     sleep(1);
 
     $t->find_element_ok(
-        "(//div[\@id='wizard']/span/span/div/div/div[\@class='panel-heading']/select)[1]/optgroup/option[text()='$fourth_list_name']",
+        "(//div[\@class='panel-heading']/select)[1]/optgroup/option[text()='$fourth_list_name']",
         'xpath',
         "find and select '$fourth_list_name' in first column")->click();
     sleep(1);
 
     # selected 1 column - 2 new accessions and 1 old
     $selected_reloaded_elements = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]/ul[contains(@class, "wizard-list-selected wizard-list")]',
+        '(//div[@class="panel-body"])[1]//ul[contains(@class, "wizard-list-selected wizard-list")]',
         'xpath',
         "find content of selected list from first column")->get_attribute('innerHTML');
 
     ok($selected_reloaded_elements =~ /UG120001/, "Verify first column wizard, selected after load $fourth_list_name: accession UG120001");
 
     # ADD TO LIST FUNCTIONALITY
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[1]', 'xpath', 'find select column type in first column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"]/select)[1]', 'xpath', 'find select column type in first column')->click();
     sleep(1);
 
     $t->find_element_ok(
-        "(//div[\@id='wizard']/span/span/div/div/div[\@class='panel-heading']/select)[1]//option[\@value='accessions']", 'xpath', 'find and select "accessions" in first column')->click();
+        "(//div[\@class='panel-heading']/select)[1]//option[\@value='accessions']", 'xpath', 'find and select "accessions" in first column')->click();
     sleep(1);
 
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]//a[contains(text(), "IITA-TMS-IBA011412")]//preceding-sibling::button' , 'xpath', 'find and add "IITA-TMS-IBA011412" accessions in first column')->click();
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]//a[contains(text(), "IITA-TMS-IBA30572")]//preceding-sibling::button' , 'xpath', 'find and add "IITA-TMS-IBA30572" accessions in first column')->click();
+    $t->find_element_ok('(//div[@class="panel-body"])[1]//a[contains(text(), "IITA-TMS-IBA011412")]//preceding-sibling::button' , 'xpath', 'find and add "IITA-TMS-IBA011412" accessions in first column')->click();
+    $t->find_element_ok('(//div[@class="panel-body"])[1]//a[contains(text(), "IITA-TMS-IBA30572")]//preceding-sibling::button' , 'xpath', 'find and add "IITA-TMS-IBA30572" accessions in first column')->click();
     sleep(1);
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[1]//select[contains(@class, "wizard-add-to-list")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[1]//select[contains(@class, "wizard-add-to-list")]',
         'xpath',
         'find a add to list select for first column')->click();
     sleep(1);
 
     $t->find_element_ok(
-        "(//div[\@id='wizard']/span/span/div/div/table[contains(\@class, 'wizard-save-to-list')])[1]//select[contains(\@class, 'wizard-add-to-list')]/optgroup/option[text()='$fourth_list_name']",
+        "(//table[contains(\@class, 'wizard-save-to-list')])[1]//select[contains(\@class, 'wizard-add-to-list')]/optgroup/option[text()='$fourth_list_name']",
         'xpath',
         "find a $fourth_list_name on lists name and select")->click();
 
     $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/table[contains(@class, "wizard-save-to-list")])[1]//button[contains(@class, "wizard-add-to-list")]',
+        '(//table[contains(@class, "wizard-save-to-list")])[1]//button[contains(@class, "wizard-add-to-list")]',
         'xpath',
         'find a button "add to list" and click')->click();
     sleep(1);
+    ok($t->driver->get_alert_text() =~ m/The following items are already in the list and were not added: UG120001/i, 'UG120001 already exists in list');
     $t->driver()->accept_alert();
     sleep(1);
+    ok($t->driver->get_alert_text() =~ m/2 items added to list/i, '2 items added to list');
     $t->driver()->accept_alert();
 
     # reload to check a new acc_list with two extra accessions
@@ -371,18 +379,18 @@ $t->while_logged_in_as("submitter", sub {
     sleep(3);
 
     # COLUMN 1 WIZARD SEARCH - load saved list with accessions acc_list
-    $t->find_element_ok('(//div[@id="wizard"]/span/span/div/div/div[@class="panel-heading"]/select)[1]', 'xpath', 'find select column type in first column')->click();
+    $t->find_element_ok('(//div[@class="panel-heading"]/select)[1]', 'xpath', 'find select column type in first column')->click();
     sleep(1);
 
     $t->find_element_ok(
-        "(//div[\@id='wizard']/span/span/div/div/div[\@class='panel-heading']/select)[1]/optgroup/option[text()='$fourth_list_name']",
+        "(//div[\@class='panel-heading']/select)[1]/optgroup/option[text()='$fourth_list_name']",
         'xpath',
         "find and select '$fourth_list_name' in first column")->click();
     sleep(1);
 
     # selected 1 column
     $selected_reloaded_elements = $t->find_element_ok(
-        '(//div[@id="wizard"]/span/span/div/div/div[@class="panel-body"])[1]/ul[contains(@class, "wizard-list-selected wizard-list")]',
+        '(//div[@class="panel-body"])[1]//ul[contains(@class, "wizard-list-selected wizard-list")]',
         'xpath',
         "find content of selected list from first column")->get_attribute('innerHTML');
 
@@ -430,7 +438,11 @@ $t->while_logged_in_as("submitter", sub {
         'xpath',
         'find a "delete" dataset button for selected dataset and click')->click();
     sleep(1);
+    ok($t->driver->get_alert_text() =~ m/Are you sure you would like to delete it/i, 'Confirm dataset deletion');
+    sleep(1);
     $t->driver()->accept_alert();
+    sleep(1);
+    ok($t->driver->get_alert_text() =~ m/The dataset has been deleted/i, 'Dataset deleted');
     sleep(1);
     $t->driver()->accept_alert();
 
@@ -449,8 +461,10 @@ $t->while_logged_in_as("submitter", sub {
     sleep(1);
 
     # DONE TESTING
+    print STDERR "\n\n====> DONE\n";
     }
 );
 
+print STDERR "\n====> CLOSING\n";
 $t->driver()->close();
 done_testing();

--- a/t/selenium2/breeders/breeder_search.t
+++ b/t/selenium2/breeders/breeder_search.t
@@ -39,6 +39,7 @@ $t->while_logged_in_as("submitter", sub {
     # ADD A SECOND FILTER ITEM
     $search_column->send_keys(KEYS->{'return'});
     $search_column->send_keys('trial2 NaCRRI');
+    sleep(2);
 
     # check if both "Kasese solgs trial" and "trial2 NaCRRI" are in the unselect panel field
     $search_unselected = $t->find_element_ok(

--- a/t/selenium2/breeders/breeder_search.t
+++ b/t/selenium2/breeders/breeder_search.t
@@ -23,7 +23,6 @@ $t->while_logged_in_as("submitter", sub {
     $t->find_element_ok('(//div[@class="panel-heading"]/select)[1]//option[@value="trials"]', 'xpath', 'find and select "trials" in first column')->click();
     sleep(1);
     my $search_column = $t->find_element_ok('(//div[contains(@class, "wizard-column")])[1]//textarea', 'xpath', 'find a search box');
-    # $t->driver->execute_script("arguments[0].scrollIntoView(true);window.scrollBy(0,-100);", $search_column);
     $search_column->send_keys('Kasese solgs trial');
     sleep(2);
 
@@ -64,12 +63,12 @@ $t->while_logged_in_as("submitter", sub {
 
     # COLUMN 1 AND 2 - test for all / any / default values / check if numbers off possible combinations are changing
     my $active_union_button = $t->find_element_ok('(//div[@class="panel-body"])[1]//div[contains(@class, "wizard-union-toggle")]/div[contains(@class, "wizard-union-toggle-btn-group")]/button[contains(@class, "active")]' , 'xpath', 'find active union button in first column');
-    ok (lc($active_union_button->get_attribute('innerHTML')) eq "any", "default active union button for selection shall be ANY");
+    ok(lc($active_union_button->get_attribute('innerHTML')) eq "any", "default active union button for selection shall be ANY");
 
     my $button_count_all_second_column_xpath = '(//div[@class="panel-body"])[2]//div[@class="btn-group"]//span[contains(@class, "wizard-count-all")]';
 
     my $button_count_all_second_column = $t->find_element_ok($button_count_all_second_column_xpath , 'xpath', 'find count traits field pointer');
-    ok ($button_count_all_second_column->get_text() eq "3", "number of traits with 'ANY button' in second panel from 'Kasese solgs trial' should be 3");
+    ok($button_count_all_second_column->get_text() eq "3", "number of traits with 'ANY button' in second panel from 'Kasese solgs trial' should be 3");
 
     $t->find_element_ok('(//div[contains(@class, "wizard-column")])[1]//button[contains(@class, "wizard-search-options-clear")]' , 'xpath', 'clear search input in first column, for union test')->click();
     sleep(2);
@@ -80,10 +79,10 @@ $t->while_logged_in_as("submitter", sub {
     my $unselected_traits_second_column_xpath = '(//div[@class="panel-body"])[2]//ul[contains(@class, "wizard-list-unselected")]';
 
     my $unselected_traits_content = $t->find_element_ok($unselected_traits_second_column_xpath, 'xpath', 'find content of unselected list from second column')->get_attribute('innerHTML');
-    ok ($unselected_traits_content =~ /harvest index variable|CO_334:0000015/, 'find new trait for two trials and ANY union "harvest index variable|CO_334:0000015"');
+    ok($unselected_traits_content =~ /harvest index variable|CO_334:0000015/, 'find new trait for two trials and ANY union "harvest index variable|CO_334:0000015"');
 
     $button_count_all_second_column = $t->find_element_ok($button_count_all_second_column_xpath , 'xpath', 'find count traits field pointer');
-    ok ($button_count_all_second_column->get_text() eq "4", "number of traits with 'ANY button' in second panel from 'Kasese solgs trial' and 'trial2 NaCRRI' should be 4");
+    ok($button_count_all_second_column->get_text() eq "4", "number of traits with 'ANY button' in second panel from 'Kasese solgs trial' and 'trial2 NaCRRI' should be 4");
 
     my $all_union_button = $t->find_element_ok('(//div[@class="panel-body"])[1]//div[contains(@class, "wizard-union-toggle")]/div[contains(@class, "wizard-union-toggle-btn-group")]/button[contains(text(), "ALL")]' , 'xpath', 'find "ALL" button');
     my $any_union_button = $t->find_element_ok('(//div[@class="panel-body"])[1]//div[contains(@class, "wizard-union-toggle")]/div[contains(@class, "wizard-union-toggle-btn-group")]/button[contains(text(), "ANY")]' , 'xpath', 'find "ANY" button');
@@ -91,27 +90,29 @@ $t->while_logged_in_as("submitter", sub {
     $all_union_button->click();
     sleep(1);
     $button_count_all_second_column = $t->find_element_ok($button_count_all_second_column_xpath , 'xpath', 'find count traits field pointer');
-    ok ($button_count_all_second_column->get_text() eq "3", "ALL traits in second panel from 'Kasese solgs trial' and 'trial2 NaCRRI' should be 3");
+    ok($button_count_all_second_column->get_text() eq "3", "ALL traits in second panel from 'Kasese solgs trial' and 'trial2 NaCRRI' should be 3");
 
     $unselected_traits_content = $t->find_element_ok($unselected_traits_second_column_xpath, 'xpath', 'find content of unselected list from second column"')->get_attribute('innerHTML');
-    ok ($unselected_traits_content !~ /harvest index variable|CO_334:0000015/, '"harvest index variable|CO_334:0000015" trait for two trials and ALL union cannot be displayed in unselected traits');
+    ok($unselected_traits_content !~ /harvest index variable|CO_334:0000015/, '"harvest index variable|CO_334:0000015" trait for two trials and ALL union cannot be displayed in unselected traits');
 
     $any_union_button->click();
     sleep(1);
     $button_count_all_second_column = $t->find_element_ok($button_count_all_second_column_xpath , 'xpath', 'find count traits field pointer');
-    ok ($button_count_all_second_column->get_text() eq "4", "ANY traits in second panel from 'Kasese solgs trial' and 'trial2 NaCRRI' should be 4");
+    ok($button_count_all_second_column->get_text() eq "4", "ANY traits in second panel from 'Kasese solgs trial' and 'trial2 NaCRRI' should be 4");
 
     $unselected_traits_content = $t->find_element_ok($unselected_traits_second_column_xpath, 'xpath', 'find content of unselected list from second column"')->get_attribute('innerHTML');
-    ok ($unselected_traits_content =~ /harvest index variable|CO_334:0000015/, '"harvest index variable|CO_334:0000015" trait for two trials and ANY union shall be displayed in unselected traits');
+    ok($unselected_traits_content =~ /harvest index variable|CO_334:0000015/, '"harvest index variable|CO_334:0000015" trait for two trials and ANY union shall be displayed in unselected traits');
 
     $t->find_element_ok('(//div[@class="panel-body"])[1]//ul[contains(@class, "wizard-list-selected wizard-list")]//a[contains(text(), "trial2 NaCRRI")]//preceding-sibling::button' , 'xpath', 'first select')->click();
     sleep(1);
     $unselected_traits_content = $t->find_element_ok($unselected_traits_second_column_xpath, 'xpath', 'find content of unselected list from second column"')->get_attribute('innerHTML');
-    ok ($unselected_traits_content !~ /harvest index variable|CO_334:0000015/, '"harvest index variable|CO_334:0000015" trait for one trial after "trial2 NaCRRI" removed should not be displayed in unselected traits');
+    ok($unselected_traits_content !~ /harvest index variable|CO_334:0000015/, '"harvest index variable|CO_334:0000015" trait for one trial after "trial2 NaCRRI" removed should not be displayed in unselected traits');
 
     # COLUMN 3 WIZARD SEARCH - select years and save first dataset with 3 list
     $t->find_element_ok('(//div[@class="panel-heading"]/select)[3]', 'xpath', 'find select column type in third column')->click();
+    sleep(1);
     $t->find_element_ok('(//div[@class="panel-heading"]/select)[3]//option[@value="years"]', 'xpath', 'find and select "years" in third column')->click();
+    sleep(1);
     $t->find_element_ok('(//div[@class="panel-body"])[3]//a[contains(text(), "2014")]//preceding-sibling::button' , 'xpath', 'find and add "2014" year in third column')->click();
     sleep(1);
 
@@ -126,9 +127,12 @@ $t->while_logged_in_as("submitter", sub {
     sleep(1);
     ok($t->driver->get_alert_text() =~ m/Dataset another_dataset_3_columns created/i, 'Created dataset another_dataset_3_columns');
     $t->driver()->accept_alert();
+    sleep(2);
 
     # COLUMN 4 WIZARD SEARCH - select accessions and save second dataset
-    $t->find_element_ok('(//div[@class="panel-heading"]/select)[4]', 'xpath', 'find select column type in fourth column')->click();
+    my $type_column_4 = $t->find_element_ok('(//div[@class="panel-heading"]/select)[4]', 'xpath', 'find select column type in fourth column');
+    $t->driver->execute_script( "arguments[0].scrollIntoView(true);window.scrollBy(0,-50);", $type_column_4);
+    $type_column_4->click();
     sleep(1);
     $t->find_element_ok('(//div[@class="panel-heading"]/select)[4]//option[@value="accessions"]', 'xpath', 'find and select "accessions" in fourth column')->click();
     sleep(1);

--- a/t/selenium2/breeders/breeder_search.t
+++ b/t/selenium2/breeders/breeder_search.t
@@ -2,7 +2,7 @@ use strict;
 
 use lib 't/lib';
 
-use Test::More 'tests' => 128;
+use Test::More 'tests' => 132;
 
 use SGN::Test::WWW::WebDriver;
 use Selenium::Remote::WDKeys 'KEYS';
@@ -36,6 +36,20 @@ $t->while_logged_in_as("submitter", sub {
     ok($search_unselected =~ /Kasese solgs trial/, "Verify if unselected panel after search contain: 'Kasese solgs trial'");
     ok($search_unselected !~ /CASS_6Genotypes_Sampling_2015/, "Verify if unselected panel after search NOT contain: 'CASS_6Genotypes_Sampling_2015'");
     ok($search_unselected !~ /trial2 NaCRRI/, "Verify if unselected panel after search NOT contain: 'trial2 NaCRRI'");
+
+    # ADD A SECOND FILTER ITEM
+    $search_column->send_keys(KEYS->{'return'});
+    $search_column->send_keys('trial2 NaCRRI');
+
+    # check if both "Kasese solgs trial" and "trial2 NaCRRI" are in the unselect panel field
+    $search_unselected = $t->find_element_ok(
+        '(//div[@class="panel-body"])[1]//ul[contains(@class, "wizard-list-unselected")]',
+        'xpath',
+        'find a content of "unselected trials panel" to test searchbox in first column')->get_attribute('innerHTML');
+
+    ok($search_unselected =~ /Kasese solgs trial/, "Verify if unselected panel after search contain: 'Kasese solgs trial'");
+    ok($search_unselected !~ /CASS_6Genotypes_Sampling_2015/, "Verify if unselected panel after search NOT contain: 'CASS_6Genotypes_Sampling_2015'");
+    ok($search_unselected =~ /trial2 NaCRRI/, "Verify if unselected panel after search contain: 'trial2 NaCRRI'");
 
     sleep(1);
     $t->find_element_ok('(//div[@class="panel-body"])[1]//a[contains(text(), "Kasese solgs trial")]//preceding-sibling::button' , 'xpath', 'find and add "Kasese solgs trial" trial in first column with search filter active')->click();
@@ -461,10 +475,8 @@ $t->while_logged_in_as("submitter", sub {
     sleep(1);
 
     # DONE TESTING
-    print STDERR "\n\n====> DONE\n";
     }
 );
 
-print STDERR "\n====> CLOSING\n";
 $t->driver()->close();
 done_testing();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This expands the search filter in each column of the Search Wizard from a single-line text input to a multi-line textarea, where matches are found for each line of input - useful for filtering by multiple items or pasting in a list of items.

It also adds a "Contains" vs "Exact" match type.  Contains (the default and original behavior) will find matches the contain the case-insensitive search term in the database term and Exact will find an exact case-insensitive match.  For example, if the search term is "BP25-123", a "contains" match will match to "BP25-123" and "BP25-123-A" while an "exact" match will only match to "BP25-123".

Here's a demo:

https://github.com/user-attachments/assets/9bca6270-07b0-4e51-a9d8-1f2ec3afc813

Fixes #5375 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
