### PR TITLE
detect click event on a dynamically generated entry

### DIFF
--- a/mason/breeders_toolbox/manage_phenotyping.mas
+++ b/mason/breeders_toolbox/manage_phenotyping.mas
@@ -45,7 +45,7 @@ $locations => undef
 
 jQuery(document).ready(function() {
 
-    jQuery('button[name=delete_pheno_file_link]').click( function() {
+    jQuery('.files_datatables').on('click', 'button[name=delete_pheno_file_link]', function() {
         var delete_phenotypes_file_id = jQuery(this).data('file_id');
         if (confirm('Are you sure you want to delete all phenotype values related to this file from the database and make this file obsolete?')){
             jQuery.ajax ( {


### PR DESCRIPTION
On the manage phenotyping table, the delete button does not work on other pages than the first, presumably because these buttons represent dynamically generated items, which need to be handled using the ".on" function

Fixes #5344


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
