### PR TITLE
Change image search requests to POST

### DIFF
--- a/lib/SGN/Controller/AJAX/Search/Image.pm
+++ b/lib/SGN/Controller/AJAX/Search/Image.pm
@@ -95,7 +95,7 @@ sub image_search_POST : Args(0) {
         $draw =~ s/\D//g; # cast to int
     }
 
-    #print STDERR Dumper $result
+    #print STDERR Dumper $result;
     my @return;
     foreach (@$result){
         my $image = SGN::Image->new($schema->storage->dbh, $_->{image_id}, $c);

--- a/lib/SGN/Controller/AJAX/Search/Image.pm
+++ b/lib/SGN/Controller/AJAX/Search/Image.pm
@@ -16,8 +16,9 @@ __PACKAGE__->config(
     map       => { 'application/json' => 'JSON' },
    );
 
+sub image_search : Path('/ajax/search/images') : ActionClass('REST') { }
 
-sub image_search :Path('/ajax/search/images') Args(0) {
+sub image_search_POST : Args(0) {
     my $self = shift;
     my $c = shift;
     print STDERR "Image search AJAX\n";
@@ -94,7 +95,6 @@ sub image_search :Path('/ajax/search/images') Args(0) {
         $draw =~ s/\D//g; # cast to int
     }
 
-    #print STDERR Dumper $result;
     my @return;
     foreach (@$result){
         my $image = SGN::Image->new($schema->storage->dbh, $_->{image_id}, $c);

--- a/lib/SGN/Controller/AJAX/Search/Image.pm
+++ b/lib/SGN/Controller/AJAX/Search/Image.pm
@@ -95,6 +95,7 @@ sub image_search_POST : Args(0) {
         $draw =~ s/\D//g; # cast to int
     }
 
+    #print STDERR Dumper $result
     my @return;
     foreach (@$result){
         my $image = SGN::Image->new($schema->storage->dbh, $_->{image_id}, $c);

--- a/mason/image/plot_images.mas
+++ b/mason/image/plot_images.mas
@@ -114,6 +114,7 @@ function _load_stock_image_results() {
         'scrollX': true,
         'lengthMenu': [10,20,50,100,1000,5000],
         'ajax': { 'url': '/ajax/search/images',
+            'type': 'POST',
             'data': function(d) {
                 d.image_stock_uniquename = plotNamesString;
             },

--- a/mason/search/images.mas
+++ b/mason/search/images.mas
@@ -108,6 +108,7 @@ function _load_image_search_results() {
         'scrollX': true,
         'lengthMenu': [10,20,50,100,1000,5000],
         'ajax': { 'url':  '/ajax/search/images',
+            'type': 'POST',
             'data': function(d) {
               d.image_description_filename_composite = jQuery('#image_description_filename_composite').val();
               d.image_person = jQuery('#image_submitter').val();

--- a/t/unit_mech/AJAX/TrialImages.t
+++ b/t/unit_mech/AJAX/TrialImages.t
@@ -75,7 +75,7 @@ if ($uri =~ /\/(\d+)$/) {
 
 diag "Image ID: $image_id";
 
-$m->get_ok("/ajax/search/images?image_stock_uniquename=test_trial212");
+$m->post_ok("/ajax/search/images?image_stock_uniquename=test_trial212");
 my $search_response = eval { decode_json $m->content };
 
 diag "Search response: " . Dumper($search_response);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Change ajax requests to image_search method to POST to fix errors when sending many params

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
