### PR TITLE
fix a missing constructor name that caused certain password resets to fail.

### DIFF
--- a/lib/SGN/Controller/AJAX/User.pm
+++ b/lib/SGN/Controller/AJAX/User.pm
@@ -242,7 +242,7 @@ sub change_account_info_action :Path('/ajax/user/update') Args(0) {
 	return;
     }
 
-    my $person = CXGN::People::Login->($c->dbc->dbh(), $c->user->get_sp_person_id());
+    my $person = CXGN::People::Login->new($c->dbc->dbh(), $c->user->get_sp_person_id());
 
 #    my ($current_password, $change_username, $change_password, $change_email) = $c->req->param({qw(current_password change_username change_password change_email)});
 

--- a/t/unit_mech/AJAX/Login.t
+++ b/t/unit_mech/AJAX/Login.t
@@ -64,6 +64,84 @@ $response = decode_json $mech->content;
 print STDERR Dumper $response;
 is($response->{message}, 'Login successful');
 
+# CHECK UPDATES LOGGED IN AS WRONG USER
+
+# test update password functionality 
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?change_password=1&current_password=secretpw&new_password=blablabla&confirm_password=blablabla');
+$response = decode_json($mech->content());
+print STDERR Dumper($response);
+is($response->{error}, "Your current password does not match SGN records.", "password update check");
+
+# reset it to what it was
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?change_password=1&current_password=blablabla&new_password=secretpw&confirm_password=secretpw');
+
+# check email update
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?change_email=1&current_password=secretpw&private_email=test@testbase.org&confirm_email=test@testbase.org');
+$response = decode_json($mech->content());
+is($response->{error}, "Your current password does not match SGN records.", 'email update check');
+
+# email was not set in the fixture, no need to reset it to nothing?
+
+
+# change username
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?current_password=secretpw&change_username=1&new_username=janemoe');
+my $un_response = decode_json($mech->content());
+is($un_response->{error}, "Your current password does not match SGN records.", "username update check");
+
+# change username back
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?current_password=secretpw&change_username=1&new_username=janedoe');
+
+# LOG OUT WRONG USER
+#
+$mech->get_ok('http://localhost:3010/ajax/user/login?logout=1');
+$response = decode_json $mech->content();
+print STDERR "LOGOUT: ".Dumper($response);
+
+# CHECK UPDATES WITH CORRECT USER
+# login again as janedoe for update tests
+#
+$mech->get_ok('http://localhost:3010/ajax/user/login?username=janedoe&password=secretpw');
+$response = decode_json $mech->content;
+print STDERR Dumper $response;
+is($response->{message}, 'Login successful');
+
+# test update password functionality
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?change_password=1&current_password=secretpw&new_password=blablabla&confirm_password=blablabla');
+$response = decode_json($mech->content());
+print STDERR Dumper($response);
+is($response->{message}, "Update successful", "password update check");
+
+# reset it to what it was
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?change_password=1&current_password=blablabla&new_password=secretpw&confirm_password=secretpw');
+
+# check email update
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?change_email=1&current_password=secretpw&private_email=test@testbase.org&confirm_email=test@testbase.org');
+$response = decode_json($mech->content());
+is($response->{message}, 'Update successful', 'email update check');
+
+# email was not set in the fixture, no need to reset it to nothing?
+
+
+# change username
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?current_password=secretpw&change_username=1&new_username=janemoe');
+my $un_response = decode_json($mech->content());
+is($un_response->{message}, "Update successful", "username update check");
+
+# change username back
+#
+$mech->get_ok('http://localhost:3010/ajax/user/update?current_password=secretpw&change_username=1&new_username=janedoe');
+
+
+
 #Delete user
 my $dbh = $schema->storage->dbh;
 if( $dbh and  my $u_id = CXGN::People::Person->get_person_by_username( $dbh, "testusername" ) ) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
