### PR TITLE
Move 'no accession image to display' message out of img tag

### DIFF
--- a/mason/stock/index.mas
+++ b/mason/stock/index.mas
@@ -299,10 +299,18 @@ function jqueryStuff() {
                             my $image = SGN::Image->new($schema->storage->dbh, $image_id, $c);
                             $image_url = $image->get_image_url('small');
                         }
-                        
-                        </%perl>
 
-                        <img src="<% $image_url %>" alt="No accession image to display" class="img-responsive" style="max-width: 100%; height: auto;" />
+                        if ($image_url ne '/data/images/image_files_test/XX/XX/XX/XX/XXXXXXXXXXXXXXXXXXXXXXXX/small.jpg') {
+                        </%perl>                      
+                        <img src="<% $image_url %>" class="img-responsive" style="max-width: 100%; height: auto;" />
+                        <%perl>
+                            } else { 
+                        </%perl>
+                        <p>No accession image to display</p>
+                        <%perl>
+                            } 
+                        </%perl>
+                        
                     </div>
                     <br /><br />
                 </div>

--- a/mason/stock/index.mas
+++ b/mason/stock/index.mas
@@ -300,13 +300,14 @@ function jqueryStuff() {
                             $image_url = $image->get_image_url('small');
                         }
 
-                        if ($image_url ne '/data/images/image_files_test/XX/XX/XX/XX/XXXXXXXXXXXXXXXXXXXXXXXX/small.jpg') {
+                        my $no_img_url = '/data/images/image_files/XX/XX/XX/XX/XXXXXXXXXXXXXXXXXXXXXXXX/small';
+                        if (index($image_url, $no_img_url) != -1) {
                         </%perl>                      
-                        <img src="<% $image_url %>" class="img-responsive" style="max-width: 100%; height: auto;" />
+                        <p>No accession image to display</p>
                         <%perl>
                             } else { 
                         </%perl>
-                        <p>No accession image to display</p>
+                        <img src="<% $image_url %>" alt="No accession image to display" class="img-responsive" style="max-width: 100%; height: auto;" />
                         <%perl>
                             } 
                         </%perl>

--- a/mason/stock/index.mas
+++ b/mason/stock/index.mas
@@ -301,13 +301,15 @@ function jqueryStuff() {
                         }
 
                         my $no_img_url = '/data/images/image_files/XX/XX/XX/XX/XXXXXXXXXXXXXXXXXXXXXXXX/small';
-                        if (index($image_url, $no_img_url) != -1) {
+                        my $no_img_url_test = '/data/images/image_files_test/XX/XX/XX/XX/XXXXXXXXXXXXXXXXXXXXXXXX/small';
+
+                        if (index($image_url, $no_img_url) != -1 || index($image_url, $no_img_url_test) != -1) {
                         </%perl>                      
                         <p>No accession image to display</p>
                         <%perl>
                             } else { 
                         </%perl>
-                        <img src="<% $image_url %>" alt="No accession image to display" class="img-responsive" style="max-width: 100%; height: auto;" />
+                        <img src="<% $image_url %>" class="img-responsive" style="max-width: 100%; height: auto;" />
                         <%perl>
                             } 
                         </%perl>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
This moves the no accession image message out of the img tag so that an image icon is no longer displayed when there are no images

<!-- If there are relevant issues, link them here: -->
Fixes #5410 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
