### PR TITLE
Make image analysis services parametrizable

### DIFF
--- a/lib/SGN/Controller/AJAX/ImageAnalysis.pm
+++ b/lib/SGN/Controller/AJAX/ImageAnalysis.pm
@@ -96,40 +96,44 @@ sub image_analysis_submit_POST : Args(0) {
     }
     print STDERR Dumper \@image_urls;
 
-    my %service_details = (
-        'necrosis' => {
-            server_endpoint => "http://unet.mcrops.org/api/",
-            image_type_name => "image_analysis_necrosis_solomon_nsumba",
-        },
-        'whitefly_count' => {
-            server_endpoint => "http://18.216.149.204/home/api2/",
-            image_type_name => "image_analysis_white_fly_count_solomon_nsumba",
-        },
-        'count_contours' => {
-            image_type_name => "image_analysis_contours",
-            trait_name => "count_contours",
-            script => 'GetContours.py',
-            input_image => 'image_path',
-            outfile_image => 'outfile_path',
-            results_outfile => 'results_outfile_path',
-        },
-        'largest_contour_percent' => {
-            image_type_name => 'image_analysis_largest_contour',
-            trait_name => 'percent_largest_contour',
-            script => 'GetLargestContour.py',
-            input_image => 'image_path',
-            outfile_image => 'outfile_path',
-            results_outfile => 'results_outfile_path',
-        },
-        'count_sift' => {
-            image_type_name => "image_analysis_sift",
-            trait_name => "count_sift",
-            script => 'ImageProcess/CalculatePhenotypeSift.py',
-            input_image => 'image_paths',
-            outfile_image => 'outfile_paths',
-            results_outfile => 'results_outfile_path',
-        }
-    );
+    my $service_details_json = $c->config->{image_analysis_services} || '{}';
+
+    my %service_details = %{decode_json($service_details_json)};
+    
+    # my %service_details = (
+    #     'necrosis' => {
+    #         server_endpoint => "http://unet.mcrops.org/api/",
+    #         image_type_name => "image_analysis_necrosis_solomon_nsumba",
+    #     },
+    #     'whitefly_count' => {
+    #         server_endpoint => "http://18.216.149.204/home/api2/",
+    #         image_type_name => "image_analysis_white_fly_count_solomon_nsumba",
+    #     },
+    #     'count_contours' => {
+    #         image_type_name => "image_analysis_contours",
+    #         trait_name => "count_contours",
+    #         script => 'GetContours.py',
+    #         input_image => 'image_path',
+    #         outfile_image => 'outfile_path',
+    #         results_outfile => 'results_outfile_path',
+    #     },
+    #     'largest_contour_percent' => {
+    #         image_type_name => 'image_analysis_largest_contour',
+    #         trait_name => 'percent_largest_contour',
+    #         script => 'GetLargestContour.py',
+    #         input_image => 'image_path',
+    #         outfile_image => 'outfile_path',
+    #         results_outfile => 'results_outfile_path',
+    #     },
+    #     'count_sift' => {
+    #         image_type_name => "image_analysis_sift",
+    #         trait_name => "count_sift",
+    #         script => 'ImageProcess/CalculatePhenotypeSift.py',
+    #         input_image => 'image_paths',
+    #         outfile_image => 'outfile_paths',
+    #         results_outfile => 'results_outfile_path',
+    #     }
+    # );
 
     my $image_type_name = $service_details{$service}->{'image_type_name'};
 

--- a/lib/SGN/Controller/ImageAnalysis.pm
+++ b/lib/SGN/Controller/ImageAnalysis.pm
@@ -2,6 +2,7 @@
 package SGN::Controller::ImageAnalysis;
 
 use Moose;
+use JSON;
 use URI::FromHash 'uri';
 
 BEGIN { extends 'Catalyst::Controller' };
@@ -13,6 +14,15 @@ sub home : Path('/tools/image_analysis') Args(0) {
         $c->res->redirect( uri( path => '/user/login', query => { goto_url => $c->req->uri->path_query } ) );
         return;
     }
+    
+    my $services_json = $c->config->{image_analysis_services}  || {};
+
+    chomp($services_json);
+    
+    my $services = decode_json($services_json);
+
+    $c->stash->{services} = $services;
+   
     $c->stash->{template} = 'tools/image_analysis.mas';
 }
 

--- a/mason/tools/image_analysis.mas
+++ b/mason/tools/image_analysis.mas
@@ -1,6 +1,6 @@
 
 <%args>
-
+%services
 </%args>
 
 <& /util/import_javascript.mas,
@@ -128,12 +128,17 @@ tr.shown td.details-control {
                     <label class="col-sm-6 control-label">Image Analysis Service: </label>
                     <div class="col-sm-6" >
                         <select class="form-control" id="image_analysis_service_select" name="image_analysis_service_select">
-                            <option value="">Select An Analysis Service</option>
-                            <option value="necrosis">Necrosis(Makerere AIR Lab)</option>
+                            <option value="">Select An Analysis Service:</option>
+
+% foreach my $s (keys %services) {
+ 		            <option value="<% $s %>"><% $services{$s}->{description} %></option>
+% }
+
+                            <!-- option value="necrosis">Necrosis(Makerere AIR Lab)</option>
                             <option value="largest_contour_percent">Necrosis Largest Contour Mask Percent</option>
                             <option value="count_contours">Count Contours</option>
                             <option value="count_sift">SIFT Feature Count</option>
-                            <option value="whitefly_count">Whitefly Count (Makerere AIR Lab)</option>
+                            <option value="whitefly_count">Whitefly Count (Makerere AIR Lab)</option  -->
                         </select>
                     </div>
                 </div>

--- a/sgn.conf
+++ b/sgn.conf
@@ -21,6 +21,9 @@ python_executable_maskrcnn_env /home/vagrant/.virtualenvs/cv/bin/python3.5
 
 exclude_phenotype_outliers 0
 
+image_analysis_services  { "necrosis" : { "server_endpoint" : "http://unet.mcrops.org/api/", "image_type_name" : "image_analysis_necrosis_solomon_nsumba", "description" : "Necrosis Analysis, Makerere University"  },  "whitefly_count" : { "server_endpoint" :  "http://18.216.149.204/home/api2/", "image_type_name" : "image_analysis_white_fly_count_solomon_nsumba", "description": "Whitefly count, Makarere University"  }, "count_contours" : { "image_type_name" :  "image_analysis_contours", "trait_name" : "count_contours", "script" : "GetContours.py", "input_image" : "image_path", "outfile_image" : "outfile_path", "results_outfile" : "results_outfile_path", "description" : "Count Contours"  }, "largest_contour_percent" : { "image_type_name" : "image_analysis_largest_contour", "trait_name" : "percent_largest_contour", "script" : "GetLargestContour.py", "input_image" : "image_path", "outfile_image" : "outfile_path", "results_outfile" : "results_outfile_path", "description" : "Largest Contour Percent" }, "count_sift" : { "image_type_name" : "image_analysis_sift", "trait_name" : "count_sift", "script" : "ImageProcess/CalculatePhenotypeSift.py", "input_image" : "image_paths", "outfile_image" : "outfile_paths", "results_outfile" : "results_outfile_path", "description" : "SIFT analysis" } }
+
+
 composable_cvs trait,object,tod,toy,unit,method
 composable_cvs_allowed_combinations Agronomic|trait+toy,Metabolic|trait+object+tod+toy+unit+method
 composable_cvterm_delimiter |


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Currently the image analysis options are hardcoded in the mason file and in the ImageAnalysis.pm class. This pull request makes it configurable in sgn_local.conf using the image_analysis_services key with the data string in JSON format.  Example is in sgn.conf.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
