### PR TITLE
Edit Trial Details: fix breeding program selection

### DIFF
--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -85,14 +85,14 @@ sub get_breeding_program_select : Path('/ajax/html/select/breeding_programs') Ar
 
     my $breeding_programs = CXGN::BreedersToolbox::Projects->new( { schema => $c->dbic_schema("Bio::Chado::Schema", undef, $sp_person_id) } )->get_breeding_programs();
 
-    my $default = $c->req->param("default") || @$breeding_programs[0]->[0];
     if ($empty) { unshift @$breeding_programs, [ "", "Please select a program" ]; }
+    my $default = $c->req->param("default") || @$breeding_programs[0]->[0];
 
     my $html = simple_selectbox_html(
       name => $name,
       id => $id,
       choices => $breeding_programs,
-#      selected => $default
+      selected => $default
     );
     $c->stash->{rest} = { select => $html };
 }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

On the Edit Trial Details dialog (from the trial detail page), there is a select box that displays all of the breeding programs.  It was displaying the first breeding program in the list, instead of the breeding program that is associated with the trial.

This re-enables the default / selected option in the HTML select function for breeding programs.

Was this commented out for a particular reason??

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
