### PR TITLE
Configurable sampling trial tissue types

### DIFF
--- a/lib/CXGN/Trial/ParseUpload.pm
+++ b/lib/CXGN/Trial/ParseUpload.pm
@@ -90,6 +90,14 @@ has 'facility_identifiers_included' => (
     default => 0,
 );
 
+has 'allowed_tissue_list' => (
+    is => 'ro',
+    isa => 'Str',
+    writer => '_set_allowed_tissue_list',
+    reader => 'get_allowed_tissue_list',
+    required => 0
+);
+
 
 sub parse {
   my $self = shift;

--- a/lib/CXGN/Trial/ParseUpload/Plugin/SamplingTrialXLS.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/SamplingTrialXLS.pm
@@ -11,6 +11,7 @@ sub _validate_with_plugin {
     my $self = shift;
     my $filename = $self->get_filename();
     my $schema = $self->get_chado_schema();
+    my $sample_tissue_types_string = $self->get_allowed_tissue_list();
     my %errors;
     my @error_messages;
     my %missing_accessions;
@@ -257,10 +258,10 @@ sub _validate_with_plugin {
         if ( ($date || $date ne '') && !$date =~ m/(\d{4})-(\d{2})-(\d{2})/ ) {
             push @error_messages, "Cell A$row_name: date must be YYYY-MM-DD format";
         }
-
-        #tissue_type must not be blank and must be either leaf, root, stem, fruit, seed, tuber
-        if (!$tissue_type || $tissue_type eq '' || ($tissue_type ne 'leaf' && $tissue_type ne 'root' && $tissue_type ne 'stem' && $tissue_type ne 'fruit' && $tissue_type ne 'seed' && $tissue_type ne 'tuber')) {
-            push @error_messages, "Cell F$row_name: column tissue type and must be either leaf, root, stem, seed, fruit or tuber";
+        
+        my @sample_tissue_types = split ',',$sample_tissue_types_string;   #tissue_type must not be blank and must be in the list of allowed tissue types
+        if (!$tissue_type || $tissue_type eq '' || !(grep(/^$tissue_type$/, @sample_tissue_types))) {
+            push @error_messages, "Cell F$row_name: column tissue type and must be one of $sample_tissue_types_string";
         }
 
     }

--- a/lib/SGN/Controller/AJAX/SamplingTrial.pm
+++ b/lib/SGN/Controller/AJAX/SamplingTrial.pm
@@ -117,6 +117,8 @@ sub parse_sampling_trial_file_POST : Args(0) {
         $c->stash->{rest} = {error => 'Sampling trial name must be given!'};
         return;
     }
+    my $sample_tissue_types_string = $c->config->{sample_tissue_types};
+
     my $parser;
     my $parsed_data;
     my $upload = $upload_xls;
@@ -194,7 +196,7 @@ sub parse_sampling_trial_file_POST : Args(0) {
     #Parse of Coordinate Template formatted file requires the plate name to be passed, so that a unique sample name can be created by concatenating the plate name to the well position.
 
     #parse uploaded file with appropriate plugin
-    $parser = CXGN::Trial::ParseUpload->new(chado_schema => $chado_schema, filename => $archived_filename_with_path);
+    $parser = CXGN::Trial::ParseUpload->new(chado_schema => $chado_schema, filename => $archived_filename_with_path, allowed_tissue_list => $sample_tissue_types_string);
     $parser->load_plugin($upload_type);
     $parsed_data = $parser->parse();
 

--- a/lib/SGN/Controller/BreedersToolbox.pm
+++ b/lib/SGN/Controller/BreedersToolbox.pm
@@ -332,6 +332,10 @@ sub manage_nirs :Path("/breeders/nirs") Args(0) {
     my $sampling_facilities = $c->config->{sampling_facilities};
     my @sampling_facilities = split ',',$sampling_facilities;
 
+    my $sample_tissue_types_string = $c->config->{sample_tissue_types};
+    my @sample_tissue_types = split ',',$sample_tissue_types_string;
+
+    $c->stash->{sample_tissue_types} = \@sample_tissue_types;
     $c->stash->{sampling_facilities} = \@sampling_facilities;
     $c->stash->{nirs_files} = $data->{files};
     $c->stash->{deleted_nirs_files} = $data->{deleted_files};
@@ -358,6 +362,11 @@ sub manage_transcriptomics :Path("/breeders/transcriptomics") Args(0) {
     my $sampling_facilities = $c->config->{sampling_facilities};
     my @sampling_facilities = split ',',$sampling_facilities;
 
+    my $sample_tissue_types_string = $c->config->{sample_tissue_types};
+    my @sample_tissue_types = split ',',$sample_tissue_types_string;
+    print STDERR Dumper(@sample_tissue_types);
+
+    $c->stash->{sample_tissue_types} = \@sample_tissue_types;
     $c->stash->{sampling_facilities} = \@sampling_facilities;
     $c->stash->{transcriptomics_files} = $data->{files};
     $c->stash->{deleted_transcriptomics_files} = $data->{deleted_files};

--- a/lib/SGN/Controller/Root.pm
+++ b/lib/SGN/Controller/Root.pm
@@ -94,6 +94,10 @@ sub index :Path :Args(0) {
     my @design_types = split ',',$design_type_string;
     $c->stash->{design_types} = \@design_types;
 
+    my $sample_tissue_types_string = $c->config->{sample_tissue_types};
+    my @sample_tissue_types = split ',',$sample_tissue_types_string;
+    $c->stash->{sample_tissue_types} = \@sample_tissue_types;
+
     $c->stash->{schema}   = $c->dbic_schema('SGN::Schema');
     $c->stash->{static_content_path} = $c->config->{static_content_path};
 

--- a/lib/SGN/Controller/Root.pm
+++ b/lib/SGN/Controller/Root.pm
@@ -94,10 +94,6 @@ sub index :Path :Args(0) {
     my @design_types = split ',',$design_type_string;
     $c->stash->{design_types} = \@design_types;
 
-    my $sample_tissue_types_string = $c->config->{sample_tissue_types};
-    my @sample_tissue_types = split ',',$sample_tissue_types_string;
-    $c->stash->{sample_tissue_types} = \@sample_tissue_types;
-
     $c->stash->{schema}   = $c->dbic_schema('SGN::Schema');
     $c->stash->{static_content_path} = $c->config->{static_content_path};
 

--- a/mason/breeders_toolbox/manage_nirs.mas
+++ b/mason/breeders_toolbox/manage_nirs.mas
@@ -6,6 +6,7 @@ $all_nirs_files => undef
 $all_deleted_nirs_files => undef
 $locations => undef
 $sampling_facilities => ()
+$sample_tissue_types => ()
 </%args>
 
 <& /util/import_javascript.mas, classes => [ 'CXGN.BreedersToolbox.Trial','CXGN.BreedersToolbox.FieldBook','CXGN.BreedersToolbox.UploadPhenotype', 'CXGN.BreederSearch', 'CXGN.Trial', 'jquery.iframe-post-form' ] &>
@@ -18,7 +19,7 @@ $sampling_facilities => ()
 my $buttons_html = "<button class='btn btn-primary' style='margin:3px' name='upload_high_dim_phenotypes_spreadsheet_link'>Upload NIRS</button><button class='btn btn-success' style='margin:3px' id='nirs_analysis_training_dialog_show'>Train NIRS Models</button><button class='btn btn-success' style='margin:3px' id='nirs_analysis_prediction_dialog_show'>Predict Phenotypes</button><button class='btn btn-default' style='margin:3px' id='nirs_analysis_plot_spectra_show'>Plot Spectra</button><button class='btn btn-default' style='margin:3px' name='high_dimensional_phenotype_download_button'>Download NIRS</button><button class='btn btn-default' style='margin:3px' name='high_dimensional_phenotype_relationship_matrix_download_button'>Download Relationship Matrix</button>";
 </%perl>
 
-<& /page/detail_page_2_col_section.mas, info_section_collapsed => 0, info_section_title => "<h4 style='display:inline'>NIRS</h4>", info_section_subtitle => 'Upload and perform analyses using NIRS data. Please <a href="https://www.biorxiv.org/content/10.1101/2020.09.18.278549v1" target=_blank>cite this work</a> if you find it useful.', buttons_html => $buttons_html, icon_class => undef, col1_width_class => "col-sm-0", col2_width_class => "col-sm-12", info_section_id => "manage_nirs_main", nirs_files => $nirs_files, deleted_nirs_files => $deleted_nirs_files, all_nirs_files => $all_nirs_files, all_deleted_nirs_files => $all_deleted_nirs_files, locations => $locations, sampling_facilities => $sampling_facilities &>
+<& /page/detail_page_2_col_section.mas, info_section_collapsed => 0, info_section_title => "<h4 style='display:inline'>NIRS</h4>", info_section_subtitle => 'Upload and perform analyses using NIRS data. Please <a href="https://www.biorxiv.org/content/10.1101/2020.09.18.278549v1" target=_blank>cite this work</a> if you find it useful.', buttons_html => $buttons_html, icon_class => undef, col1_width_class => "col-sm-0", col2_width_class => "col-sm-12", info_section_id => "manage_nirs_main", nirs_files => $nirs_files, deleted_nirs_files => $deleted_nirs_files, all_nirs_files => $all_nirs_files, all_deleted_nirs_files => $all_deleted_nirs_files, locations => $locations, sampling_facilities => $sampling_facilities, sample_tissue_types => $sample_tissue_types &>
 
 </div>
 

--- a/mason/breeders_toolbox/manage_samples.mas
+++ b/mason/breeders_toolbox/manage_samples.mas
@@ -2,6 +2,7 @@
 <%args>
 $facilities => ()
 $sampling_facilities => ()
+$sample_tissue_types => ()
 </%args>
 
 <& /util/import_javascript.mas, classes => [ 'jquery.iframe-post-form', 'CXGN.BreedersToolbox.GenotypingTrial' ] &>
@@ -17,7 +18,7 @@ $sampling_facilities => ()
 <& /help/workflow_guided/tissue_sample_help.mas &>
 <& /breeders_toolbox/genotyping_trials/create_genotyping_trial_dialogs.mas, facilities=>$facilities &>
 <& /breeders_toolbox/create_tissue_samples_dialogs.mas &>
-<& /breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas, sampling_facilities=>$sampling_facilities &>
+<& /breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas, sampling_facilities=>$sampling_facilities, sample_tissue_types=>$sample_tissue_types &>
 
 <script>
 

--- a/mason/breeders_toolbox/manage_transcriptomics.mas
+++ b/mason/breeders_toolbox/manage_transcriptomics.mas
@@ -6,6 +6,7 @@ $all_transcriptomics_files => undef
 $all_deleted_transcriptomics_files => undef
 $locations => undef
 $sampling_facilities => ()
+$sample_tissue_types => ()
 </%args>
 
 <& /util/import_javascript.mas, classes => [ 'CXGN.BreedersToolbox.Trial','CXGN.BreedersToolbox.FieldBook','CXGN.BreedersToolbox.UploadPhenotype', 'CXGN.BreederSearch', 'CXGN.Trial', 'jquery.iframe-post-form' ] &>
@@ -18,7 +19,7 @@ $sampling_facilities => ()
 my $buttons_html = "<button class='btn btn-primary' style='margin:3px' name='upload_high_dim_phenotypes_spreadsheet_link'>Upload Transcriptomic Data</button><button class='btn btn-default' style='margin:3px' name='high_dimensional_phenotype_download_button'>Download Transcriptomic Data</button>";
 </%perl>
 
-<& /page/detail_page_2_col_section.mas, info_section_collapsed => 0, info_section_title => "<h4 style='display:inline'>Transcriptomics</h4>", info_section_subtitle => 'Upload and download transcriptomic data.', buttons_html => $buttons_html, icon_class => undef, col1_width_class => "col-sm-0", col2_width_class => "col-sm-12", info_section_id => "manage_transcriptomics_main", transcriptomics_files => $transcriptomics_files, deleted_transcriptomics_files => $deleted_transcriptomics_files, all_transcriptomics_files => $all_transcriptomics_files, all_deleted_transcriptomics_files => $all_deleted_transcriptomics_files, locations => $locations, sampling_facilities => $sampling_facilities &>
+<& /page/detail_page_2_col_section.mas, info_section_collapsed => 0, info_section_title => "<h4 style='display:inline'>Transcriptomics</h4>", info_section_subtitle => 'Upload and download transcriptomic data.', buttons_html => $buttons_html, icon_class => undef, col1_width_class => "col-sm-0", col2_width_class => "col-sm-12", info_section_id => "manage_transcriptomics_main", transcriptomics_files => $transcriptomics_files, deleted_transcriptomics_files => $deleted_transcriptomics_files, all_transcriptomics_files => $all_transcriptomics_files, all_deleted_transcriptomics_files => $all_deleted_transcriptomics_files, locations => $locations, sampling_facilities => $sampling_facilities, sample_tissue_types => $sample_tissue_types &>
 </div>
 
 <& /analyses/store_new_analysis_values_and_model.mas &>

--- a/mason/breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas
+++ b/mason/breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas
@@ -173,8 +173,8 @@ $sample_tissue_types => ();
                                         <label class="col-sm-7 control-label"><i>Optional</i> Tissue: <small>(If used the same tissue for all samples)</small> </label>
                                         <div class="col-sm-5">
                                             <select class="form-control" id="sampling_trial_tissue">
-% foreach my $facility(@$sample_tissue_types){
-    <option value="<%$facility%>"><%$facility%></option>
+% foreach my $tissue_type(@$sample_tissue_types){
+    <option value="<%$tissue_type%>"><%$tissue_type%></option>
 % }
                                             </select>
                                         </div>
@@ -299,7 +299,8 @@ $sample_tissue_types => ();
                     <li>source_observation_unit_name (must exist in the database. the identifier of the origin material. in order of most desirable identifier to least desirable identifier that can be used here: tissue sample name, plant name, plot name, accession name. For blank wells, you can write BLANK here and place a 1 in the is_blank column also.)</li>
                     <li>sample_number (the sample number for the sample. Must be unique within this sampling trial)</li>
                     <li>replicate (the replicate number for the sample)</li>
-                    <li>tissue_type (must be one of: <% $sample_tissue_types %>)</li>
+% my $tissue_string = join(', ', @$sample_tissue_types);
+                    <li>tissue_type (must be one of: <% $tissue_string %>)</li>
                     </ul>
 
                     <b>Optional fields:</b>

--- a/mason/breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas
+++ b/mason/breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas
@@ -1,5 +1,6 @@
 <%args>
 $sampling_facilities => ();
+$sample_tissue_types => ();
 </%args>
 
 <& /util/import_javascript.mas, classes => [ 'CXGN.BreedersToolbox.GenotypingTrial' ] &>
@@ -172,12 +173,9 @@ $sampling_facilities => ();
                                         <label class="col-sm-7 control-label"><i>Optional</i> Tissue: <small>(If used the same tissue for all samples)</small> </label>
                                         <div class="col-sm-5">
                                             <select class="form-control" id="sampling_trial_tissue">
-                                                <option value="leaf">Leaf</option>
-                                                <option value="root">Root</option>
-                                                <option value="stem">Stem</option>
-                                                <option value="seed">Seed</option>
-                                                <option value="fruit">Fruit</option>
-                                                <option value="tuber">Tuber</option>
+% foreach my $facility(@$sample_tissue_types){
+    <option value="<%$facility%>"><%$facility%></option>
+% }
                                             </select>
                                         </div>
                                     </div>
@@ -301,7 +299,7 @@ $sampling_facilities => ();
                     <li>source_observation_unit_name (must exist in the database. the identifier of the origin material. in order of most desirable identifier to least desirable identifier that can be used here: tissue sample name, plant name, plot name, accession name. For blank wells, you can write BLANK here and place a 1 in the is_blank column also.)</li>
                     <li>sample_number (the sample number for the sample. Must be unique within this sampling trial)</li>
                     <li>replicate (the replicate number for the sample)</li>
-                    <li>tissue_type (must be either leaf, root, stem, seed, fruit or tuber)</li>
+                    <li>tissue_type (must be one of: <% $sample_tissue_types %>)</li>
                     </ul>
 
                     <b>Optional fields:</b>

--- a/mason/page/detail_page_2_col_section.mas
+++ b/mason/page/detail_page_2_col_section.mas
@@ -128,6 +128,7 @@ $all_nirs_files => undef
 $all_deleted_nirs_files => undef
 $locations => undef
 $sampling_facilities => ()
+$sample_tissue_types => ()
 
 #Specific to manage transcriptomics page
 $transcriptomics_files => undef
@@ -521,11 +522,11 @@ $field_headers => ()
 %} #End all_cross_entries_section
 
 % if ($info_section_id eq 'manage_nirs_main'){
-                                <& /tools/nirs/manage_nirs_main.mas, nirs_files => $nirs_files, deleted_nirs_files => $deleted_nirs_files, all_nirs_files => $all_nirs_files, all_deleted_nirs_files => $all_deleted_nirs_files, locations => $locations, sampling_facilities=>$sampling_facilities &>
+                                <& /tools/nirs/manage_nirs_main.mas, nirs_files => $nirs_files, deleted_nirs_files => $deleted_nirs_files, all_nirs_files => $all_nirs_files, all_deleted_nirs_files => $all_deleted_nirs_files, locations => $locations, sampling_facilities=>$sampling_facilities, sample_tissue_types=>$sample_tissue_types &>
 % } #End manage_nirs_main
 
 % if ($info_section_id eq 'manage_transcriptomics_main'){
-                                <& /tools/transcriptomics/manage_transcriptomics_main.mas, transcriptomics_files => $transcriptomics_files, deleted_transcriptomics_files => $deleted_transcriptomics_files, all_transcriptomics_files => $all_transcriptomics_files, all_deleted_transcriptomics_files => $all_deleted_transcriptomics_files, locations => $locations, sampling_facilities=>$sampling_facilities &>
+                                <& /tools/transcriptomics/manage_transcriptomics_main.mas, transcriptomics_files => $transcriptomics_files, deleted_transcriptomics_files => $deleted_transcriptomics_files, all_transcriptomics_files => $all_transcriptomics_files, all_deleted_transcriptomics_files => $all_deleted_transcriptomics_files, locations => $locations, sampling_facilities=>$sampling_facilities, sample_tissue_types=>$sample_tissue_types &>
 % } #End manage_transcriptomics_main
 
 % if ($info_section_id eq 'manage_sequence_metadata'){

--- a/mason/tools/nirs/manage_nirs_main.mas
+++ b/mason/tools/nirs/manage_nirs_main.mas
@@ -5,6 +5,7 @@ $all_nirs_files => undef
 $all_deleted_nirs_files => undef
 $locations => undef
 $sampling_facilities => ()
+$sample_tissue_types => ()
 </%args>
 
 <& /tools/high_dimensional_phenotypes/upload_high_dim_spreadsheet_dialogs.mas &>
@@ -13,7 +14,7 @@ $sampling_facilities => ()
 <& /tools/nirs/nirs_analysis_train_dialogs.mas &>
 <& /tools/nirs/nirs_analysis_predict_dialogs.mas &>
 <& /tools/nirs/nirs_analysis_plot_spectra_dialogs.mas &>
-<& /breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas, sampling_facilities=>$sampling_facilities &>
+<& /breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas, sampling_facilities=>$sampling_facilities, sample_tissue_types=>$sample_tissue_types &>
 
 <div class="well">
 <&| /page/info_section.mas, title=>'Uploaded NIRS Data', is_subsection=>1, collapsible=>1, collapsed=>1, subtitle=>'View and manage uploaded NIRS data files' &>

--- a/mason/tools/transcriptomics/manage_transcriptomics_main.mas
+++ b/mason/tools/transcriptomics/manage_transcriptomics_main.mas
@@ -5,11 +5,12 @@ $all_transcriptomics_files => undef
 $all_deleted_transcriptomics_files => undef
 $locations => undef
 $sampling_facilities => ()
+$sample_tissue_types => ()
 </%args>
 
 <& /tools/high_dimensional_phenotypes/upload_high_dim_spreadsheet_dialogs.mas &>
 <& /tools/high_dimensional_phenotypes/download_high_dim_phenotypes_dialogs.mas &>
-<& /breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas, sampling_facilities=>$sampling_facilities &>
+<& /breeders_toolbox/sampling_trials/create_sampling_trials_dialogs.mas, sampling_facilities=>$sampling_facilities, sample_tissue_types=>$sample_tissue_types &>
 
 <div class="well">
 <&| /page/info_section.mas, title=>'Uploaded Transcriptomic Data', is_subsection=>1, collapsible=>1, collapsed=>1, subtitle=>'View and manage uploaded transcriptomic data files' &>

--- a/sgn.conf
+++ b/sgn.conf
@@ -450,6 +450,9 @@ supportedCrop    Cassava
 has_expression_atlas    0
 expression_atlas_url	0
 
+#Sampling trial tissue types
+sample_tissue_types leaf,root,stem,seed,fruit,tuber
+
 #Homepage controller customization
 homepage_display_phenotype_uploads 0
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
This pull request makes the list of acceptable/allowed tissue types for sampling trials configurable in sgn_local.conf using a key called sample_tissue_types. The list that was current up to this point (leaf, root, stem, seed, fruit, and tuber) is included in the sgn.conf and serves as a default if not overridden by the sgn_local.conf value.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
