### PR TITLE
Set brapi_require_login to 1 by default

### DIFF
--- a/sgn.conf
+++ b/sgn.conf
@@ -68,7 +68,7 @@ require_login 0
 #### Report parameters
 report_engine phenotype_properties_check
 
-brapi_require_login 0
+brapi_require_login 1
 brapi_observation_units_require_login 1
 brapi_observations_require_login 1
 brapi_post_variables 0


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR sets the default value for brapi_require_login to 1 in the sgn.conf file. It seems desirable to have this as the default now, since we are setting up more breedbase instances with data that needs to be private/protected.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
