### PR TITLE
fixes correlation datasets/lists table display

### DIFF
--- a/js/source/legacy/solGS/correlation.js
+++ b/js/source/legacy/solGS/correlation.js
@@ -195,9 +195,9 @@ getSelectedPopCorrArgs: function (runCorrElemId) {
     var compatibility_message = '';
     if (dataStr.match(/dataset/)) {
       popName = `<a href="/dataset/${popId}">${popName}</a>`;
-      if (tool_compatibility == null || tool_compatibility == "(not calculated)"){
+      if (tool_compatibility == null || tool_compatibility["Correlation"] == null || tool_compatibility == "(not calculated)"){
         compatibility_message = "(not calculated)";
-      } else {
+      } else {        
           if (tool_compatibility["Correlation"]['compatible'] == 0) {
           compatibility_message = '<b><span class="glyphicon glyphicon-remove" style="color:red"></span></b>'
           } else {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

-- datasets/lists table display was blank, because tools_compatibility["Correlation"] is undefined. This fixes it.
<!-- If there are relevant issues, link them here: -->

Was:
![image](https://github.com/user-attachments/assets/db8606db-48f4-4b84-9bbd-774163c28f8a)

Now:
![image](https://github.com/user-attachments/assets/5799092f-fbc0-428d-817a-d4cc2b606456)


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
