### PR TITLE
replace deprecated minify package

### DIFF
--- a/js/build.webpack.config.js
+++ b/js/build.webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const glob = require("glob");
 const filemap = require(path.resolve(__dirname,"./webpack_util/webpack-filemap-plugin.js"));
-const UglifyWebpackPlugin = require("uglifyjs-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
 
 const sourcePath = path.resolve(__dirname, "source");
 const entryPath = path.resolve(sourcePath, "entries");
@@ -60,12 +60,7 @@ module.exports = {
     optimization: {
         minimize: true,
         namedChunks: true,
-        minimizer: [new UglifyWebpackPlugin({
-            uglifyOptions: {
-                output: {
-                    ascii_only: true
-                },
-            },
+        minimizer: [new TerserPlugin({
             'sourceMap': true,
             'parallel': 4,
         })],

--- a/js/package.json
+++ b/js/package.json
@@ -25,22 +25,21 @@
     "node-fetch": "^2.3.0",
     "requirejs": "2.3.7",
     "save-svg-as-png": "^1.4.17",
-    "source-map-support": "^0.5.10",
     "tape": "^4.10.1",
-    "uglifyjs-webpack-plugin": "^1.2.7",
-    "webpack": "^4.29.5",
+    "terser-webpack-plugin": "^4.2.3",
+    "webpack": "^4.29",
     "webpack-command": "^0.4.2"
   },
   "dependencies": {
     "@solgenomics/brapijs": "github:solgenomics/brapi-js#develop",
     "BrAPI-BoxPlotter": "git+https://github.com/solgenomics/BrAPI-BoxPlotter.git",
+    "core-js": "^3",
     "d3": "^7.3.0",
     "d3-array": "^2.11.0",
     "d3-path": "^1.0.9",
     "d3-sankey": "^0.12.3",
     "d3-shape": "^1.3.7",
     "internmap": "^1.0.0",
-    "core-js": "^3",
     "regenerator": "latest"
   },
   "engines": {


### PR DESCRIPTION
replace deprecated npm package uglifyjs-webpack-plugin with terser-webpack-plugin

this is used to minify JavaScript
gives smaller code download and better performance


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ x] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
