### PR TITLE
Multi-Trial Upload: allow crosses

### DIFF
--- a/bin/upload_multiple_trial_design.pl
+++ b/bin/upload_multiple_trial_design.pl
@@ -145,6 +145,7 @@ my $coderef = sub {
             trial_location => $trial_design->{'location'},
             trial_name => $trial_name,
             design_type => $trial_design->{'design_type'},
+            trial_stock_type => $trial_design->{'trial_stock_type'},
             design => $trial_design->{'design_details'},
             program => $trial_design->{'breeding_program'},
             upload_trial_file => $infile,

--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignGeneric.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignGeneric.pm
@@ -58,7 +58,7 @@ sub _validate_with_plugin {
         required_columns => \@REQUIRED_COLUMNS,
         optional_columns => \@OPTIONAL_COLUMNS,
         column_aliases => {
-            'accession_name' => [ 'stock_name', 'cross_name', 'cross_unique_id' ]
+            'accession_name' => [ 'stock_name', 'cross_unique_id' ]
         }
     );
     my $parsed = $parser->parse();

--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignGeneric.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignGeneric.pm
@@ -10,7 +10,7 @@ use CXGN::Calendar;
 use CXGN::Trial;
 
 my @REQUIRED_COLUMNS = qw|trial_name breeding_program location year design_type description accession_name plot_number block_number|;
-my @OPTIONAL_COLUMNS = qw|plot_name trial_type plot_width plot_length field_size planting_date transplanting_date harvest_date is_a_control rep_number range_number row_number col_number seedlot_name num_seed_per_plot weight_gram_seed_per_plot entry_number|;
+my @OPTIONAL_COLUMNS = qw|plot_name trial_type trial_stock_type plot_width plot_length field_size planting_date transplanting_date harvest_date is_a_control rep_number range_number row_number col_number seedlot_name num_seed_per_plot weight_gram_seed_per_plot entry_number|;
 # Any additional columns that are not required or optional will be used as a treatment
 
 # VALID DESIGN TYPES
@@ -31,6 +31,13 @@ my %valid_design_types = (
     "stripplot" => 1,
     "Westcott" => 1,
     "Analysis" => 1
+);
+
+# VALID STOCK TYPES
+my %valid_stock_types = (
+    "accession" => 1,
+    "cross" => 1,
+    "family_name" => 1
 );
 
 sub _validate_with_plugin {
@@ -342,6 +349,13 @@ sub _validate_with_plugin {
         }
     }
 
+    # Trial Stock Type: must be a valid / supported trial stock type
+    foreach (@{$parsed_values->{'trial_stock_type'}}) {
+        if ( !exists $valid_stock_types{$_} ) {
+            push @error_messages, "trial_stock_type <strong>$_</strong> is not supported. Supported trial stock types: " . join(', ', keys(%valid_stock_types)) . ".";
+        }
+    }
+
     # Accession Names: must exist in the database
     my @accessions = @{$parsed_values->{'accession_name'}};
     my $accessions_hashref = $validator->validate($schema,'accessions',\@accessions);
@@ -557,6 +571,7 @@ sub _parse_with_plugin {
             $single_design{'year'} = $row->{'year'};
             $single_design{'design_type'} = $row->{'design_type'};
             $single_design{'description'} = $row->{'description'};
+            $single_design{'trial_stock_type'} = $row->{'trial_stock_type'} || 'accession';
             $single_design{'plot_width'} = $row->{'plot_width'};
             $single_design{'plot_length'} = $row->{'plot_length'};
             $single_design{'field_size'} = $row->{'field_size'};

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -746,6 +746,7 @@ $design_types => ()
                                 <td>design_type</td>
                                 <td>description</td>
                                 <td>trial_type</td>
+                                <td>trial_stock_type</td>
                                 <td>plot_width</td>
                                 <td>plot_length</td>
                                 <td>field_size</td>
@@ -769,7 +770,7 @@ $design_types => ()
                     </table>
 
                     <b>Header as a string:</b><br/>
-                    <p>trial_name,breeding_program,location,year,transplanting_date,design_type,description,trial_type,plot_width,plot_length,field_size,planting_date,harvest_date,plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot,entry_number</p>
+                    <p>trial_name,breeding_program,location,year,transplanting_date,design_type,description,trial_type,trial_stock_type,plot_width,plot_length,field_size,planting_date,harvest_date,plot_name,accession_name,plot_number,block_number,is_a_control,rep_number,range_number,row_number,col_number,seedlot_name,num_seed_per_plot,weight_gram_seed_per_plot,entry_number</p>
 
                     <b> Required fields:</b>
                     <ul>
@@ -789,6 +790,7 @@ $design_types => ()
                     <ul>
                     <li>plot_name (Must be unique across entire database. If not provided in the file, it will be automatically generated as <code>{trial_name}-PLOT_{plot_number}</code>)</li>
                     <li>trial_type (The name of the trial type, must exist in the database. Possible values include Seedling Nursery, phenotyping_trial, Advanced Yield Trial, Preliminary Yield Trial, Uniform Yield Trial, Variety Release Trial, Clonal Evaluation, genetic_gain_trial, storage_trial, heterosis_trial, health_status_trial, grafting_trial, Screen House, Seed Multiplication, crossing_block_trial, Specialty Trial)</li>
+                    <li>trial_stock_type (The type of stocks that are being evaluated in the trial.  Can be either 'accession', 'cross', or 'family_name'.  When not provided, 'accession' is used as the default)
                     <li>plot_width (plot width in meters)</li>
                     <li>plot_length (plot length in meters)</li>
                     <li>field_size (field size in hectares)</li>

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -780,7 +780,7 @@ $design_types => ()
 
                     <li>design_type (The shorthand for the design type, must exist in the database. Possible values include CRD (Completely Randomized Design), RCBD (Randomized Complete Block Design), RRC (Resolvable Row-Column), DRRC (Doubly-Resolvable Row-Column), ARC (Augmented Row-Column), Alpha (Alpha Lattice Design), Lattice (Lattice Design), Augmented (Augmented Design), MAD (Modified Augmented Design), greenhouse (undesigned Nursery/Greenhouse), splitplot (Split Plot), stripplot (Strip Plot / Split Block), p-rep (Partially Replicated), Westcott (Westcott Design))</li>
                     <li>description (Additional text with any other relevant information about the trial.)</li>
-                    <li>accession_name (The accession being tested in the plot, must exist in the database.)</li>
+                    <li>accession_name OR cross_unique_id (The accession or cross being tested in the plot, must exist in the database.)</li>
                     <li>plot_number (A sequential number for the plot in the field (e.g. 1001, 1002, 2001, 2002). These numbers should be unique for the trial.)</li>
                     <li>block_number (A design parameter indicating which block the plot is in.)</li>
                     </ul>

--- a/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
+++ b/mason/breeders_toolbox/trial/trial_upload_dialogs.mas
@@ -780,7 +780,7 @@ $design_types => ()
 
                     <li>design_type (The shorthand for the design type, must exist in the database. Possible values include CRD (Completely Randomized Design), RCBD (Randomized Complete Block Design), RRC (Resolvable Row-Column), DRRC (Doubly-Resolvable Row-Column), ARC (Augmented Row-Column), Alpha (Alpha Lattice Design), Lattice (Lattice Design), Augmented (Augmented Design), MAD (Modified Augmented Design), greenhouse (undesigned Nursery/Greenhouse), splitplot (Split Plot), stripplot (Strip Plot / Split Block), p-rep (Partially Replicated), Westcott (Westcott Design))</li>
                     <li>description (Additional text with any other relevant information about the trial.)</li>
-                    <li>accession_name OR cross_unique_id (The accession or cross being tested in the plot, must exist in the database.)</li>
+                    <li>accession_name OR cross_unique_id OR family_name (The accession, cross, or family being tested in the plot, must exist in the database.)</li>
                     <li>plot_number (A sequential number for the plot in the field (e.g. 1001, 1002, 2001, 2002). These numbers should be unique for the trial.)</li>
                     <li>block_number (A design parameter indicating which block the plot is in.)</li>
                     </ul>

--- a/t/selenium2/breeders/upload_multi_trial_file.t
+++ b/t/selenium2/breeders/upload_multi_trial_file.t
@@ -156,7 +156,8 @@ for my $extension ("xlsx", "xls", "csv") {
             'trial_type'       => 76515,
             'breeding_program' => 'test',
             'plot_width'       => '5',
-            'field_size'       => '8'
+            'field_size'       => '8',
+            'trial_stock_type' => 'accession'
         },
         '199275HBEPR_stom' => {
             'breeding_program' => 'test',
@@ -227,7 +228,8 @@ for my $extension ("xlsx", "xls", "csv") {
             'year'          => '1999',
             'planting_date' => '1992-09-19',
             'plot_length'   => '5',
-            'design_type'   => 'Augmented'
+            'design_type'   => 'Augmented',
+            'trial_stock_type' => 'accession'
         },
         '199934HBEPR_cara' => {
             'description'    => 'EPR',
@@ -298,7 +300,8 @@ for my $extension ("xlsx", "xls", "csv") {
             'design_type'      => 'Augmented',
             'plot_length'      => '5',
             'harvest_date'     => '2000-03-14',
-            'year'             => '1999'
+            'year'             => '1999',
+            'trial_stock_type' => 'accession'
         },
         '199947HBEPR_mora' => {
             'year'         => '1999',
@@ -369,7 +372,8 @@ for my $extension ("xlsx", "xls", "csv") {
             },
             'location'    => 'test_location',
             'trial_type'  => 76515,
-            'description' => 'EPR'
+            'description' => 'EPR',
+            'trial_stock_type' => 'accession'
         }
     };
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This updates the multi-trial upload to allow crosses to be used instead of accessions.  The accession_name column can be changed to stock_name, cross_name or cross_unique_id and the validation will check the name of the stock against existing accessions and crosses.  Previously, the multi-trial upload only allowed accession names as the stocks in plots.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
