### PR TITLE
create 'composed traits' cvterm if does not exist

### DIFF
--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -152,38 +152,32 @@ sub store_composed_term {
         $h->execute();
         my $accession = $h->fetchrow_array();
 
-      my $new_term_dbxref =  $schema->resultset("General::Dbxref")->create( {
-          db_id     => $db->get_column('db_id'),
-          accession => sprintf("%07d",$accession)
-      });
-
-      my $parent_term= $schema->resultset("Cv::Cvterm")->create_with(
-        { cv     =>$cv,
-          name   => 'Composed traits',
-      });
-      #parent term for post-composed traits should already be in teh database.
-      #Using here create_with if for some reason the root term for the COMP ontology needs to be created
-      my $parent_term= $schema->resultset("Cv::Cvterm")->create_with(
-        { cv     =>$cv,
-          name   => 'Composed traits',
-          db     => $db,      });
-      });
-
-    print STDERR "Parent cvterm_id = " . $parent_term->cvterm_id();
-
-    my $new_term = $schema->resultset('Cv::Cvterm')->find({ name=>$name });
-    if ($new_term){
-        print STDERR "Cvterm with name $name already exists... so components must be new\n";
-    } else {
-        $new_term= $schema->resultset("Cv::Cvterm")->create_with({
-            cv     =>$cv,
-            name   => $name,
-            dbxref => $new_term_dbxref
+        my $new_term_dbxref =  $schema->resultset("General::Dbxref")->create( {
+            db_id     => $db->get_column('db_id'),
+            accession => sprintf("%07d",$accession)
         });
 
-    }
+        #parent term for post-composed traits should already be in teh database.
+        #Using here create_with if for some reason the root term for the COMP ontology needs to be created
+        my $parent_term= $schema->resultset("Cv::Cvterm")->create_with(
+            { cv     =>$cv,
+            name   => 'Composed traits',
+            db     => $db,
+        });
 
-    #print STDERR "New term cvterm_id = " . $new_term->cvterm_id();
+        print STDERR "Parent cvterm_id = " . $parent_term->cvterm_id();
+
+        my $new_term = $schema->resultset('Cv::Cvterm')->find({ name=>$name });
+        if ($new_term){
+            print STDERR "Cvterm with name $name already exists... so components must be new\n";
+        } else {
+            $new_term= $schema->resultset("Cv::Cvterm")->create_with({
+                cv     =>$cv,
+                name   => $name,
+                dbxref => $new_term_dbxref
+            });
+        }
+        #print STDERR "New term cvterm_id = " . $new_term->cvterm_id();
 
         my $variable_rel = $schema->resultset('Cv::CvtermRelationship')->find_or_create({
             subject_id => $new_term->cvterm_id(),

--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -157,21 +157,21 @@ sub store_composed_term {
           accession => sprintf("%07d",$accession)
       });
 
-      my $parent_term= $schema->resultset("Cv::Cvterm")->find(
-        { cv_id  =>$cv->cv_id(),
+      my $parent_term= $schema->resultset("Cv::Cvterm")->create_with(
+        { cv     =>$cv,
           name   => 'Composed traits',
       });
 
-    #print STDERR "Parent cvterm_id = " . $parent_term->cvterm_id();
+    print STDERR "Parent cvterm_id = " . $parent_term->cvterm_id();
 
     my $new_term = $schema->resultset('Cv::Cvterm')->find({ name=>$name });
     if ($new_term){
         print STDERR "Cvterm with name $name already exists... so components must be new\n";
     } else {
-        $new_term= $schema->resultset("Cv::Cvterm")->create({
-            cv_id  =>$cv->cv_id(),
+        $new_term= $schema->resultset("Cv::Cvterm")->create_with({
+            cv     =>$cv,
             name   => $name,
-            dbxref_id  => $new_term_dbxref-> dbxref_id()
+            dbxref => $new_term_dbxref
         });
 
     }

--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -161,6 +161,13 @@ sub store_composed_term {
         { cv     =>$cv,
           name   => 'Composed traits',
       });
+      #parent term for post-composed traits should already be in teh database.
+      #Using here create_with if for some reason the root term for the COMP ontology needs to be created
+      my $parent_term= $schema->resultset("Cv::Cvterm")->create_with(
+        { cv     =>$cv,
+          name   => 'Composed traits',
+          db     => $db,      });
+      });
 
     print STDERR "Parent cvterm_id = " . $parent_term->cvterm_id();
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
error in okra.breedbase 
No cvterm for composed traits, so has to be created from the post composing tool the first time a COMP trait is generated 


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
