### PR TITLE
fix version info in footer

### DIFF
--- a/mason/site/footer/body.mas
+++ b/mason/site/footer/body.mas
@@ -10,8 +10,8 @@
         $commit = `git rev-parse --short HEAD`;
         $updated = `git log -1 --format=%cd`;
     } else {
-        $tag = eval{ $c->get_conf('version') };
-        $updated = eval{ $c->get_conf('version_updated') };
+        $tag = $ENV{VERSION};
+        $updated = $ENV{BUILD_DATE};
     }
 </%init>
 
@@ -37,7 +37,7 @@
                 <span class="git-version-commit"><a href="https://github.com/solgenomics/sgn/commits/<% $commit %>"><% $commit %></a></span>&nbsp;
                 <span class="git-version-tag"><a href="https://github.com/solgenomics/sgn/commits/<% $tag %>"><% $tag %></a></span>
 % } else {
-                <span class="git-version-tag"><% $tag %></span>&nbsp;
+                <span class=""><% $tag %></span>&nbsp;
 % }
                 <br />
                 <span class="git-version-updated"><% $updated %></span>


### PR DESCRIPTION
This pr will substitute version information from the config file for version information stuffed into environment variables during the build process. 

The issue with the config variable in sgn.conf was that the version is not available before all the commits are complete for a new version. Putting the version in sgn_local.conf is inconvenient because all sites would have to be updated every time. This solution avoids these problems.

Note: This feature depends on a modification in the Dockerfile, which sets the required environment variables during build time.

Closes #5002.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
