### PR TITLE
List Manager: change date format to fix sorting

### DIFF
--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -56,7 +56,7 @@ CXGN.List = function () {
 
 // Keep track of the rendered lists page number and sort column between refreshes
 var render_lists_page = 0;  // first page
-var render_lists_order = [[0, "asc"]];  // sort by list name, ascending
+var render_lists_order = [[3, "desc"], [2, "desc"]];  // sort by date modified and created, newest first
 
 
 CXGN.List.prototype = {
@@ -397,8 +397,8 @@ CXGN.List.prototype = {
             if ( (!type || type === lists[i][5]) && (autocreated || !(lists[i][2] || '').startsWith("Autocreated")) ) {
                 html += '<tr><td><a href="javascript:showListItems(\'list_item_dialog\','+lists[i][0]+')"><b>'+lists[i][1]+'</b></a></td>';
                 html += '<td>'+(lists[i][2] ? lists[i][2] : '')+'</td>';
-                html += '<td>'+(lists[i][7] ? new Date(lists[i][7]).toLocaleDateString() : '')+'</td>';
-                html += '<td>'+(lists[i][8] ? new Date(lists[i][8]).toLocaleDateString() : '')+'</td>';
+                html += '<td>'+(lists[i][7] ? new Date(lists[i][7]).toLocaleDateString('en-CA') : '')+'</td>';
+                html += '<td>'+(lists[i][8] ? new Date(lists[i][8]).toLocaleDateString('en-CA') : '')+'</td>';
                 html += '<td>'+(lists[i][3] ? lists[i][3] : '0')+'</td>';
                 html += '<td>'+(lists[i][5] ? lists[i][5] : '&lt;NOT SET&gt;')+'</td>';
                 html += '<td><a onclick="javascript:validateList(\''+lists[i][0]+'\',\''+lists[i][5]+'\')"><span class="glyphicon glyphicon-ok"></span></a></td>';

--- a/t/selenium2/01_list/list_groups.t
+++ b/t/selenium2/01_list/list_groups.t
@@ -18,6 +18,11 @@ $d->while_logged_in_as("submitter", sub {
 
     sleep(2);
 
+    # Revert to original sorting: by list name, ascending
+    $d->find_element_ok("(//table[\@id='private_list_data_table']/thead/tr/th)[1]", "xpath", "Sort table by List Name")->click();
+
+    sleep(1);
+
     $d->find_element_ok("list_select_checkbox_808", "id", "checkbox select list")->click();
 
     sleep(1);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This updates the table of lists in the lists manager:

- Force date format (for all locales) to YYYY-MM-DD to enable logical sorting
- Sort the lists table by modified date by default

Fixes #5505

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
