### PR TITLE
Replace plot accessions propagates down to child stocks

### DIFF
--- a/js/source/entries/fieldmap.js
+++ b/js/source/entries/fieldmap.js
@@ -813,7 +813,12 @@ export function init() {
                                                 if (col == 0) {// row header
                                                     table_elems.push("<th style=\"border:none;text-align:left; vertical-align:middle;padding-right:5px;\">"+row+"</th>");
                                                 } else {// normal plant
-                                                    table_elems.push("<td style=\"border: 1px solid black; padding:2px; border-radius:10px;text-align:center; vertical-align:middle;\">"+coord_dictionary["" + row + "," + col + ""]+"</td>");
+                                                    let coord = "" + row + "," + col + "";
+                                                    if (coord in coord_dictionary) {
+                                                        table_elems.push("<td style=\"border: 1px solid black; padding:2px; border-radius:10px;text-align:center; vertical-align:middle;\">"+coord_dictionary["" + row + "," + col + ""]+"</td>");
+                                                    } else {
+                                                        table_elems.push("<td style=\"border: 1px solid black; padding:2px; border-radius:10px;text-align:center; vertical-align:middle;\">empty space</td>");
+                                                    }
                                                 }
                                             }
                                         }

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -2645,17 +2645,22 @@ sub replace_plot_accession : Chained('trial') PathPart('replace_plot_accessions'
         uniquename => $new_accession
     });
     $accession_rs = $accession_rs->next();
-    my $accession_id = $accession_rs->stock_id;
+    my $new_accession_id = $accession_rs->stock_id;
+    my $old_accession_rs = $schema->resultset("Stock::Stock")->search({
+        uniquename => $old_accession
+    });
+    $old_accession_rs = $old_accession_rs->next();
+    my $old_accession_id = $old_accession_rs->stock_id;
 
     print "Calling Replace Function...............\n";
-    my $replace_return_error = $replace_plot_accession_fieldmap->replace_plot_accession_fieldMap($plot_id, $accession_id, $plot_of_type_id);
+    my $replace_return_error = $replace_plot_accession_fieldmap->replace_plot_accession_fieldMap($plot_id, $old_accession_id, $new_accession_id, $plot_of_type_id);
     if ($replace_return_error) {
         $c->stash->{rest} = { error => $replace_return_error };
         return;
     }
 
     if ($new_plot_name) {
-        my $replace_plot_name_return_error = $replace_plot_accession_fieldmap->replace_plot_name_fieldMap($plot_id, $new_plot_name);
+        my $replace_plot_name_return_error = $replace_plot_accession_fieldmap->replace_plot_name_fieldMap($plot_id, $old_plot_name, $new_plot_name);
         if ($replace_plot_name_return_error) {
             $c->stash->{rest} = { error => $replace_plot_name_return_error };
             return;

--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -558,6 +558,7 @@ $has_plant_entries => undef
                         <label class="col-sm-3 control-label">Enter New Accession: </label>
                         <div class="col-sm-9" >
                           <input class="form-control" id="hm_accession" name="hm_accession"></input>
+                        <p><i>Warning: subplots, plants, and tissue samples will be updated but will keep their original names unless a new plot name is specified. The new plot name will replace the old plot name in subplots, plants, and tissue samples if possible.</i></p>
                         </div>
                       </div>
 
@@ -1220,9 +1221,9 @@ jQuery(document).ready( function() {
 
       var new_accession = jQuery('#hm_accession').val();
       var new_plot_name = jQuery('#hm_new_plot_name').val();
-      var old_accession = jQuery('#hm_edit_plot_accession').html();
-      var old_plot_id = jQuery('#hm_edit_plot_id').html();
-      var old_plot_name = jQuery('#hm_edit_plot_name').html();
+      var old_accession = jQuery('#hm_plot_accession').html();
+      var old_plot_id = jQuery('#hm_plot_id').html();
+      var old_plot_name = jQuery('#hm_plot_name').html();
 
       new jQuery.ajax({
         type: 'POST',


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
- Fixes bug in replacing plot accession from fieldmap
- empty cells in plot-level diagram are called "empty space" instead of "undefined"
- Propagates accession changes down to subplots, plants, and tissue samples
- attempts to rename child stocks using new plot name

<!-- If there are relevant issues, link them here: -->
#5420 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
