### PR TITLE
Fixing report generation for large files

### DIFF
--- a/lib/SGN/Controller/AJAX/Report.pm
+++ b/lib/SGN/Controller/AJAX/Report.pm
@@ -140,12 +140,6 @@ sub generatereport_POST :Path('generatereport') :Args(0) {
         
         my $script_cmd = "perl ${basepath}${reports_dir}${script}.pl -U $dbuser -H $dbhost -P $dbpass -D $dbname -o '$out_directory' -f '$json_filename' -s '$start_date' -e '$end_date'";
         
-       
-
-        print("Starting command $script_cmd \n");
-        print("Diretorio json $out_directory \n");
-        print("Arquivo json $json_filename \n");
-        print("Arquivo excel $excel_filename \n");
 
         # my $report_job = CXGN::Job->new({
         #     schema => $schema,
@@ -165,7 +159,12 @@ sub generatereport_POST :Path('generatereport') :Args(0) {
         if ($? != 0) {
             die "Report script failed with exit code " . ($? >> 8);
         }
-
+        
+        print("Starting command $script_cmd \n");
+        print("Path to json $out_directory \n");
+        print("json file $json_filename \n");
+        print("excel file $excel_filename \n");
+        
         my $json_file = File::Spec->catfile($out_directory, $json_filename);
         print("Reading output from file: $json_file \n");
 


### PR DESCRIPTION
The report generation process was intermittently failing to decode JSON output files. The error message indicated that the JSON was incomplete or malformed (e.g., unexpected end of string while parsing JSON string).

This happened because the code was attempting to read the JSON file as soon as it appeared on disk, before the report generation script had fully finished writing the file. Since the script was launched asynchronously via CXGN::Job, there was no guarantee that the file was complete at the moment it became visible.

Solution:
To ensure the JSON file is fully written before reading, the code was updated to execute the report script synchronously using system() instead of submitting it to CXGN::Job. This guarantees that the process has completed and the file is complete before any attempt to decode its contents.

This change eliminates race conditions and ensures consistent, valid JSON parsing.