### PR TITLE
Fix trial upload by fixing error handling

### DIFF
--- a/lib/CXGN/Job.pm
+++ b/lib/CXGN/Job.pm
@@ -472,10 +472,9 @@ sub cancel {
     }
 }
 
-=head2 submit("sync")
+=head2 submit()
 
 Creates a CXGN::Tools::Run object and runs the current job. Stores job data in a new db row. Returns sp_job_id. 
-Optional parameter runs it syncronously rather than on the cluster.
 
 =cut
 
@@ -520,11 +519,7 @@ sub submit {
         $job = CXGN::Tools::Run->new($cxgn_tools_run_config);
         print STDERR "Submitting job: \n$cmd\n";
         $job->is_cluster(1);
-        if ($run_sync eq "sync") {
-            $job->run($cmd.$finish_timestamp_cmd);
-        } else {
-            $job->run_cluster($cmd.$finish_timestamp_cmd);
-        }
+        $job->run_cluster("(".$cmd.$finish_timestamp_cmd.")");
 
         $self->cxgn_tools_run_config->{err} = $job->err_file();
         $self->cxgn_tools_run_config->{out} = $job->out_file();

--- a/lib/SGN/Controller/AJAX/Trial.pm
+++ b/lib/SGN/Controller/AJAX/Trial.pm
@@ -1250,7 +1250,7 @@ sub upload_multiple_trial_designs_file_POST : Args(0) {
         #my $err = $runner->err();
         #my $out = $runner->out();
 
-        $job->submit("sync");
+        $job->submit();
 
         while($job->alive()) {
             sleep(1);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes an issue with multiple trial uploads that prevented error files from being generated, causing all files to pass validation even if they shouldn't

<!-- If there are relevant issues, link them here: -->
#5597 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
