### PR TITLE
remove the link to the necrosis analysis

### DIFF
--- a/mason/tools/image_analysis.mas
+++ b/mason/tools/image_analysis.mas
@@ -44,12 +44,6 @@ tr.shown td.details-control {
 
 <div class="well well-sm">
     <center>
-    <h4>The Necrosis Image Analysis is explained in the paper here: <a href="https://csce.ucmss.com/cr/books/2018/LFS/CSREA2018/IPC3638.pdf">Necrosis Image Analysis</a>.</h4>
-    </center>
-</div>
-
-<div class="well well-sm">
-    <center>
     <button class="btn btn-primary" id="upload_images_link">Upload New Images</button>
     </center>
 </div>


### PR DESCRIPTION
The link to the paper for that specific analysis is not appropriate for the generic image analysis page.
closes #5617.



Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
