### PR TITLE
Allow obsoleted accessions to be included in transgenic historical data upload

### DIFF
--- a/lib/CXGN/List/Validate/Plugin/NotObsoletedAndObsoletedAccessions.pm
+++ b/lib/CXGN/List/Validate/Plugin/NotObsoletedAndObsoletedAccessions.pm
@@ -1,0 +1,29 @@
+package CXGN::List::Validate::Plugin::NotObsoletedAndObsoletedAccessions;
+
+use Moose;
+
+sub name {
+    return "not_obsoleted_and_obsoleted_accessions";
+}
+
+sub validate {
+    my $self = shift;
+    my $schema = shift;
+    my $list = shift;
+
+    my $accession_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
+
+    my @missing = ();
+    foreach my $l (@$list){
+        my $rs = $schema->resultset("Stock::Stock")->search({
+            type_id=>$accession_type_id,
+		    uniquename => $l,
+	    });
+	    if ($rs->count() == 0){
+            push @missing, $l;
+        }
+    }
+    return { missing => \@missing };
+}
+
+1;

--- a/lib/CXGN/Stock/ParseUpload/Plugin/TransgenicHistoricalDataGeneric.pm
+++ b/lib/CXGN/Stock/ParseUpload/Plugin/TransgenicHistoricalDataGeneric.pm
@@ -66,7 +66,7 @@ sub _validate_with_plugin {
     if ($is_existing_accessions) {
         if (scalar(@$is_existing_accessions) > 0) {
             my $accession_validator = CXGN::List::Validate->new();
-            my @accessions_missing = @{$accession_validator->validate($schema,'uniquenames', $seen_accession_names)->{'missing'}};
+            my @accessions_missing = @{$accession_validator->validate($schema,'not_obsoleted_and_obsoleted_accessions', $seen_accession_names)->{'missing'}};
             if (scalar(@accessions_missing) > 0) {
                 push @error_messages, "The following accessions are not in the database, or are not in the database as uniquenames: ".join(',',@accessions_missing);
             }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
