### PR TITLE
fix a couple of issues with the phenotype upload

### DIFF
--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -548,7 +548,9 @@ sub verify {
                 # print STDERR "Trait name = $trait_name\n";
                 foreach my $value_array (@$measurements_array) {
                     # print STDERR "Value array = ".Dumper($value_array)."\n";
-                    ($warnings, $errors) = $self->check_measurement($plot_name, $trait_name, $value_array, 1); 
+		    my $multiple_values = 0;
+		    if (scalar(@$measurements_array) > 1) { $multiple_values = 1; } 
+                    ($warnings, $errors) = $self->check_measurement($plot_name, $trait_name, $value_array, $multiple_values); 
                     $error_message .= $errors;
                     $warning_message .= $warnings;
                 }
@@ -778,7 +780,7 @@ sub check_measurement {
         #print STDERR "$trait_value, $trait_cvterm_id, $stock_id\n";
         #check if the plot_name, trait_name combination already exists in database.
         elsif ($repeat_type eq "single") {
-	    if ($file_contains_multiple_values) {
+	    if ($file_contains_multiple_values  && (defined($trait_value) && $trait_value ne '')) {
 		$warning_message .= "Multiple values present in file for single repeat_type term $trait_name\n";
 	    }
 	    

--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -652,8 +652,8 @@ sub check_measurement {
             }
         }
 
-        #check that trait value is valid for trait name
-        if (exists($self->check_trait_format()->{$trait_cvterm_id})) {
+        #check that trait value is valid for trait name (but only if we have a trait_value)
+        if ((defined($trait_value) && $trait_value ne '') && exists($self->check_trait_format()->{$trait_cvterm_id})) { 
             # print STDERR "Trait minimum value checks if it exists: " . $self->check_trait_min_value->{$trait_cvterm_id} . "\n";
             if ($self->check_trait_format()->{$trait_cvterm_id} eq 'numeric') {
                 my $trait_format_checked = looks_like_number($trait_value);

--- a/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
+++ b/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
@@ -88,6 +88,7 @@ sub upload_phenotype_verify_POST : Args(1) {
     }
     catch {
         $verified_error = $_;
+	print STDERR "ERROR DURING UPLOAD: $verified_error\n";
     };
 
     if ($verified_error) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
1. empty values counted towards duplicate values in the phenotype upload
2. empty values were checked against range limits for the trait

Both should be fixed in this PR.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
