### PR TITLE
link images to cvterms in load_images.pl

### DIFF
--- a/bin/load_images.pl
+++ b/bin/load_images.pl
@@ -27,8 +27,10 @@ host name
 
 =item -m 
 
-map file. If provided links between stock names - image file name , is read from a mapping file.
-Row labels are expected to be unique file names, column header for the associated stocks is 'name' 
+map file. If provided, creates links between stocks and images.
+Row labels are expected to be unique file names, column header for the associated stocks
+are 'file name',  'name', and 'cvterm'. The cvterm column is optional. It should 
+contain the name of the cvterm, not the id. 
 
 =item -i
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
using the mapping file (-m option), a new optional column "cvterm" can be added that will link the cvterm to the image.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
