### PR TITLE
Store point geoCoordinates as float instead of string

### DIFF
--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -1921,7 +1921,7 @@ sub trial_plot_gps_upload : Chained('trial') PathPart('upload_plot_gps') Args(0)
                         "type"=> "Point",
                         "coordinates"=> [
                             
-                            $coords->{WGS84_x}, $coords->{WGS84_y},
+                            0.0 + $coords->{WGS84_x}, 0.0 + $coords->{WGS84_y},
                             
                         ]
                     },


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Stores point geocoordinates as floats instead of sting in geoJSON to avoid brapi import error

<!-- If there are relevant issues, link them here: -->
Fixes #5678 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
