### PR TITLE
Fix issue with identifier generation

### DIFF
--- a/lib/CXGN/List.pm
+++ b/lib/CXGN/List.pm
@@ -387,14 +387,26 @@ sub remove_element {
 	return "An error occurred while attempting to delete item $element";
     }
 
-		eval {
+    eval {
     	my $q = "UPDATE sgn_people.list SET modified_date = now() WHERE list_id=?";
     	my $h1 = $self->dbh()->prepare($q);
     	$h1->execute($self->list_id());
-		};
+    };
 
     my $elements = $self->elements();
-    my @clean = grep(!/^$element$/, @$elements);
+
+    # the following loop was refactored from a grep statement, as lists sometimes contain
+    # json data and gets interpreted wrong using grep, leading to errors. For example,
+    # in some lists, usernames are stored, and when they contain dashes, an error occurs
+    # as it is not legal regexp. See issue: https://github.com/solgenomics/sgn/issues/5689
+    
+    my @clean;
+    foreach my $e (@$elements) {
+	if ($e ne $element) { 
+	    push @clean, $e;
+	}
+    }
+    
     $self->elements(\@clean);
     return 0;
 }


### PR DESCRIPTION
The username is stored in the json structure for lists of type identifier_generation. If the username contains a dash, the remove_element function crashes as it tries to use grep to remove elements, interpreting it as an illegal re range. Going the old-fashioned loop/match route instead that does not require regular expressions.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
