### PR TITLE
fix link from GCPC tools to selection index tool by providing a semiabsolute url.

### DIFF
--- a/mason/tools/gcpc/index.mas
+++ b/mason/tools/gcpc/index.mas
@@ -43,7 +43,7 @@
             <div id="sin_list"></div>
               <p style="margin-left: 30px;margin-right: 30px;">OR</p>
               <button class="btn btn-success" >
-              <a href="http://localhost:8080/selection/index" target="_blank" rel="noopener noreferrer" style="color: white">Create a new one here</a>
+              <a href="/selection/index" target="_blank" rel="noopener noreferrer" style="color: white">Create a new one here</a>
               </button>
           </div>
           


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
