### PR TITLE
CXGN::File::Parse ->clean_header - remove BOM bytes

### DIFF
--- a/lib/CXGN/File/Parse.pm
+++ b/lib/CXGN/File/Parse.pm
@@ -430,6 +430,9 @@ sub clean_header {
     # Do usual value cleaning
     $header = $self->clean_value($header);
 
+    # Strip BOM bytes, if present
+    $header =~ s/^\N{BOM}//;
+
     # check for case-insensitive required column match
     if ( $required_columns ) {
       foreach my $col (@$required_columns ) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Remove BOM bytes from file headers, if present.  These can be included in some MS Office csv exports.

Fixes #5700

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
