### PR TITLE
Geo Field Map: restore load / save plot functionality

### DIFF
--- a/js/source/legacy/brapi/BrAPIFieldmap.js
+++ b/js/source/legacy/brapi/BrAPIFieldmap.js
@@ -2688,7 +2688,6 @@
 		}
 	  
 		// Final plots
-		data.plots = [...plots_polygons, ...plots_points]; // omit missing
 		return data;
 	  }
 	  
@@ -2833,11 +2832,9 @@
 
 			let params = {};
 			this.plots.features.forEach((plot)=>{
-				if (plot._originalType === "Polygon") {
-					params[plot.properties.observationUnitDbId] = {
+				params[plot.properties.observationUnitDbId] = {
 					observationUnitPosition: {geoCoordinates: plot, observationLevel:{levelName: this.opts.brapi_levelName }}
-					};
-				}
+				};
 			});
 
 			return new Promise((resolve, reject)=> {

--- a/mason/tools/fieldmap.mas
+++ b/mason/tools/fieldmap.mas
@@ -93,8 +93,8 @@ $trial_id => undef
                 .then((value)=>{
                   if (!value) return setLocation(studyDbId); 
                   else { jQuery("#select_trial_for_selection_index option[value="+studyDbId+"]").attr('selected', 'selected'); }
-                  const hasPolygon = fieldMap.plots.features.some(plot => plot.geometry && plot._originalType === "Polygon");
-                  jQuery("#btn-save-geo-coordinates").prop("disabled", !hasPolygon); // disable save geo cooridnates button if there are only point geometries loaded
+                  const hasPoints = fieldMap.plots.features.some(plot => plot.geometry && plot._originalType === "Point");
+                  jQuery("#btn-save-geo-coordinates").prop("disabled", hasPoints); // disable save geo cooridnates button if there are only point geometries loaded
                 })  
                 .finally(() => {
                     jQuery("#btn-load-plots").prop("disabled", false);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes the loading and storing of plot boundaries using the Geo Field Map viewer when the trial does not initially have them set.

Fixes #5746 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
