### PR TITLE
enable COMP trait image upload

### DIFF
--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -327,11 +327,8 @@ sub verify_exif_POST {
             }
             # Get cvterm_id of recorded trait
             my $cvterm_name = $decoded_json->{observation_variable}->{observation_variable_name};
-            $cvterm_name =~ s/\|[^|]+$//;
-            my $q = "SELECT cvterm_id FROM cvterm join dbxref USING (dbxref_id) JOIN db USING (db_id) WHERE db.name = ? AND cvterm.name = ?";
-            my $h = $schema->storage->dbh->prepare($q);
-            $h->execute($c->config->{trait_ontology_db_name},  $cvterm_name);
-            my ($cvterm_id) = $h->fetchrow_array();
+            my $trait_cvterm = SGN::Model::Cvterm->get_cvterm_row_from_trait_name($schema, $cvterm_name);
+            my $cvterm_id = $trait_cvterm->cvterm_id();
 
             $decoded_json->{stock_name} = $stock_name;
             if ($cvterm_id) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
COMP trait images were not passing verification. The db ontology name was coming from the conf file (trait_ontology_db_name), so the COMP traits were not being found; now it uses get_cvterm_row_from_trait_name instead.

<!-- If there are relevant issues, link them here: -->
Closes #5770 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
