### PR TITLE
Fix loop condition for stock types iteration

### DIFF
--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -32,7 +32,7 @@ use CXGN::Page::FormattingHelpers qw / conditional_like_input_html simple_select
 
 my $accession_cvterm_id;
 
-for (my $i=0; $i<= scalar(@$stock_types); $i++) {
+for (my $i=0; $i< scalar(@$stock_types); $i++) {
      if ( $stock_types->[$i][1] eq "accession" ) {
      	$accession_cvterm_id = $stock_types->[$i][0];
 	last();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

## Bug
- Line 35 contains an off-by-one error that causes an infinite loop when:
  - Stock table is empty, OR
  - No "accession" stock type exists
- Using `<=` instead of `<` in the loop condition causes accessing  `$stock_types->[$i]` where `$i` equals the array size (out of bounds). This triggers Perl autovivification, which creates new array elements, increasing the array size, which makes the loop condition true again, creating an infinite loop that consumes unbounded memory.

## Change
- Change `$i<= scalar(@$stock_types)` to `$i< scalar(@$stock_types)`
- Prevents memory leaks caused by Perl's autovivification in cases where the stock table is empty or no "accession" stock type exists.

## Testing
- I've tested these changes locally (within a Docker container based off [breedbase_web](https://hub.docker.com/r/triticeaetoolbox/breedbase_web)) and I can confirm they fix the bug.
  - with empty stock table: page loads successfully
  - with populated stock table: existing functionality preserved

I encountered this issue when using [TriticeaeToolbox's sgn](https://github.com/TriticeaeToolbox/sgn), but this repository seems to be the upstream for their fork and the issue exists in both repositories.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
