### PR TITLE
Accession Transform: return ids in same order as original name list

### DIFF
--- a/lib/CXGN/List/Transform/Plugin/Accessions2AccessionIds.pm
+++ b/lib/CXGN/List/Transform/Plugin/Accessions2AccessionIds.pm
@@ -43,9 +43,7 @@ sub transform {
 
          # add map of found name --> found id
          for my $i (0 .. $#found_names) {
-            my $n = $found_names[$i];
-            my $i = $found_ids[$i];
-            $found_hash{$n} = $i;
+            $found_hash{$found_names[$i]} = $found_ids[$i];
          }
 
          my %found_names_hash = map{$_ => 1} @found_names;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This updates the accessions2accession_ids list transformation to return the found ids in the same order as the original list names.

Fixes #5782

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
