### PR TITLE
Topic/label designer improvements

### DIFF
--- a/js/source/legacy/tools/LabelDesigner.js
+++ b/js/source/legacy/tools/LabelDesigner.js
@@ -1632,6 +1632,7 @@ function retrievePageParams() {
         start_col: document.getElementById("start_col").value,
         start_row: document.getElementById("start_row").value,
         text_alignment : getAlignmentSpecs(),
+        page_units : getPageUnits()
     }
     return page_params;
 
@@ -1672,6 +1673,13 @@ function getAlignmentSpecs() {
         return "left";
     }   
     return "middle";
+}
+
+function getPageUnits() {
+    if(jQuery('#dim_inches').prop('checked')) {
+        return "imperial";
+    }   
+    return "metric";
 }
 
 function initializeCustomModal(add_fields) {
@@ -1810,21 +1818,39 @@ function loadDesign (list_id) {
         }
     }
 
+     var page_units = params['page_units'];
+
+    if (page_units == "imperial") {
+        jQuery(".radio-select-metric").each(function() {
+            jQuery(this).prop("checked", false)
+        });
+        jQuery(".radio-select-imperial").each(function() {
+            jQuery(this).prop("checked", true)
+        });
+    } else {
+        jQuery(".radio-select-metric").each(function() {
+            jQuery(this).prop("checked", true)
+        });
+        jQuery(".radio-select-imperial").each(function() {
+            jQuery(this).prop("checked", false)
+        });
+    }
+
     var page = params['page_format'];
     document.getElementById('page_format').value = page;
     //console.log("page is "+page);
     switchPageDependentOptions(page);
     if (page == 'Custom') {
-        document.getElementById("page_width").value = params['page_width'] / 72;
-        document.getElementById("page_height").value = params['page_height'] / 72;
+        document.getElementById("page_width").value = convertPixelsToPageDimensions(params['page_width']);
+        document.getElementById("page_height").value = convertPixelsToPageDimensions(params['page_height']);
     }
 
     var label = params['label_format'];
     document.getElementById('label_format').value = label;
     switchLabelDependentOptions(label);
     if (label == 'Custom') {
-        document.getElementById("label_width").value = params['label_width'];
-        document.getElementById("label_height").value = params['label_height'];
+        document.getElementById("label_width").value = convertPixelsToPageDimensions(params['label_width']);
+        document.getElementById("label_height").value = convertPixelsToPageDimensions(params['label_height']);
         page_formats[page].label_sizes['Custom'].label_width = params['label_width'];
         page_formats[page].label_sizes['Custom'].label_height = params['label_height'];
         changeLabelSize(params['label_width'], params['label_height']);
@@ -1843,7 +1869,6 @@ function loadDesign (list_id) {
         jQuery('#align_middle').prop("checked", true);
     }
 
-    
     saveAdditionalOptions(
         params['top_margin'],
         params['left_margin'],

--- a/mason/tools/label_designer/label_designer_modals.mas
+++ b/mason/tools/label_designer/label_designer_modals.mas
@@ -66,21 +66,21 @@
                 </div>
                 <div class="col-md-12" id="">
                     <center>
-                        <label class='radio'><input type="radio" name="dimoptradio2" id="dim_inches2" class="radio-select-imperial" value="inch" checked>Imperial (inches)</label>
-                        <label class='radio'><input type="radio" name="dimoptradio2" id="dim_cm2" class="radio-select-metric" value="cm">Metric (cm)</label>
+                        <label class='radio'><input type="radio" name="dimoptradio2" id="dim_inches2" class="radio-select-imperial" value="inch">Imperial (inches)</label>
+                        <label class='radio'><input type="radio" name="dimoptradio2" id="dim_cm2" class="radio-select-metric" value="cm" checked>Metric (cm)</label>
                     </center>
                     <div class="col-md-1">
                     </div>
                     <div class="col-md-5">
                         <center>
                             <br><label>Top Margin:</label><br>
-                            <input class="form-control" placeholder="In inches" type="number" id="top_margin" style="max-width: 100%;">
+                            <input class="form-control"  type="number" id="top_margin" style="max-width: 100%;">
                         </center>
                     </div>
                     <div class="col-md-5">
                         <center>
                             <br><label>Left Margin:</label><br>
-                            <input class="form-control" placeholder="In inches" type="number" id="left_margin" style="max-width: 100%;">
+                            <input class="form-control"  type="number" id="left_margin" style="max-width: 100%;">
                         </center>
                     </div>
                     <div class="col-md-1"></div>
@@ -90,13 +90,13 @@
                     <div class="col-md-5">
                         <center>
                             <br><label>Horizontal Gap:</label><br>
-                            <input class="form-control" placeholder="In inches" type="number" id="horizontal_gap" style="max-width: 100%;">
+                            <input class="form-control"  type="number" id="horizontal_gap" style="max-width: 100%;">
                         </center>
                     </div>
                     <div class="col-md-5">
                         <center>
                             <br><label>Vertical Gap:</label><br>
-                            <input class="form-control" placeholder="In inches" type="number" id="vertical_gap" style="max-width: 100%;">
+                            <input class="form-control" type="number" id="vertical_gap" style="max-width: 100%;">
                         </center>
                     </div>
                     <div class="col-md-1"></div>

--- a/mason/tools/label_designer/select_layout.mas
+++ b/mason/tools/label_designer/select_layout.mas
@@ -36,13 +36,13 @@
            <div class="col-md-5">
                <center>
                    <label>Page Width:</label><br>
-                   <input class="form-control"  placeholder="In inches" type="number" id="page_width" style="max-width: 100%;">
+                   <input class="form-control"   type="number" id="page_width" style="max-width: 100%;">
                </center>
            </div>
            <div class="col-md-5">
                <center>
                    <label>Page Height:</label><br>
-                   <input class="form-control" placeholder="In inches" type="number" id="page_height" style="max-width: 100%;">
+                   <input class="form-control"  type="number" id="page_height" style="max-width: 100%;">
                </center>
            </div>
        </div>
@@ -53,18 +53,18 @@
            <div class="col-md-5">
                <center>
                    <label>Label Width:</label><br>
-                   <input class="form-control" placeholder="In inches" type="number" id="label_width" style="max-width: 100%;">
+                   <input class="form-control"  type="number" id="label_width" style="max-width: 100%;">
                </center>
            </div>
            <div class="col-md-5">
                <center>
                    <label>Label Height:</label><br>
-                   <input class="form-control" placeholder="In inches" type="number" id="label_height" style="max-width: 100%;">
+                   <input class="form-control"  type="number" id="label_height" style="max-width: 100%;">
                </center>
            </div>
            <div class="col-md-2">
-                <label class='radio'><input type="radio" name="dimoptradio" id="dim_inches" class="radio-select-imperial" value="inch" checked>Imperial</label>
-                <label class='radio'><input type="radio" name="dimoptradio" id="dim_cm" class="radio-select-metric" value="cm">Metric</label>
+                <label class='radio'><input type="radio" name="dimoptradio" id="dim_inches" class="radio-select-imperial" value="inch">Imperial (inches)</label>
+                <label class='radio'><input type="radio" name="dimoptradio" id="dim_cm" class="radio-select-metric" value="cm" checked>Metric (cm)</label>
            </div>
            <div class="col-md-2">
                <br>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Makes the units (cm or inches) a part of a label design. Makes left/middle text alignment part of a saved design. Fixes a bug where saved designs would load properly, but custom size dimensions would be populated with pixel values instead of real measurements. Metric is used by default. Fixes bug where row numbers and column numbers are ignored for custom label sizes

<!-- If there are relevant issues, link them here: -->
closes #5791 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
