### PR TITLE
fix error in file creation, only need file name

### DIFF
--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -1256,10 +1256,9 @@ sub download_gbs_action : Path('/breeders/download_gbs_action') {
         expires => '+1m',
     };
 
-    my ($fh, $file_path) = tempfile("breedbase_grm_XXXXX", DIR=> $c->config->{cluster_shared_tempdir});
+    my ($fh, $file_path) = tempfile("breedbase_grm_XXXXX", DIR => $c->config->{cluster_shared_tempdir});
     my $filename = basename($file_path);
-    # my $num = sprintf("%05d", int(rand(100000)));
-    # my $filename = "breedbase_genotype_data_" . $num;
+    
     if ($download_format eq 'VCF') {
         $filename .= '.vcf';
     }
@@ -1350,11 +1349,9 @@ sub download_grm_action : Path('/breeders/download_grm_action') {
         expires => '+1m',
     };
 
-    my ($fh, $file_path) = tempfile("breedbase_grm_XXXXX", DIR=> $c->config->{cluster_shared_tempdir});
+    my ($fh, $file_path) = tempfile("breedbase_grm_XXXXX", DIR => $c->config->{cluster_shared_tempdir});
     my $filename = basename($file_path);
-    print STDERR "temp file for grm download: $file_path\n";
-    print STDERR "filename for grm download: $filename\n";
-
+    
     if ($download_format eq 'heatmap') {
         $filename .= '.pdf';
     }


### PR DESCRIPTION
fix permission error when file created
only need file name


Fixes #5805 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
