### PR TITLE
Fix working modal on trial details page load 

### DIFF
--- a/mason/breeders_toolbox/trial/phenotype_summary.mas
+++ b/mason/breeders_toolbox/trial/phenotype_summary.mas
@@ -264,14 +264,14 @@ input[type="text"] {
 
         jQuery('#trial_detail_traits_assayed_onswitch').click( function() {
             init_summary_table(type);
-        });
+        
 
 %  if ($trial_stock_type eq 'analysis_instance') {
         trait_summary_hist_display_change('analysis_instance');
 %  } else {
         trait_summary_hist_display_change('plot');
 %  }
-
+        });
         jQuery('#phenotype_summary_data').on('click', 'a[href^="#"]', function(event) {
             //console.log("scrolling histo into view");
             var offset = jQuery(window).height() - jQuery('#raw_data_histogram_well').height() - 40;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Moves function causing working modal to appear on trial details page load into onswitch function.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
