### PR TITLE
Add support for Synonym Search Tool auth client

### DIFF
--- a/sgn.conf
+++ b/sgn.conf
@@ -490,7 +490,7 @@ crontab_file NULL
 crontab_log_filepath NULL
 
 #Authorized Clients for SSO
-authorized_clients_JSON {"TEST://":"TEST","fieldbook://":"FieldBook App","https://apps.cipotato.org/hidap_sbase/":"HIDAP","https://phenoapps.org/field-book":"fieldbook","https://fieldbook.phenoapps.org/": "fieldbook", "https://climmob.net":"ClimMob"}
+authorized_clients_JSON {"TEST://":"TEST","fieldbook://":"FieldBook App","https://apps.cipotato.org/hidap_sbase/":"HIDAP","https://phenoapps.org/field-book":"fieldbook","https://fieldbook.phenoapps.org/": "fieldbook", "https://climmob.net":"ClimMob","https://synonyms.triticeaetoolbox.org":"BrAPI Synonym Search Tool"}
 
 simsearch_datadir /home/production/simsearch_data
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


Adds [synonyms.triticeaetoolbox.org](https://synonyms.triticeaetoolbox.org) as an auth client to the sgn.conf file


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
