### PR TITLE
Geno Proj Lists: add missing ID transformation

### DIFF
--- a/js/source/entries/wizard.js
+++ b/js/source/entries/wizard.js
@@ -48,7 +48,7 @@ const toValidateType = (t) => (t === "tissue_sample" ? "tissue_samples" : t);
 const toLoadType = (t) => (t === "tissue_samples" ? "tissue_sample" : t);
 
 // Allow both forms when FETCHING lists so legacy lists appear
-const fetchTypes = [...new Set([...initialtypes, "tissue_sample", "subplots", "plants", "plots"])];
+const fetchTypes = [...new Set([...initialtypes, "genotyping_plates", "tissue_sample", "subplots", "plants", "plots"])];
 
 function makeURL(target, id) {
     switch (target) {
@@ -73,6 +73,7 @@ function makeURL(target, id) {
           return document.location.origin + `/breeders/trial/${id}`;
         case "genotyping_protocols":
           return document.location.origin + `/breeders_toolbox/protocol/${id}`;
+        case "genotyping_plates":
         case "genotyping_projects":
           return document.location.origin + `/breeders/trial/${id}`;
         case "trial_designs":

--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -70,7 +70,9 @@ CXGN.List.prototype = {
         "accessions": 'accessions_2_accession_ids',
         "plots": 'plots_2_plot_ids',
         "seedlots": 'stocks_2_stock_ids',
-        "crosses": 'stocks_2_stock_ids'
+        "crosses": 'stocks_2_stock_ids',
+        "genotyping_projects": 'projects_2_project_ids',
+        "genotyping_plates": 'projects_2_project_ids'
     },
 
     // Return the data as a straight list


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds genotyping_projects and genotyping_plates transformation keys to CXGN.List which was causing the wrong IDs to be assigned to genotyping project list items in the Search Wizard


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
