### PR TITLE
Sync plants per plot between first page and greenhouse-specific page

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/AddTrial.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/AddTrial.js
@@ -53,18 +53,14 @@ jQuery(document).ready(function ($) {
 
     jQuery('#add_plant_entries').on('change', function() {
         let plants_per_plot = jQuery(this).val();
-        if (plants_per_plot != null && plants_per_plot != 0) {
-            jQuery('#greenhouse_default_num_plants_per_accession_val').val(plants_per_plot);
-            greenhouse_show_num_plants_section()
-        }
+        jQuery('#greenhouse_default_num_plants_per_accession_val').val(plants_per_plot);
+        greenhouse_show_num_plants_section()
     });
 
     jQuery('#greenhouse_default_num_plants_per_accession_val').on('change', function() {
         let plants_per_plot = jQuery(this).val();
-        if (plants_per_plot != null && plants_per_plot != 0) {
-            jQuery('#add_plant_entries').val(plants_per_plot);
-            greenhouse_show_num_plants_section()
-        }
+        jQuery('#add_plant_entries').val(plants_per_plot);
+        greenhouse_show_num_plants_section()
     });
 
     function create_trial_validate_form(){


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Changing the plants per plot input box changes the default number of plants on the greenhouse/nursery trial dialog, and vice versa

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
