### PR TITLE
Fix non trait ontologies showing up in trait search

### DIFF
--- a/lib/CXGN/BrAPI/v2/Common.pm
+++ b/lib/CXGN/BrAPI/v2/Common.pm
@@ -1,7 +1,7 @@
 package CXGN::BrAPI::v2::Common;
 
 =head1 NAME
- CXGN::BrAPI::v1::Common - parent class for BrAPI subclasses.
+ CXGN::BrAPI::v2::Common - parent class for BrAPI subclasses.
 =head1 DESCRIPTION
  Defines the following properties:
 =over 4

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -479,7 +479,13 @@ sub observation_variable_ontologies {
     }
 
     #Using code pattern from SGN::Controller::AJAX::Onto->roots_GET
-    my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, dbxref.accession, dbxref.version, dbxref.description, cv.cv_id, cv.name, cv.definition FROM cvterm JOIN dbxref USING(dbxref_id) JOIN db USING(db_id) JOIN cv USING(cv_id) JOIN cvprop USING(cv_id) LEFT JOIN cvterm_relationship ON (cvterm.cvterm_id=cvterm_relationship.subject_id) WHERE cvterm_relationship.subject_id IS NULL AND is_obsolete= 0 AND is_relationshiptype = 0 and db.name=? $composable_cv_prop_sql;";
+    my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, dbxref.accession, dbxref.version, dbxref.description, cv.cv_id, cv.name, cv.definition FROM cvterm 
+    JOIN dbxref USING(dbxref_id) 
+    JOIN db USING(db_id) 
+    JOIN cv USING(cv_id) 
+    JOIN cvprop USING(cv_id) 
+    LEFT JOIN cvterm_relationship ON (cvterm.cvterm_id=cvterm_relationship.subject_id) 
+    WHERE cvterm_relationship.subject_id IS NULL AND is_obsolete= 0 AND is_relationshiptype = 0 and db.name=? $composable_cv_prop_sql;";
     my $sth = $self->bcs_schema->storage->dbh->prepare($q);
     foreach (@$name_spaces){
         $sth->execute($_);

--- a/lib/SGN/Controller/AJAX/Search/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Search/Trait.pm
@@ -22,11 +22,39 @@ sub search : Path('/ajax/search/traits') Args(0) {
     my $sp_person_id = $c->user() ? $c->user->get_object()->get_sp_person_id() : undef;    
     my $schema = $c->dbic_schema("Bio::Chado::Schema", undef, $sp_person_id);
     my $params = $c->req->params() || {};
-    #print STDERR Dumper $params;
 
-    my $ontology_db_ids;
+    my $ontology_db_ids = [];
     if ($params->{'ontology_db_id[]'}){
         $ontology_db_ids = ref($params->{'ontology_db_id[]'}) eq 'ARRAY' ? $params->{'ontology_db_id[]'} : [$params->{'ontology_db_id[]'}];
+    }
+
+    my $observation_variables = CXGN::BrAPI::v2::ObservationVariables->new({
+        bcs_schema => $c->dbic_schema("Bio::Chado::Schema", undef, $sp_person_id),
+        metadata_schema => $c->dbic_schema("CXGN::Metadata::Schema", undef, $sp_person_id),
+        phenome_schema=>$c->dbic_schema("CXGN::Phenome::Schema", undef, $sp_person_id),
+        people_schema => $c->dbic_schema("CXGN::People::Schema", undef, $sp_person_id),
+        page_size => 1000000,
+        page => 0,
+        status => [],
+        context => $c
+    });
+
+    my $name_spaces_str = $c->config->{onto_root_namespaces};
+    my @name_spaces_pairs = split(", ",$name_spaces_str);
+    my @name_spaces = map { s/ .*//r } @name_spaces_pairs;
+
+    my $result = $observation_variables->observation_variable_ontologies({
+        cvprop_type_names => ['trait_ontology', 'composed_trait_ontology'],
+        name_spaces => \@name_spaces
+    });
+
+    my @ontos;
+    if (scalar(@{$ontology_db_ids}) == 0) {
+        foreach my $o (@{$result->{result}->{data}}) {
+            push @ontos, $o->{ontologyDbId};
+        }
+    } else {
+        @ontos = @{$ontology_db_ids};
     }
 
     my $rows = $params->{length};
@@ -58,7 +86,7 @@ sub search : Path('/ajax/search/traits') Args(0) {
     my $trait_search = CXGN::Trait::Search->new({
         bcs_schema=>$schema,
 	    is_variable=>1,
-        ontology_db_id_list => $ontology_db_ids,
+        ontology_db_id_list => \@ontos,
         limit => $limit,
         offset => $offset,
         trait_name_list => $subset_traits,

--- a/lib/SGN/Controller/AJAX/Search/Treatment.pm
+++ b/lib/SGN/Controller/AJAX/Search/Treatment.pm
@@ -28,17 +28,25 @@ sub search : Path('/ajax/search/treatments') Args(0) {
         $ontology_db_ids = ref($params->{'ontology_db_id[]'}) eq 'ARRAY' ? $params->{'ontology_db_id[]'} : [$params->{'ontology_db_id[]'}];
     }
 
-    my $observation_variables = CXGN::BrAPI::v1::ObservationVariables->new({
+    my $observation_variables = CXGN::BrAPI::v2::ObservationVariables->new({
         bcs_schema => $c->dbic_schema("Bio::Chado::Schema", undef, $sp_person_id),
         metadata_schema => $c->dbic_schema("CXGN::Metadata::Schema", undef, $sp_person_id),
         phenome_schema=>$c->dbic_schema("CXGN::Phenome::Schema", undef, $sp_person_id),
         people_schema => $c->dbic_schema("CXGN::People::Schema", undef, $sp_person_id),
         page_size => 1000000,
         page => 0,
-        status => []
+        status => [],
+        context => $c
     });
 
-    my $result = $observation_variables->observation_variable_ontologies({cvprop_type_names => ['experiment_treatment_ontology', 'composed_experiment_treatment_ontology']});
+    my $name_spaces_str = $c->config->{onto_root_namespaces};
+    my @name_spaces_pairs = split(", ",$name_spaces_str);
+    my @name_spaces = map { s/ .*//r } @name_spaces_pairs;
+
+    my $result = $observation_variables->observation_variable_ontologies({
+        cvprop_type_names => ['experiment_treatment_ontology', 'composed_experiment_treatment_ontology'],
+        name_spaces => \@name_spaces
+    });
 
     my @ontos;
     if (scalar(@{$ontology_db_ids}) == 0) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes an issue where non trait ontologies show up in trait search. For this to work on dockerized servers, the onto_root_namespaces config key must be correctly set, including composed onto namespaces if they are to show up in the trait/treatment search.

<!-- If there are relevant issues, link them here: -->
Fixes #5968 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
