### PR TITLE
Remove requirement for finish logfile when retrieving existing job

### DIFF
--- a/js/source/legacy/solGS/analysisSelect.js
+++ b/js/source/legacy/solGS/analysisSelect.js
@@ -195,7 +195,7 @@ jQuery(document).ready(function () {
                     corrArgs["corr_table_file"] = res.corre_table_file;
                     var corrDownload = solGS.correlation.createCorrDownloadLink(corrArgs);
                     var heatmapArgs = {
-                      output_data: res.data,
+                      heatmap_input_data: res.data,
                       canvas: canvas,
                       plot_div_id: corrPlotDivId,
                       download_links: corrDownload,

--- a/js/source/legacy/solGS/correlation.js
+++ b/js/source/legacy/solGS/correlation.js
@@ -480,8 +480,8 @@ jQuery(document).ready(function () {
             corrArgs["corr_table_file"] = res.corre_table_file;    
             var corrDownload = solGS.correlation.createCorrDownloadLink(corrArgs);
             var heatmapArgs = {
-              input_data: res.input_data,
-              output_data: res.output_data,
+              scatter_input_data: res.corr_input_data,
+              heatmap_input_data: res.corr_output_data,
               canvas: canvas,
               plot_div_id: corrPlotDivId,
               download_links: corrDownload,
@@ -530,8 +530,8 @@ jQuery(document).ready(function () {
           args["corr_table_file"] = res.corre_table_file;
           var corrDownload = solGS.correlation.createCorrDownloadLink(args);
           var heatmapArgs = {
-            input_data: res.input_data,
-            output_data: res.output_data,
+            scatter_input_data: res.corr_input_data,
+            heatmap_input_data: res.corr_output_data,
             canvas: canvas,
             plot_div_id: corrPlotDivId,
             download_links: corrDownload,

--- a/js/source/legacy/solGS/heatMap.js
+++ b/js/source/legacy/solGS/heatMap.js
@@ -10,12 +10,11 @@ var solGS = solGS || function solGS() {};
 solGS.heatmap = {
 
   plot: function (heatmapArgs) {
-    var outputData = heatmapArgs.output_data;
-    var inputData = heatmapArgs.input_data;
+    var heatmapInputData = heatmapArgs.heatmap_input_data;
+    var scatterInputData = heatmapArgs.scatter_input_data;
     var heatmapCanvasDiv = heatmapArgs.canvas;
     var heatmapPlotDivId = heatmapArgs.plot_div_id;
     var downloadLinks = heatmapArgs.download_links;
-    var inputData = heatmapArgs.input_data;
     var axisMode = heatmapArgs.axis_mode || 2;
 
     if (heatmapCanvasDiv == null) {
@@ -52,20 +51,20 @@ solGS.heatmap = {
 
     
 
-    var parsedInputData = null;
-    if (inputData) { 
-        parsedInputData = JSON.parse(inputData);
+    var parsedScatterInputData = null;
+    if (scatterInputData) {
+        parsedScatterInputData = JSON.parse(scatterInputData);
     }
 
-    var parsedOutputData = null;
-    if (outputData) {
-        parsedOutputData = JSON.parse(outputData);
+    var parsedHeatmaprInputData = null;
+    if (heatmapInputData) {
+        parsedHeatmaprInputData = JSON.parse(heatmapInputData);
     } else {
-        alert(`The heatmap output data is missing: ${outputData}`);
+        alert(`The heatmap output data is missing: ${heatmapInputData}`);
         return;
     }
 
-    var nLabels = parsedOutputData.labels.length;
+    var nLabels = parsedHeatmaprInputData.labels.length;
 
     if (nLabels >= 100) {
       height = 600;
@@ -95,9 +94,9 @@ solGS.heatmap = {
     var corr = [];
     var coefs = [];
 
-    var labels = parsedOutputData.labels;
-    var values = parsedOutputData.values;
-    var pvalues = parsedOutputData.pvalues;
+    var labels = parsedHeatmaprInputData.labels;
+    var values = parsedHeatmaprInputData.values;
+    var pvalues = parsedHeatmaprInputData.pvalues;
 
     for (var i = 0; i < values.length; i++) {
       var rw = values[i];
@@ -268,7 +267,7 @@ solGS.heatmap = {
             .attr("dominant-baseline", "middle")
             .attr("text-anchor", "middle");
 
-          if (parsedInputData) {
+          if (parsedScatterInputData) {
             jQuery("#" + scatterPlotMsgDivId)
               .html("Scatter plot: " + rowLabel + " vs. " + colLabel)
               .show();
@@ -277,7 +276,7 @@ solGS.heatmap = {
             var yData = [];
 
             
-            jQuery.each(parsedInputData, function (sampleName, colValues) {
+            jQuery.each(parsedScatterInputData, function (sampleName, colValues) {
               if (!colValues) {
                 return true;
               }

--- a/js/source/legacy/solGS/kinship.js
+++ b/js/source/legacy/solGS/kinship.js
@@ -433,7 +433,7 @@ jQuery(document).ready(function () {
 
             var links = solGS.kinship.addDowloandLinks(res);
             var heatmapArgs = {
-              output_data: res.data,
+              heatmap_input_data: res.data,
               canvas: canvas,
               plot_div_id: kinshipPlotDivId,
               download_links: links,
@@ -496,7 +496,7 @@ jQuery(document).ready(function () {
 
                           var links = solGS.kinship.addDowloandLinks(res);
                           var heatmapArgs = {
-                            output_data: res.data,
+                            heatmap_input_data: res.data,
                             canvas: canvas,
                             plot_div_id: kinshipPlotDivId,
                             download_links: links,
@@ -573,7 +573,7 @@ jQuery(document).ready(function () {
 
           var links = solGS.kinship.addDowloandLinks(res);
           var heatMapArgs = {
-            output_data: res.data,
+            heatmap_input_data: res.data,
             canvas: canvas,
             plot_div_id: kinshipPlotDivId,
             download_links: links,

--- a/js/source/legacy/solGS/selectionIndex.js
+++ b/js/source/legacy/solGS/selectionIndex.js
@@ -381,10 +381,12 @@ jQuery(document).on("click", "#calculate_si", function () {
                 genArgs["corr_table_file"] = res.corre_table_file;
                 var corrDownload = solGS.correlation.createCorrDownloadLink(genArgs);
                 var heatmapArgs = {
-                  output_data: res.data,
+                  heatmap_input_data: res.corr_output_data,
+                  scatter_input_data: res.corr_input_data,
                   canvas: canvas,
                   plot_div_id: corrPlotDivId,
                   download_links: corrDownload,
+                  axis_mode: 'four'
                 };
 
                 solGS.heatmap.plot(heatmapArgs);

--- a/lib/CXGN/Job.pm
+++ b/lib/CXGN/Job.pm
@@ -221,11 +221,11 @@ has 'cmd' => (isa => 'Maybe[Str]', is => 'rw');
 
 =head2 logfile()
 
-The logfile used to store and retrieve finish timestamps. Required for object creation. 
+The logfile used to store and retrieve finish timestamps.
 
 =cut
 
-has 'finish_logfile' => (isa => 'Str', is => 'rw', predicate => 'has_finish_logfile', required => 1);
+has 'finish_logfile' => (isa => 'Maybe[Str]', is => 'rw', predicate => 'has_finish_logfile', required => 0);
 
 =head2 name()
 
@@ -253,11 +253,6 @@ sub BUILD {
 
     my $bcs_schema = $args->{schema};
     my $people_schema = $args->{people_schema};
-    my $logfile = $args->{finish_logfile};
-
-    if (!$logfile) {
-        die "finish_logfile is required for job creation.\n";
-    }
 
     if (!$self->has_sp_job_id()) { # New job, no ID yet.
         my $cv_rs = $bcs_schema->resultset("Cv::Cv")->find( { name => "job_type" } );
@@ -270,6 +265,9 @@ sub BUILD {
                 name => $self->job_type(),
                 cv_id => $cv_id
             });
+        }
+        if (!$self->has_finish_logfile()) {
+            die "Need a finish logfile to create new jobs.";
         }
         $self->create_timestamp(DateTime->now(time_zone => 'local')->strftime('%Y-%m-%d %H:%M:%S'));
         if (!$self->has_cxgn_tools_run_config()) {
@@ -297,6 +295,8 @@ sub BUILD {
         $self->additional_args($job_args->{additional_args});
         $self->cxgn_tools_run_config($job_args->{cxgn_tools_run_config});
         $self->cmd($job_args->{cmd});
+        my $logfile = $job_args->{finish_logfile};
+        $self->finish_logfile($logfile);
     }
 }
 
@@ -726,7 +726,7 @@ sub alive {
 
 =head1 CLASS METHODS
 
-=head2 get_user_submitted_jobs(bcs_schema, people_schema, user_id)
+=head2 get_user_submitted_jobs(bcs_schema, people_schema, user_id, user_role)
 
 Returns a listref of sp_job_ids submitted by the given user id
 

--- a/lib/SGN/Controller/solGS/Correlation.pm
+++ b/lib/SGN/Controller/solGS/Correlation.pm
@@ -52,8 +52,8 @@ sub pheno_correlation_analysis :Path('/phenotypic/correlation/analysis') Args(0)
     
     if (-s $corre_json_file) {
         $ret->{status}   = 'success';
-        $ret->{output_data}     = read_file($corre_json_file, {binmode => ':utf8'});
-        $ret->{input_data} = read_file($corre_input_data_json_file, {binmode => ':utf8'});
+        $ret->{corr_output_data}     = read_file($corre_json_file, {binmode => ':utf8'});
+        $ret->{corr_input_data} = read_file($corre_input_data_json_file, {binmode => ':utf8'});
         $ret->{corre_table_file} = $self->download_pheno_correlation_file($c);
     }
 
@@ -97,8 +97,8 @@ sub genetic_correlation_analysis :Path('/genetic/correlation/analysis') Args() {
 
     if (-s $corre_json_file) {
         $ret->{status}   = 'success';
-        $ret->{output_data} = read_file($corre_json_file, {binmode => ':utf8'});
-        $ret->{input_data} = read_file($corre_input_data_json_file, {binmode => ':utf8'});
+        $ret->{corr_output_data} = read_file($corre_json_file, {binmode => ':utf8'});
+        $ret->{corr_input_data} = read_file($corre_input_data_json_file, {binmode => ':utf8'});
         $ret->{corre_table_file} = $self->download_genetic_correlation_file($c);
     } 
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
The requirement to supply the job_finish_log config key would lead to errors when trying to use class methods to delete jobs that already existed. This changes it so that job objects can be created from sp_job_id without supplying the logfile

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
