### PR TITLE
fix wizard stuck updating

### DIFF
--- a/bin/refresh_materialized_markerview.pl
+++ b/bin/refresh_materialized_markerview.pl
@@ -28,15 +28,16 @@ use strict;
 use warnings;
 use Getopt::Std;
 use DBI;
+use Try::Tiny;
 
 our ($opt_H, $opt_D, $opt_U, $opt_P);
 getopts('H:D:U:P:');
 
 print STDERR "Connecting to database...\n";
 my $dsn = 'dbi:Pg:database='.$opt_D.";host=".$opt_H.";port=5432";
-my $dbh = DBI->connect($dsn, $opt_U, $opt_P);
+my $dbh = DBI->connect($dsn, $opt_U, $opt_P, { RaiseError => 1, AutoCommit=>1 });
 
-eval {
+try {
     print STDERR "Refreshing materialized_markerview . . . " . localtime() . "\n";
 
     my $q = "SELECT public.create_materialized_markerview(true);";
@@ -44,11 +45,10 @@ eval {
     $h->execute();
     
     print STDERR "materialized_markerview refreshed! " . localtime() . "\n";
-};
-
-if ($@) {
-  $dbh->rollback();
-  print STDERR $@;
-} else {
-  print STDERR "Done, exiting refresh_matviews.pl \n";
 }
+catch {
+    print STDERR "Refresh failed: $_";
+};
+$dbh->disconnect();
+
+print STDERR "Done, exiting refresh_materialized_markerview.pl \n";

--- a/bin/refresh_materialized_markerview.pl
+++ b/bin/refresh_materialized_markerview.pl
@@ -37,7 +37,14 @@ print STDERR "Connecting to database...\n";
 my $dsn = 'dbi:Pg:database='.$opt_D.";host=".$opt_H.";port=5432";
 my $dbh = DBI->connect($dsn, $opt_U, $opt_P, { RaiseError => 1, AutoCommit=>1 });
 
+my $lock_acquired = 0;
+
 try {
+    # Prevent concurrent runs
+    my ($got_lock) = $dbh->selectrow_array("SELECT pg_try_advisory_lock(12345)");
+    die "Another instance is already running\n" unless $got_lock;
+    $lock_acquired = 1;
+    
     print STDERR "Refreshing materialized_markerview . . . " . localtime() . "\n";
 
     my $q = "SELECT public.create_materialized_markerview(true);";
@@ -48,7 +55,10 @@ try {
 }
 catch {
     print STDERR "Refresh failed: $_";
+}
+finally {
+    $dbh->selectrow_array("SELECT pg_advisory_unlock(12345)") if $lock_acquired;
+    $dbh->disconnect();
 };
-$dbh->disconnect();
 
 print STDERR "Done, exiting refresh_materialized_markerview.pl \n";

--- a/bin/refresh_matviews.pl
+++ b/bin/refresh_matviews.pl
@@ -45,7 +45,6 @@ GetOptions(
     'dbhost|H=s' => \$dbhost,
 );
 
-
 unless ($mode =~ m/^(fullview|stockprop|phenotypes|all_but_genoview)$/ ) { die "Option -m must be fullview, stockprop, phenotypes, or all_but_genoview. -m  = $mode\n"; }
 
 print STDERR "Connecting to database...\n";
@@ -67,12 +66,17 @@ if ($mode eq 'all_but_genoview') {
 #set TRUE before the transaction begins
 my $state = 'TRUE';
 my $refresh_failed = 0;
+my $lock_acquired = 0;
 print STDERR "*Setting currently_refreshing = TRUE\n";
 my $cur_refreshing_h = $dbh->prepare($cur_refreshing_q);
 $cur_refreshing_h->execute($state);
 $dbh->commit();
 
 try {
+    my ($got_lock) = $dbh->selectrow_array("SELECT pg_try_advisory_lock(67895)");
+    die "Another instance is already running\n" unless $got_lock;
+    $lock_acquired = 1;
+
     print STDERR "Refreshing materialized views . . ." . localtime() . "\n";
     my @mv_names = ();
 
@@ -100,17 +104,19 @@ catch {
     $dbh->rollback();
 }
 finally {
+    $dbh->selectrow_array("SELECT pg_advisory_unlock(12345)") if $lock_acquired;
+    if ($lock_acquired) {  # only reset flag if we actually started
+        my $done_h = $dbh->prepare($cur_refreshing_q);
+        print STDERR "*Setting currently_refreshing = FALSE\n";
+        $done_h->execute('FALSE');
+        $dbh->commit();
+    }
     if ($refresh_failed) {
 	print STDERR "Refresh did not complete. Changes rolled back.\n";
     } else {
         print STDERR "COMMITTING\n";
         $dbh->commit();
     }
-    #always set the refreshing status to FALSE at the end
-    my $done_h = $dbh->prepare($cur_refreshing_q);
-    print STDERR "*Setting currently_refreshing = FALSE \n";
-    $done_h->execute('FALSE');
-    $dbh->commit();
 };
 
 sub refresh_mvs {

--- a/bin/refresh_matviews.pl
+++ b/bin/refresh_matviews.pl
@@ -64,19 +64,20 @@ if ($mode eq 'all_but_genoview') {
 }
     
 #set TRUE before the transaction begins
-my $state = 'TRUE';
 my $refresh_failed = 0;
 my $lock_acquired = 0;
-print STDERR "*Setting currently_refreshing = TRUE\n";
-my $cur_refreshing_h = $dbh->prepare($cur_refreshing_q);
-$cur_refreshing_h->execute($state);
-$dbh->commit();
+my $status;
 
 try {
     my ($got_lock) = $dbh->selectrow_array("SELECT pg_try_advisory_lock(67895)");
     print STDERR "Another instance is already running\n" unless $got_lock;
     die "Another instance is already running\n" unless $got_lock;
     $lock_acquired = 1;
+
+    print STDERR "*Setting currently_refreshing = TRUE\n";
+    my $cur_refreshing_h = $dbh->prepare($cur_refreshing_q);
+    $cur_refreshing_h->execute('TRUE');
+    $dbh->commit();
 
     print STDERR "Refreshing materialized views . . ." . localtime() . "\n";
     my @mv_names = ();
@@ -93,10 +94,13 @@ try {
     if ($mode eq 'all_but_genoview') {
        @mv_names = ("materialized_stockprop", "materialized_phenoview", "materialized_phenotype_jsonb_table");
     }
-
-    my $status = refresh_mvs($dbh, $auto_dbh, \@mv_names, $concurrent);
-
-    if ($test) { die "TEST MODE\n"; }
+    if ($test) {
+	$status = test_mvs($dbh, \@mv_names);
+	print STDERR "TEST MODE - rolling back refresh work.\n";
+        $dbh->rollback();
+    } else {
+        $status = refresh_mvs($dbh, $auto_dbh, \@mv_names, $concurrent);
+    }
 }
 catch {
     $refresh_failed = 1;
@@ -105,18 +109,17 @@ catch {
     $dbh->rollback();
 }
 finally {
-    $dbh->selectrow_array("SELECT pg_advisory_unlock(67895)") if $lock_acquired;
-    if ($lock_acquired) {  # only reset flag if we actually started
+    if ($lock_acquired) {
         my $done_h = $dbh->prepare($cur_refreshing_q);
         print STDERR "*Setting currently_refreshing = FALSE\n";
         $done_h->execute('FALSE');
         $dbh->commit();
+        $dbh->selectrow_array("SELECT pg_advisory_unlock(67895)");
     }
     if ($refresh_failed) {
-	print STDERR "Refresh did not complete. Changes rolled back.\n";
+	print STDERR "Refresh did not complete cleanly.\n";
     } else {
         print STDERR "COMMITTING\n";
-        $dbh->commit();
     }
 };
 
@@ -160,3 +163,28 @@ sub refresh_mvs {
     }
     return $status;
 }
+
+sub test_mvs {
+    my $dbh = shift;
+    my $mv_names_ref = shift;
+    my $end_h;
+    my $start_q = "UPDATE matviews SET refresh_start = statement_timestamp() where mv_name = ?";
+    my $end_q =   "UPDATE matviews SET  last_refresh = statement_timestamp() where mv_name = ? ";
+    my $refresh_q = "REFRESH MATERIALIZED VIEW ";
+    my $refresh_h;
+    my $status;
+
+    foreach my $name ( @$mv_names_ref ) {
+        print STDERR "**Refreshing view $name ". localtime() . " \n";
+        print STDERR "**QUERY = " . $refresh_q . $name . "\n";
+        my $start_h = $dbh->prepare($start_q);
+        $start_h->execute($name);
+        $refresh_h = $dbh->prepare($refresh_q . $name) ;
+        $status = $refresh_h->execute();
+        $end_h = $dbh->prepare($end_q);
+        $end_h->execute($name);
+        print STDERR "Materialized view $name refreshed! Status: $status " . localtime() . "\n\n";
+    }
+    return $status;
+}
+

--- a/bin/refresh_matviews.pl
+++ b/bin/refresh_matviews.pl
@@ -74,6 +74,7 @@ $dbh->commit();
 
 try {
     my ($got_lock) = $dbh->selectrow_array("SELECT pg_try_advisory_lock(67895)");
+    print STDERR "Another instance is already running\n" unless $got_lock;
     die "Another instance is already running\n" unless $got_lock;
     $lock_acquired = 1;
 
@@ -104,7 +105,7 @@ catch {
     $dbh->rollback();
 }
 finally {
-    $dbh->selectrow_array("SELECT pg_advisory_unlock(12345)") if $lock_acquired;
+    $dbh->selectrow_array("SELECT pg_advisory_unlock(67895)") if $lock_acquired;
     if ($lock_acquired) {  # only reset flag if we actually started
         my $done_h = $dbh->prepare($cur_refreshing_q);
         print STDERR "*Setting currently_refreshing = FALSE\n";

--- a/bin/refresh_matviews.pl
+++ b/bin/refresh_matviews.pl
@@ -51,6 +51,7 @@ unless ($mode =~ m/^(fullview|stockprop|phenotypes|all_but_genoview)$/ ) { die "
 print STDERR "Connecting to database...\n";
 my $dsn = 'dbi:Pg:database='.$dbname.";host=".$dbhost.";port=5432";
 my $dbh = DBI->connect($dsn, $username, $password, { RaiseError => 1, AutoCommit=>0 });
+my $auto_dbh = DBI->connect($dsn, $username, $password, { RaiseError => 1, AutoCommit=>1 });
 
 my $cur_refreshing_q =  "UPDATE public.matviews SET currently_refreshing=?";
 if ($mode eq 'stockprop'){
@@ -65,6 +66,7 @@ if ($mode eq 'all_but_genoview') {
     
 #set TRUE before the transaction begins
 my $state = 'TRUE';
+my $refresh_failed = 0;
 print STDERR "*Setting currently_refreshing = TRUE\n";
 my $cur_refreshing_h = $dbh->prepare($cur_refreshing_q);
 $cur_refreshing_h->execute($state);
@@ -87,53 +89,67 @@ try {
        @mv_names = ("materialized_stockprop", "materialized_phenoview", "materialized_phenotype_jsonb_table");
     }
 
-    my $status = refresh_mvs($dbh, \@mv_names, $concurrent);
+    my $status = refresh_mvs($dbh, $auto_dbh, \@mv_names, $concurrent);
 
-    #rollback if running in test mode
-    if ($test) { die ; }
+    if ($test) { die "TEST MODE\n"; }
 }
 catch {
-    warn "Refresh failed: @_";
-    if ($test ) { print STDERR "TEST MODE\n" ; }
-    $dbh->rollback()
+    $refresh_failed = 1;
+    warn "Refresh failed: $_";
+    if ($test) { print STDERR "TEST MODE - rolling back.\n"; }
+    $dbh->rollback();
 }
 finally {
-    if (@_) {
-        print "The try block died. Rolling back.\n";
+    if ($refresh_failed) {
+	print STDERR "Refresh did not complete. Changes rolled back.\n";
     } else {
         print STDERR "COMMITTING\n";
         $dbh->commit();
     }
     #always set the refreshing status to FALSE at the end
-    $state = 'FALSE';
     my $done_h = $dbh->prepare($cur_refreshing_q);
     print STDERR "*Setting currently_refreshing = FALSE \n";
-    $done_h->execute($state);
+    $done_h->execute('FALSE');
     $dbh->commit();
 };
 
 sub refresh_mvs {
     my $dbh = shift;
+    my $auto_dbh = shift;
     my $mv_names_ref = shift;
-    $concurrent = shift;
+    my $concurrent = shift;
+    my $end_h;
     my $start_q = "UPDATE matviews SET refresh_start = statement_timestamp() where mv_name = ?";
     my $end_q =   "UPDATE matviews SET  last_refresh = statement_timestamp() where mv_name = ? ";
     my $refresh_q = "REFRESH MATERIALIZED VIEW ";
+    my $refresh_h;
     if ($concurrent) { $refresh_q .= " CONCURRENTLY "; }
     my $status;
 
+    # increase work_mem to avoid out of space error while refreshing
+    # $auto_dbh->prepare("SET work_mem = '256MB'")->execute();
     foreach my $name ( @$mv_names_ref ) {
         print STDERR "**Refreshing view $name ". localtime() . " \n";
-        my $start_h = $dbh->prepare($start_q);
-        $start_h->execute($name);
         print STDERR "**QUERY = " . $refresh_q . $name . "\n";
-        my $refresh_h = $dbh->prepare($refresh_q . $name) ;
-        $status = $refresh_h->execute();
-
+	if ($concurrent) {
+	    my $start_h = $dbh->prepare($start_q);
+            $start_h->execute($name);
+	    $dbh->commit();
+	    $refresh_h = $auto_dbh->prepare($refresh_q . $name);
+	    $status = $refresh_h->execute();
+	    $end_h = $dbh->prepare($end_q);
+	    $end_h->execute($name);
+	    $dbh->commit();
+        } else {
+	    my $start_h = $dbh->prepare($start_q);
+            $start_h->execute($name);
+	    $refresh_h = $auto_dbh->prepare($refresh_q . $name) ;
+	    $status = $refresh_h->execute();
+	    $end_h = $dbh->prepare($end_q);
+	    $end_h->execute($name);
+	    $dbh->commit();
+	}
         print STDERR "Materialized view $name refreshed! Status: $status " . localtime() . "\n\n";
-
-        my $end_h = $dbh->prepare($end_q);
-        $end_h->execute($name);
     }
     return $status;
 }


### PR DESCRIPTION
wizard stuck in updating state may be caused by loading data while there is a materialized view update in process

Improves error handling during materialized view refresh
uses pg_advisory_lock to prevent execution if there is a currently running update
improves logic when updating "currently_refreshing" in database

closes #6025 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
