### PR TITLE
set allow_trait_edits to 1 in sgn.conf 

### DIFF
--- a/sgn.conf
+++ b/sgn.conf
@@ -41,7 +41,7 @@ trait_ontology_cvterm_name Solanaceae trait ontology
 # For displaying ontologies in Ontology Browser
 onto_root_namespaces  GO (Gene Ontology), PO (Plant Ontology), SO (Sequence Ontology), PATO (Phenotype and Trait Ontology), SP (Solanaceae Ontology), UO (Units), CASSTISS (Cass tissues)
 
-allow_trait_edits 0
+allow_trait_edits 1
 allow_treatment_edits 0
 # Marker Metadata Trait Categories
 # Set the DB:Accession of the root term of the ontology used to define trait categories for marker metadata


### PR DESCRIPTION
variable attributes have traditionally been editable by curators, but it was changed in a recent pull request. This changes it back to allowing curators to edit the attributes.

Fixes #6031.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
