### PR TITLE
Marker Metadata Improvements

### DIFF
--- a/lib/CXGN/Genotype/ParseUpload.pm
+++ b/lib/CXGN/Genotype/ParseUpload.pm
@@ -68,6 +68,14 @@ has 'parse_errors' => (
     predicate => 'has_parse_errors',
 );
 
+has 'parse_warnings' => (
+    is => 'ro',
+    isa => 'HashRef',
+    writer => '_set_parse_warnings',
+    reader => 'get_parse_warnings',
+    predicate => 'has_parse_warnings',
+);
+
 has '_parsed_data' => (
     is => 'ro',
     isa => 'HashRef',

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
@@ -40,7 +40,7 @@ sub _validate_with_plugin {
     my $parsed_data = $parsed->{data};
 
     my @markers = @{$parsed->{values}->{'Marker'}};
-    my @aliases = @{$parsed->{values}->{'Alias'}};
+    my @aliases = @{$parsed->{values}->{'Alias'} || []};
     my @alleles = @{$parsed->{values}->{'Allele'}};
     my @categories = @{$parsed->{values}->{'Category'} || []};
     my @references = @{$parsed->{values}->{'Reference'} || []};

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
@@ -17,7 +17,9 @@ sub _validate_with_plugin {
     my $dbh = $schema->storage->dbh();
     my $onto = CXGN::Onto->new({ schema => $schema });
     my %errors;
+    my %warnings;
     my @error_messages;
+    my @warning_messages;
 
     ## Parse the upload file
     my $parser = CXGN::File::Parse->new(
@@ -63,31 +65,83 @@ sub _validate_with_plugin {
         }
     }
 
-    # Make sure the markers don't already exist in the phenome.locus table
-    my @locus_names = (@markers, @aliases);
-    my $phs = join ',', map { "?" } @locus_names;
-    my $q = "SELECT locus_name FROM phenome.locus WHERE locus_name IN ($phs)";
+    # Get names of markers and aliases from the upload file
+    my @file_locus_names = (@markers, @aliases);
+    my $phs = join ',', map { "?" } @file_locus_names;
+
+    # Return a warning for locus names that already exist and are associated with this protocol
+    my $q = "SELECT locus_name, locus_id FROM phenome.locus WHERE locus_name IN ($phs) AND locus_id IN (SELECT locus_id FROM phenome.locus_geno_marker WHERE nd_protocol_id = ?)";
     my $h = $dbh->prepare($q);
-    $h->execute(@locus_names);
-    my @existing_loci;
-    while (my ($locus_name) = $h->fetchrow_array()) {
-        push @existing_loci, $locus_name;
+    $h->execute(@file_locus_names, $protocol_id);
+    my @existing_protocol_locus_names;
+    my @existing_protocol_locus_ids;
+    while (my ($locus_name, $locus_id) = $h->fetchrow_array()) {
+        push @existing_protocol_locus_names, $locus_name;
+        push @existing_protocol_locus_ids, $locus_id;
     }
-    if ( scalar @existing_loci > 0 ) {
-        push @error_messages, "The following markers already exist in the Locus table: " . join(', ', sort @existing_loci);
+    if ( scalar @existing_protocol_locus_names > 0 ) {
+        push @warning_messages, "The following markers already exist in the Locus table and are associated with this protocol: " . join(', ', sort @existing_protocol_locus_names) . ".  You can replace the existing metadata with the information in your file by selecting the 'ignore warnings' option.";
+    }
+    $parsed->{existing_locus_names} = \@existing_protocol_locus_names;
+    $parsed->{existing_locus_ids} = \@existing_protocol_locus_ids;
+
+    # Make sure the markers don't already exist in the phenome.locus table
+    $q = "SELECT locus_name FROM phenome.locus WHERE locus_name IN ($phs)";
+    if ( scalar @existing_protocol_locus_names > 0 ) {
+        $phs = join ',', map { "?" } @existing_protocol_locus_names;
+        $q .= " AND locus_name NOT IN ($phs)";
+    }
+    $h = $dbh->prepare($q);
+    if ( scalar @existing_protocol_locus_names > 0 ) {
+        $h->execute(@file_locus_names, @existing_protocol_locus_names);
+    }
+    else {
+        $h->execute(@file_locus_names);
+    }
+    my @existing_global_locus_names;
+    while (my ($locus_name) = $h->fetchrow_array()) {
+        push @existing_global_locus_names, $locus_name;
+    }
+    if ( scalar @existing_global_locus_names > 0 ) {
+        push @error_messages, "The following markers already exist in the Locus table outside of this protocol: " . join(', ', sort @existing_global_locus_names) . ". These locus names cannot be used.";
     }
 
-    # Make sure the allele values don't already exist in the phenome.allele table
+    # Return a warning for allele names that already exist and are associated with this protocol
     $phs = join ',', map { "?" } @alleles;
-    $q = "SELECT allele_name FROM phenome.allele WHERE allele_name in ($phs)";
+    $q = "SELECT allele_symbol, allele_id FROM phenome.allele WHERE allele_symbol IN ($phs) AND locus_id IN (SELECT locus_id FROM phenome.locus_geno_marker WHERE nd_protocol_id = ?)";
     $h = $dbh->prepare($q);
-    $h->execute(@alleles);
-    my @existing_alleles;
-    while ( my ($allele_name) = $h->fetchrow_array()) {
-        push @existing_alleles, $allele_name;
+    $h->execute(@alleles, $protocol_id);
+    my @existing_protocol_allele_names;
+    my @existing_protocol_allele_ids;
+    while (my ($allele_name, $allele_id) = $h->fetchrow_array()) {
+        push @existing_protocol_allele_names, $allele_name;
+        push @existing_protocol_allele_ids, $allele_id;
     }
-    if ( scalar @existing_alleles > 0 ) {
-        push @error_messages, "The following alleles already exist in the Allele table: " . join(', ', sort @existing_alleles);
+    if ( scalar @existing_protocol_allele_names > 0 ) {
+        push @warning_messages, "The following alleles already exist in the Allele table and are associated with this protocol: " . join(', ', sort @existing_protocol_allele_names) . ".  You can replace the existing metadata with the information in your file by selecting the 'ignore warnings' option.";
+    }
+    $parsed->{existing_allele_names} = \@existing_protocol_allele_names;
+    $parsed->{existing_allele_ids} = \@existing_protocol_allele_ids;
+
+    # Make sure the allele values don't already exist in the phenome.allele table
+    $q = "SELECT allele_symbol FROM phenome.allele WHERE allele_symbol in ($phs)";
+    if ( scalar @existing_protocol_allele_names > 0 ) {
+            $phs = join ',', map { "?" } @existing_protocol_allele_names;
+            $q .= " AND allele_symbol NOT IN ($phs)";
+    }
+    $h = $dbh->prepare($q);
+    if ( scalar @existing_protocol_allele_names > 0 ) {
+        $h->execute(@alleles, @existing_protocol_allele_names);
+    }
+    else {
+        $h->execute(@alleles);
+    }
+    my @existing_global_allele_names;
+    while ( my ($allele_name) = $h->fetchrow_array()) {
+        push @existing_global_allele_names, $allele_name;
+    }
+    if ( scalar @existing_global_allele_names > 0 ) {
+        push @error_messages, "The following alleles already exist in the Allele table outside of this protocol: " . join(', ', sort @existing_global_allele_names) . ". These names cannot be used.";
     }
 
     # Parse each row to get unique marker and allele counts
@@ -206,6 +260,12 @@ sub _validate_with_plugin {
         return;
     }
 
+    # set warning messages
+    if (scalar(@warning_messages) >= 1) {
+        $warnings{'warning_messages'} = \@warning_messages;
+        $self->_set_parse_warnings(\%warnings);
+    }
+
     # Cache parsed allele data
     $self->parsed_allele_data($parsed);
 
@@ -287,7 +347,13 @@ sub _parse_with_plugin {
     }
 
     # Set parsed data
-    $self->_set_parsed_data(\%marker_metadata);
+    $self->_set_parsed_data({
+        markers => \%marker_metadata,
+        existing_locus_names => $parsed->{existing_locus_names},
+        existing_locus_ids => $parsed->{existing_locus_ids},
+        existing_allele_names => $parsed->{existing_allele_names},
+        existing_allele_ids => $parsed->{existing_allele_ids}
+    });
 }
 
 1;

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
@@ -224,7 +224,7 @@ sub _validate_with_plugin {
     # Extract the db names from the references
     my %db_names;
     foreach my $reference (@references) {
-        my ($db_name, $entity_name) = split('=', $reference);
+        my ($db_name, $entity_name) = split(':', $reference);
         $db_name =~ s/^\s+|\s+$//g;
         $db_names{lc $db_name} = $db_name;
     }

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
@@ -38,6 +38,7 @@ sub _validate_with_plugin {
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{errors};
     my $parsed_data = $parsed->{data};
+
     my @markers = @{$parsed->{values}->{'Marker'}};
     my @aliases = @{$parsed->{values}->{'Alias'}};
     my @alleles = @{$parsed->{values}->{'Allele'}};
@@ -327,7 +328,7 @@ sub _parse_with_plugin {
         # add references (hash of db id and entity name)
         my @references;
         foreach my $ref (@$reference_values) {
-            my ($db_name, $entity_name) = split('=', $ref);
+            my ($db_name, $entity_name) = split(':', $ref);
             $db_name =~ s/^\s+|\s+$//g;
             $entity_name =~ s/^\s+|\s+$//g;
             my $db_id = $existing_dbs->{lc $db_name};

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
@@ -186,7 +186,6 @@ sub _validate_with_plugin {
 
     # Check the trait categories against the ontology terms
     else {
-        my $ontology_root = $self->{marker_metadata_trait_ontology_root};
 
         # Get cvterm of root term
         my ($db_name, $accession) = split ":", $self->{marker_metadata_trait_ontology_root};

--- a/lib/CXGN/Genotype/Protocol.pm
+++ b/lib/CXGN/Genotype/Protocol.pm
@@ -599,13 +599,15 @@ sub set_marker_metadata {
 
         # Add each allele value for the locus
         foreach my $av (@$allele_values) {
-            my $av_symbol = $av;
-            $locus_obj->create_related('alleles', {
-                allele_name => $av,
-                allele_symbol => $av_symbol,
-                sp_person_id => $sp_person_id,
-                is_default => 0
-            });
+            if ( defined $av && $av ne '' ) {
+                my $av_symbol = $av;
+                $locus_obj->create_related('alleles', {
+                    allele_name => $av,
+                    allele_symbol => $av_symbol,
+                    sp_person_id => $sp_person_id,
+                    is_default => 0
+                });
+            }
         }
 
         # Add the Locus / Marker link
@@ -627,13 +629,14 @@ sub get_marker_metadata {
     my $dbh = $schema->storage->dbh();
     my $protocol_id = $self->nd_protocol_id;
 
-    my $q = "SELECT nd_protocol_id, locus.locus_id, locus.locus_name, marker_name, locus.description, allele.allele_id, allele_name, db.name, db.urlprefix, db.url, dbxref.accession ";
+    my $q = "SELECT nd_protocol_id, locus.locus_id, locus.locus_name, marker_name, locus.description, allele.allele_id, allele_name, db.name, db.urlprefix, db.url, dbxref.accession, cvterm.cvterm_id, cvterm.name ";
     $q .= "FROM phenome.locus_geno_marker ";
     $q .= "LEFT JOIN phenome.locus ON (locus_geno_marker.locus_id = locus.locus_id) ";
     $q .= "LEFT JOIN phenome.allele ON (allele.locus_id = locus.locus_id) ";
     $q .= "LEFT JOIN phenome.locus_dbxref ON (locus.locus_id = locus_dbxref.locus_id) ";
     $q .= "LEFT JOIN public.dbxref ON (locus_dbxref.dbxref_id = dbxref.dbxref_id) ";
     $q .= "LEFT JOIN public.db ON (dbxref.db_id = db.db_id) ";
+    $q .= "LEFT JOIN public.cvterm ON (dbxref.dbxref_id = cvterm.dbxref_id) ";
     $q .= "WHERE nd_protocol_id = ? ";
     $q .= "AND marker_name = ?" if $marker_name;
 
@@ -648,7 +651,7 @@ sub get_marker_metadata {
     my %metadata;
     my %seen_alleles;
     my %seen_references;
-    while (my ($nd_protocol_id, $locus_id, $locus_name, $marker_name, $locus_description, $allele_id, $allele_name, $db_name, $db_urlprefix, $db_url, $dbxref_accession) = $sth->fetchrow_array()) {
+    while (my ($nd_protocol_id, $locus_id, $locus_name, $marker_name, $locus_description, $allele_id, $allele_name, $db_name, $db_urlprefix, $db_url, $dbxref_accession, $cvterm_id, $cvterm_name) = $sth->fetchrow_array()) {
         if ( ! exists($metadata{$locus_name}) ) {
             $metadata{$locus_name} = {
                 nd_protocol_id => $nd_protocol_id,
@@ -672,11 +675,19 @@ sub get_marker_metadata {
         if ( defined $db_name && defined $dbxref_accession ) {
             my $refkey = "$db_name:$dbxref_accession";
             if ( !exists $seen_references{$locus_name}->{$refkey} ) {
-                my $url = defined $db_urlprefix && defined $db_url ? "$db_urlprefix$db_url$dbxref_accession" : undef;
+                my $url;
+                if ( defined $db_urlprefix && defined $db_url ) {
+                    $url = $db_urlprefix. $db_url . $dbxref_accession;
+                }
+                elsif ( defined $cvterm_id ) {
+                    $url = "/cvterm/$cvterm_id/view";
+                }
                 push @{$metadata{$locus_name}->{'references'}}, { 
                     db_name => $db_name,
                     dbxref_accession => $dbxref_accession,
-                    url => $url
+                    url => $url,
+                    cvterm_id => $cvterm_id,
+                    cvterm_name => $cvterm_name
                 };
                 $seen_references{$locus_name}->{$refkey} = 1;
             }

--- a/lib/CXGN/Genotype/Protocol.pm
+++ b/lib/CXGN/Genotype/Protocol.pm
@@ -627,10 +627,13 @@ sub get_marker_metadata {
     my $dbh = $schema->storage->dbh();
     my $protocol_id = $self->nd_protocol_id;
 
-    my $q = "SELECT nd_protocol_id, locus.locus_id, locus.locus_name, marker_name, locus.description, allele.allele_id, allele_name ";
+    my $q = "SELECT nd_protocol_id, locus.locus_id, locus.locus_name, marker_name, locus.description, allele.allele_id, allele_name, db.name, db.urlprefix, db.url, dbxref.accession ";
     $q .= "FROM phenome.locus_geno_marker ";
     $q .= "LEFT JOIN phenome.locus ON (locus_geno_marker.locus_id = locus.locus_id) ";
     $q .= "LEFT JOIN phenome.allele ON (allele.locus_id = locus.locus_id) ";
+    $q .= "LEFT JOIN phenome.locus_dbxref ON (locus.locus_id = locus_dbxref.locus_id) ";
+    $q .= "LEFT JOIN public.dbxref ON (locus_dbxref.dbxref_id = dbxref.dbxref_id) ";
+    $q .= "LEFT JOIN public.db ON (dbxref.db_id = db.db_id) ";
     $q .= "WHERE nd_protocol_id = ? ";
     $q .= "AND marker_name = ?" if $marker_name;
 
@@ -642,26 +645,45 @@ sub get_marker_metadata {
         $sth->execute($protocol_id);
     }
 
-    my %alleles;
-    while (my ($nd_protocol_id, $locus_id, $locus_name, $marker_name, $locus_description, $allele_id, $allele_name) = $sth->fetchrow_array()) {
-        if ( ! exists($alleles{$locus_name}) ) {
-            $alleles{$locus_name} = {
+    my %metadata;
+    my %seen_alleles;
+    my %seen_references;
+    while (my ($nd_protocol_id, $locus_id, $locus_name, $marker_name, $locus_description, $allele_id, $allele_name, $db_name, $db_urlprefix, $db_url, $dbxref_accession) = $sth->fetchrow_array()) {
+        if ( ! exists($metadata{$locus_name}) ) {
+            $metadata{$locus_name} = {
                 nd_protocol_id => $nd_protocol_id,
                 locus_id => $locus_id,
                 locus_name => $locus_name,
                 marker_name => $marker_name,
                 locus_description => $locus_description,
-                alleles => []
+                alleles => [],
+                references => [],
             };
         }
 
-        push @{$alleles{$locus_name}->{'alleles'}}, { 
-            allele_id => $allele_id,
-            allele_name => $allele_name
-        };
+        if ( !exists $seen_alleles{$locus_name}->{$allele_name} ) {
+            push @{$metadata{$locus_name}->{'alleles'}}, { 
+                allele_id => $allele_id,
+                allele_name => $allele_name
+            };
+            $seen_alleles{$locus_name}->{$allele_name} = 1;
+        }
+
+        if ( defined $db_name && defined $dbxref_accession ) {
+            my $refkey = "$db_name:$dbxref_accession";
+            if ( !exists $seen_references{$locus_name}->{$refkey} ) {
+                my $url = defined $db_urlprefix && defined $db_url ? "$db_urlprefix$db_url$dbxref_accession" : undef;
+                push @{$metadata{$locus_name}->{'references'}}, { 
+                    db_name => $db_name,
+                    dbxref_accession => $dbxref_accession,
+                    url => $url
+                };
+                $seen_references{$locus_name}->{$refkey} = 1;
+            }
+        }
     }
 
-    return \%alleles;
+    return \%metadata;
 }
 
 #

--- a/lib/CXGN/Genotype/Protocol.pm
+++ b/lib/CXGN/Genotype/Protocol.pm
@@ -470,9 +470,10 @@ sub set_description {
 
 #
 # Add metadata and alleles the markers in this protocol
-# @param param_data = a hashref of marker metadata,
-#   where the key is the marker/locus name
-#   and the value is a hashref of marker details (marker, alias, description, categories, references, alleles)
+# @param parsed_data = parsed data from the marker metadata upload plugin, a hashref of:
+#   markers = marker metadata, where the key is the marker/locus name and the value is a hashref of marker details (marker, alias, description, categories, references, alleles)
+#   existing_locus_ids = ids of phenome.locus that exist and should be removed before storing the new marker metadata
+#   existing_allele_ids = ids of phenome.allele that exist and should be removed before storing the new marker metadata
 #
 sub set_marker_metadata {
     my $self = shift;
@@ -484,6 +485,21 @@ sub set_marker_metadata {
     my $protocol_id = $self->nd_protocol_id;
     my $sp_person_id = $self->sp_person_id;
 
+    my $parsed_markers = $parsed_data->{markers};
+    my $existing_locus_ids = $parsed_data->{existing_locus_ids};
+    my $existing_allele_ids = $parsed_data->{existing_allele_ids};
+
+    # Delete existing alleles
+    if ( $existing_allele_ids && scalar @$existing_allele_ids > 0 ) {
+        my $allele_rs = $phenome_schema->resultset('Allele')->search({ 'me.allele_id' => { -in => $existing_allele_ids } });
+        $allele_rs->delete_all();
+    }
+
+    # Delete existing loci
+    if ( $existing_locus_ids && scalar @$existing_locus_ids > 0 ) {
+        $self->delete_marker_metadata($existing_locus_ids);
+    }
+
     my $is_a_rel_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'is_a', 'relationship')->cvterm_id();
 
     # Get the organism to use for the loci
@@ -492,8 +508,10 @@ sub set_marker_metadata {
     $sths->execute();
     my ($common_name_id) = $sths->fetchrow_array();
 
-    foreach my $name (keys %$parsed_data) {
-        my $ml = $parsed_data->{$name};
+
+    # Parse the markers
+    foreach my $name (keys %$parsed_markers) {
+        my $ml = $parsed_markers->{$name};
         my $marker = $ml->{'marker'};
         my $alias = $ml->{'alias'};
         my $locus_description = $ml->{'description'};
@@ -670,7 +688,8 @@ sub delete_marker_metadata {
     my @remove_locus_ids;
     my $q = "SELECT locus_id FROM phenome.locus_geno_marker WHERE nd_protocol_id = ?";
     if ( defined $locus_ids && scalar($locus_ids) > 0 ) {
-        $q .= " AND locus_id IN (" . join ',',('?') x @$locus_ids . ")";
+        my $ph = join ',', map { "?" } @$locus_ids;
+        $q .= " AND locus_id IN ($ph)";
     }
     my $sth = $dbh->prepare($q);
     if ( defined $locus_ids && scalar($locus_ids) > 0 ) {
@@ -685,7 +704,7 @@ sub delete_marker_metadata {
 
     # Remove the requested loci...
     if ( scalar @remove_locus_ids > 0 ) {
-        my $lph = join ',',('?') x @remove_locus_ids;
+        my $lph = join ',', map { "?" } @remove_locus_ids;
 
         # Get the loci to remove
         my $locus_rs = $phenome_schema->resultset('Locus')->search({ 'me.locus_id' => { -in => \@remove_locus_ids } });

--- a/lib/CXGN/Genotype/Protocol.pm
+++ b/lib/CXGN/Genotype/Protocol.pm
@@ -646,5 +646,76 @@ sub get_marker_metadata {
     return \%alleles;
 }
 
+#
+# Delete Marker Metadata
+# Delete all or a specified set of marker metadata from this protocol
+# This will remove:
+#    - the associated alleles
+#    - any associated locus dbxrefs
+#    - the entries in the locus_geno_markers junction table
+#    - the locus entries
+# When not given an array of locus ids, all of the marker metadata will be removed
+# @param locus_ids = (optional) array ref of locus ids of specific markers to remove metadata from
+# @return = a hasref with removed locus ids
+#
+sub delete_marker_metadata {
+    my $self = shift;
+    my $locus_ids = shift;
+    my $schema = $self->bcs_schema();
+    my $phenome_schema = $self->phenome_schema();
+    my $dbh = $phenome_schema->storage->dbh();
+    my $protocol_id = $self->nd_protocol_id;
+
+    # Get locus IDs to remove
+    my @remove_locus_ids;
+    my $q = "SELECT locus_id FROM phenome.locus_geno_marker WHERE nd_protocol_id = ?";
+    if ( defined $locus_ids && scalar($locus_ids) > 0 ) {
+        $q .= " AND locus_id IN (" . join ',',('?') x @$locus_ids . ")";
+    }
+    my $sth = $dbh->prepare($q);
+    if ( defined $locus_ids && scalar($locus_ids) > 0 ) {
+        $sth->execute($protocol_id, @$locus_ids);
+    }
+    else {
+        $sth->execute($protocol_id);
+    }
+    while (my ($locus_id) = $sth->fetchrow_array()) {
+        push @remove_locus_ids, $locus_id;
+    }
+
+    # Remove the requested loci...
+    if ( scalar @remove_locus_ids > 0 ) {
+        my $lph = join ',',('?') x @remove_locus_ids;
+
+        # Get the loci to remove
+        my $locus_rs = $phenome_schema->resultset('Locus')->search({ 'me.locus_id' => { -in => \@remove_locus_ids } });
+
+        # Remove the alleles
+        my $allele_rs = $locus_rs->search_related('alleles');
+        $allele_rs->delete_all();
+
+        # Remove references
+        my $ref_rs = $phenome_schema->resultset('LocusDbxref')->search({ 'locus_id' => { -in => \@remove_locus_ids } });
+        my @locus_dbxref_ids;
+        while ( my $r = $ref_rs->next() ) {
+            push @locus_dbxref_ids, $r->locus_dbxref_id();
+        }
+        if ( scalar @locus_dbxref_ids > 0 ) {
+            my $refev_rs = $phenome_schema->resultset('LocusDbxrefEvidence')->search({ 'locus_dbxref_id' => { -in => \@locus_dbxref_ids } });
+            $refev_rs->delete_all();
+            $ref_rs->delete_all();
+        }
+
+        # Remove from junction table
+        $q = "DELETE FROM phenome.locus_geno_marker WHERE locus_id IN ($lph)";
+        $sth = $dbh->prepare($q);
+        $sth->execute(@remove_locus_ids);
+
+        # Remove the loci
+        $locus_rs->delete_all();
+    }
+
+    return { removed => \@remove_locus_ids }
+}
 
 1;

--- a/lib/SGN/Controller/AJAX/GenotypingProtocol.pm
+++ b/lib/SGN/Controller/AJAX/GenotypingProtocol.pm
@@ -401,6 +401,89 @@ sub genotyping_protocol_get_marker_metadata_GET : Args(1) {
     return;
 }
 
+sub genotyping_protocol_update_marker_metadata : Path('/ajax/genotyping_protocol/update_marker_metadata') : ActionClass('REST') { }
+
+sub genotyping_protocol_update_marker_metadata_POST : Args(1) {
+    my $self = shift;
+    my $c = shift;
+    my $protocol_id = shift;
+    my $locus_id = $c->req->param('locus_id');
+    my $marker = $c->req->param('marker');
+    my $alias = $c->req->param('alias');
+    my $description = $c->req->param('description');
+    my @alleles = $c->req->param('alleles[]');
+    my @references = $c->req->param('references[]');
+    my $schema = $c->dbic_schema("Bio::Chado::Schema");
+    my $phenome_schema = $c->dbic_schema("CXGN::Phenome::Schema");
+
+    # Must be logged in
+    if (!$c->user()) {
+        print STDERR "User not logged in... not deleting marker metadata.\n";
+        $c->stash->{rest} = {error => "You need to be logged in to update marker metadata." };
+        return;
+    }
+
+    # Must be a curator
+    my $user_id = $c->user()->get_object()->get_sp_person_id();
+    my $user_role = $c->user->get_object->get_user_type();
+    if ($user_role ne 'curator') {
+        $c->stash->{rest} = { error => "You must be a curator to update marker metadata." };
+        return;
+    }
+
+    # Lookup DB names to map to DB IDs
+    my $dbh = $c->dbc->dbh;
+    my %existing_dbs;
+    my $q = "SELECT db_id, lower(name) FROM public.db GROUP BY 1,2;";
+    my $h = $dbh->prepare($q);
+    $h->execute();
+    while ( my ($db_id, $db_name) = $h->fetchrow_array()) {
+        $existing_dbs{$db_name} = $db_id;
+    }
+
+    # Set parsed data to store marker metadata
+    my %parsed_data = (
+        existing_locus_ids => [$locus_id],
+        markers => {}
+    );
+    $parsed_data{markers}->{$marker} = {
+        marker => $marker,
+        alias => $alias,
+        description => $description,
+        alleles => \@alleles,
+        references => []
+    };
+    foreach my $ref (@references) {
+        my ($db_name, $entity) = split(':', $ref);
+        if ( defined $db_name && defined $entity && $db_name ne '' && $entity ne '' ) {
+            my $db_name_lc = lc($db_name);
+            if ( ! exists $existing_dbs{$db_name_lc} ) {
+                $c->stash->{rest} = { error => "DB name $db_name not found in the database" };
+                return;
+            }
+            my $rh = {
+                db => $existing_dbs{$db_name_lc},
+                entity => $entity
+            };
+            push @{$parsed_data{markers}->{$marker}->{references}}, $rh;
+        }
+    }
+
+    # Store the marker metadata
+    my $protocol = CXGN::Genotype::Protocol->new({
+        bcs_schema => $schema,
+        phenome_schema => $phenome_schema,
+        nd_protocol_id => $protocol_id,
+        sp_person_id => $user_id
+    });
+    $protocol->set_marker_metadata(\%parsed_data);
+
+    # Return new marker metadata
+    my $metadata = $protocol->get_marker_metadata($marker);
+    $c->stash->{rest} = $metadata || {};
+    return;
+}
+
 sub genotyping_protocol_delete_marker_metadata : Path('/ajax/genotyping_protocol/delete_marker_metadata') : ActionClass('REST') { }
 
 sub genotyping_protocol_delete_marker_metadata_DELETE : Args(1) {

--- a/lib/SGN/Controller/AJAX/GenotypingProtocol.pm
+++ b/lib/SGN/Controller/AJAX/GenotypingProtocol.pm
@@ -293,6 +293,7 @@ sub genotyping_protocol_add_marker_metadata_POST : Args(1) {
     my $schema = $c->dbic_schema("Bio::Chado::Schema");
     my $phenome_schema = $c->dbic_schema("CXGN::Phenome::Schema");
 
+    my $ignore_warnings = $c->req->param('ignore_warnings');
     my $upload = $c->req->upload('upload_mla_file');
     my $upload_original_name = $upload->filename();
     my $upload_tempfile = $upload->tempname;
@@ -341,21 +342,29 @@ sub genotyping_protocol_add_marker_metadata_POST : Args(1) {
     });
     $parser->load_plugin('MarkerMetadata');
     my $parsed_data = $parser->parse();
-    my $parse_errors = $parser->get_parse_errors();
+
+    if ( $parser->has_parse_errors() ) {
+        my $errors = $parser->get_parse_errors();
+        my $return = '';
+        foreach my $s (@{$errors->{'error_messages'}}){
+            $return .= $s."\n\n";
+        }
+        $c->stash->{rest} = {error_string => $return};
+        return;
+    }
+
+    if ( $parser->has_parse_warnings() && !$ignore_warnings ) {
+        my $warnings = $parser->get_parse_warnings();
+        my $return = '';
+        foreach my $s (@{$warnings->{'warning_messages'}}){
+            $return .= $s."\n\n";
+        }
+        $c->stash->{rest} = {warning_string => $return};
+        return;
+    }
 
     if (!$parsed_data) {
-        my $return_error = '';
-        my $parse_errors;
-        if (!$parser->has_parse_errors() ){
-            $c->stash->{rest} = {error_string => "Could not get parsing errors"};
-            return;
-        } else {
-            $parse_errors = $parser->get_parse_errors();
-            foreach my $error_string (@{$parse_errors->{'error_messages'}}){
-                $return_error .= $error_string."\n";
-            }
-        }
-        $c->stash->{rest} = {error_string => $return_error};
+        $c->stash->{rest} = {error_string => 'The parser did not return any data!'};
         return;
     }
 

--- a/lib/SGN/Controller/AJAX/GenotypingProtocol.pm
+++ b/lib/SGN/Controller/AJAX/GenotypingProtocol.pm
@@ -392,6 +392,42 @@ sub genotyping_protocol_get_marker_metadata_GET : Args(1) {
     return;
 }
 
+sub genotyping_protocol_delete_marker_metadata : Path('/ajax/genotyping_protocol/delete_marker_metadata') : ActionClass('REST') { }
+
+sub genotyping_protocol_delete_marker_metadata_DELETE : Args(1) {
+    my $self = shift;
+    my $c = shift;
+    my $protocol_id = shift;
+    my $locus_id = $c->req->param("locus_id");
+    my $schema = $c->dbic_schema("Bio::Chado::Schema");
+    my $phenome_schema = $c->dbic_schema("CXGN::Phenome::Schema");
+
+    # Must be logged in
+    if (!$c->user()) {
+        print STDERR "User not logged in... not deleting marker metadata.\n";
+        $c->stash->{rest} = {error => "You need to be logged in to delete marker metadata." };
+        return;
+    }
+
+    # Must be a curator
+    my $user_role = $c->user->get_object->get_user_type();
+    if ($user_role ne 'curator') {
+        $c->stash->{rest} = { error => "You must be a curator to delete marker metadata." };
+        return;
+    }
+
+    # Delete the marker metadata
+    my $protocol = CXGN::Genotype::Protocol->new({
+        bcs_schema => $schema,
+        phenome_schema => $phenome_schema,
+        nd_protocol_id => $protocol_id
+    });
+    my $resp = $protocol->delete_marker_metadata($locus_id ? [int($locus_id)] : undef);
+
+    $c->stash->{rest} = $resp || {};
+    return;
+}
+
 sub locus_marker_autocomplete : Path('/ajax/genotyping_protocol/locus_marker_autocomplete') : ActionClass('REST') { }
 
 sub locus_marker_autocomplete_GET :Args(0) {

--- a/mason/breeders_toolbox/genotyping_protocol/marker_metadata.mas
+++ b/mason/breeders_toolbox/genotyping_protocol/marker_metadata.mas
@@ -31,9 +31,37 @@
     <button class="btn btn-danger" <% $curator ? '' : 'disabled' %> onclick="deleteMetadata()"><span class="glyphicon glyphicon-trash"></span>&nbsp;&nbsp;Delete All Marker Metadata</button>
 </div>
 
+<div class="modal fade" id="edit_marker_metadata_dialog" name="edit_marker_metadata_dialog" tabindex="-1" role="dialog" aria-labelledby="EditMarkerMetadataDialog">
+    <div class="modal-dialog " role="document">
+        <div class="modal-content">
+            <div class="modal-header" style="text-align: center">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="EditMarkerMetadataDialog">Edit Marker Metadata</h4>
+            </div>
+            <div class="modal-body">
+
+                <p><strong>Marker Name:</strong><input class="form-control" id="edit_marker_metadata_marker" name="Marker" /></p>
+                <p><strong>Alias:</strong><input class="form-control" id="edit_marker_metadata_alias" name="Alias" /></p>
+                <p><strong>Description:</strong><textarea class="form-control" id="edit_marker_metadata_description" name="Description" rows="3"></textarea></p>
+                <p><strong>Alleles (one per line):</strong><textarea class="form-control" id="edit_marker_metadata_alleles" name="Alleles" rows="5"></textarea></p>
+                <p><strong>References (one per line):</strong><textarea class="form-control" id="edit_marker_metadata_references" name="References" rows="5"></textarea></p>
+                <span>The references include the associated trait categories and external database references.  The format of each reference is <code>{database name}:{entity name}</code></span>
+                <input type="hidden" id="edit_marker_metadata_locus_id" />
+            </div>
+            <div class="modal-footer">
+                <button id="close_delete_model_dialog" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" name="edit_marker_metadata_dialog_submit" id="edit_marker_metadata_dialog_submit">Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script type="text/javascript">
+    var MARKER_METADATA = {};
+
     jQuery(window).ready(() => {
         loadMetadata();
+        jQuery("#edit_marker_metadata_dialog_submit").on('click', submitMetadata);
     });
 
     function loadMetadata() {
@@ -46,6 +74,7 @@
     }
 
     function displayMetadata(response) {
+        MARKER_METADATA = response;
 
         // Metadata found, generate table...
         if ( response && Object.keys(response).length > 0 ) {
@@ -78,9 +107,23 @@
                     }},
                     { title: "Description", data: "locus_description" },
                     { title: "Alleles", render: (data, type, row) => { return row.alleles.map((x) => x.allele_name).join(type === 'export' ? ', ' : '<br />') } },
+                    { title: "References", render: (data, type, row) => {
+                        var html = "<ul style='padding-left: 15px;'>";
+                        row.references.forEach((r) => {
+                            html += `<li>`;
+                            if ( r.url ) html += `<a href="${r.url}" target="_blank">`;
+                            html += `${r.db_name}:${r.dbxref_accession}`
+                            if ( r.url ) html += `</a>`;
+                            html += `</li>`;
+                        });
+                        html += "</ul>";
+                        return html;
+                    }},
                     { title: "Edit", render: (data, type, row) => { 
-                        return `<button class="btn btn-sm btn-danger" onclick="deleteMetadata(${row.locus_id})" <% $curator ? '' : 'disabled' %>><span class="glyphicon glyphicon-trash"></span></button>`;
-                    } }
+                        var html = `<button class="btn btn-sm btn-info" style="margin: 5px" onclick="editMetadata('${row.locus_name}')" <% $curator ? '' : 'disabled' %>><span class="glyphicon glyphicon-pencil"></span></button>`;
+                        html += `<button class="btn btn-sm btn-danger" style="margin: 5px" onclick="deleteMetadata(${row.locus_id})" <% $curator ? '' : 'disabled' %>><span class="glyphicon glyphicon-trash"></span></button>`;
+                        return html;
+                    }}
                 ]
             });
         }
@@ -105,6 +148,59 @@
         jQuery("#marker_metadata_loading").hide();
         jQuery("#marker_metadata_table_container").show();
         jQuery("#marker_metadata_upload").hide();
+    }
+
+    function editMetadata(marker_name) {
+        const md = MARKER_METADATA[marker_name];
+
+        jQuery("#edit_marker_metadata_marker").val(md.marker_name);
+        jQuery("#edit_marker_metadata_alias").val(md.marker_name !== md.locus_name ? md.locus_name : '');
+        jQuery("#edit_marker_metadata_description").val(md.locus_description);
+        jQuery("#edit_marker_metadata_alleles").val(md.alleles.map(e => e.allele_name).join("\n"));
+        jQuery("#edit_marker_metadata_references").val(md.references.map(e => `${e.db_name}:${e.dbxref_accession}`).join("\n"));
+        jQuery("#edit_marker_metadata_locus_id").val(md.locus_id);
+
+        jQuery('#edit_marker_metadata_dialog').modal('show');
+    }
+
+    function submitMetadata() {
+        const marker = jQuery("#edit_marker_metadata_marker").val();
+        const alias = jQuery("#edit_marker_metadata_alias").val();
+        const description = jQuery("#edit_marker_metadata_description").val();
+        const alleles = jQuery("#edit_marker_metadata_alleles").val().split("\n");
+        const references = jQuery("#edit_marker_metadata_references").val().split("\n");
+        const locus_id = jQuery("#edit_marker_metadata_locus_id").val();
+
+        jQuery.ajax({
+            url: '/ajax/genotyping_protocol/update_marker_metadata/<% $protocol_id %>',
+            method: 'POST',
+            data: {
+                locus_id,
+                marker,
+                alias,
+                description,
+                alleles,
+                references
+            },
+            dataType: 'json',
+            beforeSend: () => {
+                jQuery("#working_modal").modal("show");
+            },
+            success: (response) => {
+                jQuery("#working_modal").modal("hide");
+                if ( response?.error ) {
+                    alert("Could not update marker metadata: " + response.error);
+                }
+                else {
+                    jQuery('#edit_marker_metadata_dialog').modal('hide');
+                    loadMetadata();
+                }
+            },
+            error: () => {
+                jQuery("#working_modal").modal("hide");
+                alert("Could not update marker metadata");
+            }
+        });
     }
 
     function deleteMetadata(locus_id) {

--- a/mason/breeders_toolbox/genotyping_protocol/marker_metadata.mas
+++ b/mason/breeders_toolbox/genotyping_protocol/marker_metadata.mas
@@ -1,6 +1,13 @@
 <%args>
-    $protocol_id
+    $protocol_id => undef
 </%args>
+
+<%perl>
+    my $curator = 0;
+    if ( $c->user() && $c->user()->check_roles("curator") ) {
+        $curator = 1;
+    }
+</%perl>
 
 <& /util/import_javascript.mas, entries => [], classes => [ 'jquery', 'jquery.dataTables','jquery.dataTables-buttons-min', 'jszip-min', 'buttons.bootstrap-min', 'buttons.html5-min' ],  &>
 
@@ -20,22 +27,32 @@
     </p>
 </div>
 
+<div id="marker_metadata_delete" style="margin-top: 15px; display:none">
+    <button class="btn btn-danger" <% $curator ? '' : 'disabled' %> onclick="deleteMetadata()"><span class="glyphicon glyphicon-trash"></span>&nbsp;&nbsp;Delete All Marker Metadata</button>
+</div>
+
 <script type="text/javascript">
     jQuery(window).ready(() => {
+        loadMetadata();
+    });
+
+    function loadMetadata() {
         jQuery.ajax({
             url: '/ajax/genotyping_protocol/get_marker_metadata/<% $protocol_id %>',
             method: 'GET',
             success: displayMetadata,
             error: displayError
         });
-    });
+    }
 
     function displayMetadata(response) {
 
         // Metadata found, generate table...
         if ( response && Object.keys(response).length > 0 ) {
             jQuery("#marker_metadata_upload").hide();
+            jQuery("#marker_metadata_delete").show();
             new jQuery("#marker_metadata_table").DataTable({
+                destroy: true,
                 dom: 'Bfrtip',
                 buttons: [
                     'pageLength',
@@ -60,9 +77,12 @@
                         return html;
                     }},
                     { title: "Description", data: "locus_description" },
-                    { title: "Alleles", render: (data, type, row) => { return row.alleles.map((x) => x.allele_name).join(type === 'export' ? ', ' : '<br />') } }
+                    { title: "Alleles", render: (data, type, row) => { return row.alleles.map((x) => x.allele_name).join(type === 'export' ? ', ' : '<br />') } },
+                    { title: "Edit", render: (data, type, row) => { 
+                        return `<button class="btn btn-sm btn-danger" onclick="deleteMetadata(${row.locus_id})" <% $curator ? '' : 'disabled' %>><span class="glyphicon glyphicon-trash"></span></button>`;
+                    } }
                 ]
-            })
+            });
         }
 
         // No Metadata found, show upload information...
@@ -70,6 +90,7 @@
             let html = "<p style='font-style: italic; padding-bottom: 10px'>There are no metadata or allele values set for the markers in this protocol.</p>";
             jQuery("#marker_metadata_table_container").html(html);
             jQuery("#marker_metadata_upload").show();
+            jQuery("#marker_metadata_delete").hide();
         }
 
         jQuery("#marker_metadata_loading").hide();
@@ -85,4 +106,26 @@
         jQuery("#marker_metadata_table_container").show();
         jQuery("#marker_metadata_upload").hide();
     }
+
+    function deleteMetadata(locus_id) {
+        if ( confirm(`Are you sure you want to delete ${locus_id ? "this marker's metadata" : "all of the marker metadata for this protocol"}?  This cannot be undone!`) ) {
+            jQuery.ajax({
+                url: `/ajax/genotyping_protocol/delete_marker_metadata/<% $protocol_id %>?${locus_id ? "locus_id=" + locus_id : ""}`,
+                method: 'DELETE',
+                success: (resp) => {
+                    if ( resp?.error ) {
+                        alert("Could not delete marker meatadata: " + resp.error);
+                    }
+                    else {
+                        loadMetadata();
+                    }
+                },
+                error: (err) => {
+                    console.log(err);
+                    alert("Could not delete marker metadata: " + err?.statusText);
+                }
+            });
+        }
+    }
+
 </script>

--- a/mason/breeders_toolbox/genotyping_protocol/marker_metadata.mas
+++ b/mason/breeders_toolbox/genotyping_protocol/marker_metadata.mas
@@ -113,6 +113,7 @@
                             html += `<li>`;
                             if ( r.url ) html += `<a href="${r.url}" target="_blank">`;
                             html += `${r.db_name}:${r.dbxref_accession}`
+                            if ( r.cvterm_name ) html += ` (${r.cvterm_name})`;
                             if ( r.url ) html += `</a>`;
                             html += `</li>`;
                         });

--- a/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
+++ b/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
@@ -1114,7 +1114,7 @@ $facilities
                             <b>Alias:</b> an alternate name for the marker (use this to provide a more human-friendly name for the marker)<br>
                             <b>Description:</b> a description of the marker (its associated phenotype, etc)<br>
                             <b>Category:</b> the name of the trait category that the marker belongs to (add as many Category columns as necessary - or separate values in one column with a comma) <br>
-                            <b>Reference:</b> a reference to an entity in an external database (such as a matching gene entry in GrainGenes). The format of this value should be: <code>{database name}={entity name}</code> (such as <code>GrainGenes gene=Rht12 (Triticum)</code>).  The database name must already exist as an external database reference.<br>
+                            <b>Reference:</b> a reference to an entity in an external database (such as a matching gene entry in GrainGenes). The format of this value should be: <code>{database name}:{entity name}</code> (such as <code>GrainGenes gene:Rht12 (Triticum)</code>).  The database name must already exist as an external database reference.<br>
 
                             <& /help/file_upload_type.mas, type => "Marker Metadata" &>
 

--- a/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
+++ b/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
@@ -1121,8 +1121,16 @@ $facilities
                             <br /><br />
 
                             <form method="post" enctype="multipart/form-data" encoding="multipart/form-data" id="upload_mla_form" name="upload_mla_form">
-                                <label for="upload_mla_file" style="display: inline-block;">Marker Metadata Alleles File:</label>
-                                <input type="file" name="upload_mla_file" id="upload_mla_file" encoding="multipart/form-data" />
+                                <div style="display: flex; flex-wrap: wrap; gap: 25px; align-items: flex-end">
+                                    <div>
+                                        <label for="upload_mla_file" style="display: inline-block;">Marker Metadata Alleles File:</label>
+                                        <input type="file" name="upload_mla_file" id="upload_mla_file" encoding="multipart/form-data" />
+                                    </div>
+                                    <div>
+                                        <input id="upload_entry_numbers_ignore_warnings_cb" name="ignore_warnings" type="checkbox" value="checked">
+                                        <label for="upload_entry_numbers_ignore_warnings_cb">Ignore Warnings</label><br>
+                                    </div>
+                                </div>
                             </form>
 
                             <br /><br />
@@ -1503,8 +1511,8 @@ jQuery(document).ready(function(){
                     jQuery('#upload_mla_success').show();
                 }
                 else {
-                    const errors = (response.error_string || "An unknown error occurred.  Please try again later or contact us for more help.").replaceAll('\n', '<br />');
-                    jQuery('#upload_mla_errors').html(`<strong>Marker Metadata NOT stored due to the following errors:</strong><br /><br />${errors}`);
+                    const errors = (response.error_string || response.warning_string || "An unknown error occurred.  Please try again later or contact us for more help.").replaceAll('\n', '<br />');
+                    jQuery('#upload_mla_errors').html(`<strong>Marker Metadata NOT stored:</strong><br /><br />${errors}`);
                     jQuery('#upload_mla_errors').show();
                 }
             },

--- a/sgn.conf
+++ b/sgn.conf
@@ -45,7 +45,7 @@ allow_trait_edits 0
 allow_treatment_edits 0
 # Marker Metadata Trait Categories
 # Set the DB:Accession of the root term of the ontology used to define trait categories for marker metadata
-marker_metadata_trait_ontology_root CO_334:0000000
+marker_metadata_trait_ontology_root
 
 # Seedlot Maintenance Events
 #

--- a/sgn.conf
+++ b/sgn.conf
@@ -45,7 +45,7 @@ allow_trait_edits 0
 allow_treatment_edits 0
 # Marker Metadata Trait Categories
 # Set the DB:Accession of the root term of the ontology used to define trait categories for marker metadata
-marker_metadata_trait_ontology_root
+marker_metadata_trait_ontology_root CO_334:0000000
 
 # Seedlot Maintenance Events
 #

--- a/sgn_test.conf
+++ b/sgn_test.conf
@@ -99,6 +99,10 @@ homepage_display_phenotype_uploads 0
 allow_treatment_edits 1
 allow_trait_edits 0
 
+# Marker Metadata Trait Categories
+# Using the cassava trait ontology for tests
+marker_metadata_trait_ontology_root CO_334:0000000
+
 
 solyc_conversion_files /home/production/solcyc_conversion_files/tomato_unigenes_solyc_conversion_annotated.txt
 

--- a/t/data/genotype_data/marker_metadata.csv
+++ b/t/data/genotype_data/marker_metadata.csv
@@ -1,0 +1,4 @@
+Marker,Alias,Description,Category,Allele,Allele,Allele,Reference
+S1_21597,,Description of Marker 1,Stem height,1_P,1_A,1_H,
+S1_26576,ML_2,Description of Marker 2,Fresh root yield,2_P,2_A,,
+S2_26659,,Description of Marker 3,,3_P,3_A,3_H,

--- a/t/unit_mech/AJAX/MarkerMetadata.t
+++ b/t/unit_mech/AJAX/MarkerMetadata.t
@@ -1,0 +1,180 @@
+use strict;
+use warnings;
+
+use lib 't/lib';
+use SGN::Test::Fixture;
+use Test::More;
+use Test::WWW::Mechanize;
+use CXGN::List;
+use CXGN::Genotype::Protocol;
+use Data::Dumper;
+use JSON;
+
+local $Data::Dumper::Indent = 0;
+
+my $f = SGN::Test::Fixture->new();
+my $schema = $f->bcs_schema;
+my $dbh = $schema->storage->dbh;
+my $people_schema = $f->people_schema;
+
+my $mech = Test::WWW::Mechanize->new;
+
+$mech->post_ok('http://localhost:3010/brapi/v1/token', [ "username"=> "janedoe", "password"=> "secretpw", "grant_type"=> "password" ]);
+my $response = decode_json $mech->content;
+is($response->{'metadata'}->{'status'}->[2]->{'message'}, 'Login Successfull');
+my $sgn_session_id = $response->{access_token};
+
+my $location_rs = $schema->resultset('NaturalDiversity::NdGeolocation')->search({description => 'Cornell Biotech'});
+my $location_id = $location_rs->first->nd_geolocation_id;
+
+my $bp_rs = $schema->resultset('Project::Project')->search({name => 'test'});
+my $breeding_program_id = $bp_rs->first->project_id;
+
+#adding genotyping data for testing marker metadata
+my $file = $f->config->{basepath}."/t/data/genotype_data/test_genotype_upload.vcf";
+
+my $ua = LWP::UserAgent->new;
+$response = $ua->post(
+        'http://localhost:3010/ajax/genotype/upload',
+        Content_Type => 'form-data',
+        Content => [
+            upload_genotype_vcf_file_input => [ $file, 'genotype_vcf_data_upload' ],
+            "sgn_session_id"=>$sgn_session_id,
+            "upload_genotypes_species_name_input"=>"Manihot esculenta",
+            "upload_genotype_vcf_project_name"=>"test_genotype_project",
+            "upload_genotype_location_select"=>$location_id,
+            "upload_genotype_year_select"=>"2015",
+            "upload_genotype_breeding_program_select"=>$breeding_program_id,
+            "upload_genotype_vcf_observation_type"=>"accession",
+            "upload_genotype_vcf_facility_select"=>"IGD",
+            "upload_genotype_vcf_project_description"=>"Test uploading",
+            "upload_genotype_vcf_protocol_name"=>"2015_genotype_protocol",
+            "upload_genotype_vcf_include_igd_numbers"=>0,
+            "upload_genotype_vcf_reference_genome_name"=>"Mesculenta_511_v7",
+            "upload_genotype_add_new_accessions"=>0,
+            "upload_genotype_accept_warnings"=>1,
+        ]
+    );
+
+ok($response->is_success, 'Upload genotype VCF');
+my $message = $response->decoded_content;
+my $message_hash = decode_json $message;
+is($message_hash->{success}, 1, 'Upload genotype VCF success');
+ok($message_hash->{project_id}, 'Upload genotype project id');
+ok($message_hash->{nd_protocol_id}, 'Upload genotype protocol id');
+
+my $protocol_id = $message_hash->{nd_protocol_id};
+my $project_id = $message_hash->{project_id};
+
+
+# Upload Marker Metadata
+my $metadata_file = $f->config->{basepath} . "/t/data/genotype_data/marker_metadata.csv";
+$response = $ua->post(
+    "http://localhost:3010/ajax/genotyping_protocol/add_marker_metadata/$protocol_id",
+    Cookie => 'sgn_session_id=' . $sgn_session_id,
+    Content_Type => 'form-data',
+    Content => [
+        upload_mla_file => [ $metadata_file, 'marker_metadata_upload.csv' ],
+    ]
+);
+ok($response->is_success, 'Upload marker metadata');
+my $upload_resp = decode_json $response->decoded_content;
+is($upload_resp->{error_string}, undef, 'Upload marker metadata - no errors');
+is($upload_resp->{success}, 1, 'Upload marker metadata - success');
+
+
+# Get Marker Metadata (all)
+$mech->get_ok("http://localhost:3010/ajax/genotyping_protocol/get_marker_metadata/$protocol_id", 'Get marker metadata - all');
+$response = decode_json $mech->content;;
+my $expected = {'ML_2' => {'locus_id' => 4,'alleles' => [{'allele_name' => '2_P','allele_id' => 2},{'allele_name' => '2_A','allele_id' => 3}],'references' => [{'url' => '/cvterm/70691/view','db_name' => 'CO_334','cvterm_id' => 70691,'cvterm_name' => 'fresh root yield','dbxref_accession' => '0000013'}],'marker_name' => 'S1_26576','nd_protocol_id' => 3,'locus_name' => 'ML_2','locus_description' => 'Description of Marker 2'},'S1_21597' => {'locus_name' => 'S1_21597','locus_description' => 'Description of Marker 1','nd_protocol_id' => 3,'marker_name' => 'S1_21597','locus_id' => 6,'alleles' => [{'allele_name' => '1_P','allele_id' => 7},{'allele_id' => 8,'allele_name' => '1_A'},{'allele_id' => 9,'allele_name' => '1_H'}],'references' => [{'dbxref_accession' => '0000478','url' => '/cvterm/76801/view','db_name' => 'CO_334','cvterm_id' => 76801,'cvterm_name' => 'Stem height'}]},'S2_26659' => {'locus_description' => 'Description of Marker 3','locus_name' => 'S2_26659','nd_protocol_id' => 3,'marker_name' => 'S2_26659','references' => [],'alleles' => [{'allele_name' => '3_P','allele_id' => 4},{'allele_name' => '3_A','allele_id' => 5},{'allele_name' => '3_H','allele_id' => 6}],'locus_id' => 5}};
+check_metadata_response($expected, $response, "all");
+
+
+# Get Marker Metadata (S1_21597)
+$mech->get_ok("http://localhost:3010/ajax/genotyping_protocol/get_marker_metadata/$protocol_id?marker_name=S1_21597", 'Get marker metadata - S1_21597');
+$response = decode_json $mech->content;
+$expected = {'S1_21597' => {'nd_protocol_id' => 3,'marker_name' => 'S1_21597','locus_name' => 'S1_21597','locus_description'
+ => 'Description of Marker 1','alleles' => [{'allele_name' => '1_P','allele_id' => 7},{'allele_id' => 8,'allele_name' => '1_A'},{'allele_id' => 9,'allele_name' => '1_H'}],'references' => [{'db_name' => 'CO_334','url' => '/cvterm/76801/view','cvterm_name' => 'Stem height','cvterm_id' => 76801,'dbxref_accession' => '0000478'}],'locus_id' => 6}};
+check_metadata_response($expected, $response, "S1_21597");
+
+
+# Update Marker Metadata (S1_21597)
+$mech->post(
+    "http://localhost:3010/ajax/genotyping_protocol/update_marker_metadata/$protocol_id",
+    {
+        locus_id => $response->{S1_21597}->{locus_id},
+        marker => 'S1_21597',
+        description => 'Updated description of Marker 1',
+        'alleles[]' => [ '1_P', '1_A', '1_UNK' ],
+        'references[]' => [ 'CO_334:0000478' ]
+    }
+);
+$response = decode_json $mech->content;
+$expected = {'S1_21597' => {'alleles' => [{'allele_id' => 10,'allele_name' => '1_P'},{'allele_id' => 11,'allele_name' => '1_A'},{'allele_id' => 12,'allele_name' => '1_UNK'}],'locus_name' => 'S1_21597','nd_protocol_id' => 3,'locus_description' => 'Updated description of Marker 1','references' => [{'cvterm_id' => 76801,'db_name' => 'CO_334','cvterm_name' => 'Stem height','url' => '/cvterm/76801/view','dbxref_accession' => '0000478'}],'locus_id' => 7,'marker_name' => 'S1_21597'}};
+check_metadata_response($expected, $response, "S1_21597 - updated");
+
+
+# Delete marker metadata
+$response = $ua->delete("http://localhost:3010/ajax/genotyping_protocol/delete_marker_metadata/$protocol_id", Cookie => "sgn_session_id=$sgn_session_id");
+ok($response->is_success, 'Delete marker metadata');
+
+# Delete genotype protocol after testing
+$mech->get("/ajax/genotyping_protocol/delete/$protocol_id");
+$response = decode_json $mech->content;
+is($response->{'success'}, 1, 'Delete genotype protocol');
+
+#Delete genotype project
+$schema->resultset("Project::Project")->find({project_id=>$project_id})->delete();
+
+$f->clean_up_db();
+
+done_testing();
+
+
+sub check_metadata_response {
+    my $expected = shift;
+    my $response = shift;
+    my $label = shift;
+
+    # Check marker names
+    my $expected_loci = keys %$expected;
+    my $response_loci = keys %$response;
+    is_deeply($response_loci, $expected_loci, "Get marker metadata - $label - marker names");
+
+    # Check marker descriptions
+    my %expected_descriptions;
+    my %response_descriptions;
+     foreach my $m (keys %$expected) {
+        $expected_descriptions{$m} = $expected->{$m}->{locus_description};
+    }
+    foreach my $m (keys %$response) {
+        $response_descriptions{$m} = $response->{$m}->{locus_description};
+    }
+    is_deeply(\%response_descriptions, \%expected_descriptions, "Get marker metadata - $label - marker descriptions");
+
+    # Check allele names
+    my %expected_alleles;
+    my %response_alleles;
+    foreach my $m (keys %$expected) {
+        my @an = map { $_->{allele_name} } @{$expected->{$m}->{alleles}};
+        $expected_alleles{$m} = \@an;
+    }
+    foreach my $m (keys %$response) {
+        my @an = map { $_->{allele_name} } @{$response->{$m}->{alleles}};
+        $response_alleles{$m} = \@an;
+    }
+    is_deeply(\%response_alleles, \%expected_alleles, "Get marker metadata - $label - allele names");
+
+    # Check references
+    my %expected_references;
+    my %response_references;
+    foreach my $m (keys %$expected) {
+        my @ref = map { $_->{db_name} . ":" . $_->{dbxref_accession} } @{$expected->{$m}->{references}};
+        $expected_references{$m} = \@ref;
+    }
+    foreach my $m (keys %$response) {
+        my @ref = map { $_->{db_name} . ":" . $_->{dbxref_accession} } @{$response->{$m}->{references}};
+        $response_references{$m} = \@ref;
+    }
+    is_deeply(\%response_references, \%expected_references, "Get marker metadata - $label - references");
+}


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This updates the marker metadata file upload and display table on the genotyping protocol page

- When uploading a marker metadata file:
     - if the marker name does not exist in the `phenome.locus` table: the locus is created and the marker metadata added
     - if the marker name exists and is associated with the selected protocol in the `phenome.locus_geno_marker` junction table: a warning message is returned and the the locus and metadata are updated if warnings are ignored
     - if the marker name exists and is NOT associated with the selected protocol in the `phenome.locus_geno_marker` junction table: an error message is returned and the existing name cannot be used
 - Updates to the marker metadata data table on the protocol detail page:
     - added a references column to display and link to associated ontology terms and/or external dbs
     - added an edit column to allow a curator to edit existing metadata or remove a single locus and saved metadata
     - added a delete all marker metadata option (curator only)
 - Add mech tests to test adding, fetching, updating, and deleting marker metadata 

<img width="1175" height="767" alt="image" src="https://github.com/user-attachments/assets/6b731669-d650-4eee-bf7e-337c98312a8f" />



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
