### PR TITLE
improve interface for adding trait attributes

### DIFF
--- a/lib/CXGN/BrAPI/v2/Scales.pm
+++ b/lib/CXGN/BrAPI/v2/Scales.pm
@@ -432,7 +432,7 @@ sub _format_data_type {
     if ($value) {
         my %formats = (
 	    "categorical" => "Categorical",
-	    "orginal" => "Ordinal",
+	    "ordinal" => "Ordinal",
             "numeric" => "Numerical",
             "qualitative" => "Nominal",
             "numerical" => "Numerical",

--- a/lib/CXGN/BrAPI/v2/Scales.pm
+++ b/lib/CXGN/BrAPI/v2/Scales.pm
@@ -431,7 +431,8 @@ sub _format_data_type {
 
     if ($value) {
         my %formats = (
-	        "categorical" => "Ordinal",
+	    "categorical" => "Categorical",
+	    "orginal" => "Ordinal",
             "numeric" => "Numerical",
             "qualitative" => "Nominal",
             "numerical" => "Numerical",
@@ -441,10 +442,12 @@ sub _format_data_type {
             "duration" => "Duration",
             "ordinal" => "Ordinal",
             "text" => "Text",
-	        "photo" => "Photo",
-	        "multicat" => "Multicat",
+	    "photo" => "Photo",
+	    "multicat" => "Multicat",
             "boolean" => "Boolean",
             "counter" => "Counter",
+	    "zebra label print" => "Zebra Label Print",
+	    "loation" => "Location"
         );
 
         $dataType = $formats{lc $value} ? $formats{lc $value} : $dataType;

--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -549,8 +549,8 @@ sub verify {
                 foreach my $value_array (@$measurements_array) {
                     # print STDERR "Value array = ".Dumper($value_array)."\n";
 		    my $multiple_values = 0;
-		    if (scalar(@$measurements_array) > 1) { $multiple_values = 1; } 
-                    ($warnings, $errors) = $self->check_measurement($plot_name, $trait_name, $value_array, $multiple_values); 
+		    if (scalar(@$measurements_array) > 1) { $multiple_values = 1; }
+                    ($warnings, $errors) = $self->check_measurement($plot_name, $trait_name, $value_array, $multiple_values);
                     $error_message .= $errors;
                     $warning_message .= $warnings;
                 }
@@ -609,7 +609,7 @@ sub check_measurement {
     my $trait_name = shift;
     my $value_array = shift;
     my $file_contains_multiple_values = shift;
-    
+
     my $error_message = "";
     my $warning_message = "";
 
@@ -655,7 +655,7 @@ sub check_measurement {
         }
 
         #check that trait value is valid for trait name (but only if we have a trait_value)
-        if ((defined($trait_value) && $trait_value ne '' && $trait_value ne 'NA' && $trait_value ne '.') && exists($self->check_trait_format()->{$trait_cvterm_id})) { 
+        if ((defined($trait_value) && $trait_value ne '' && $trait_value ne 'NA' && $trait_value ne '.') && exists($self->check_trait_format()->{$trait_cvterm_id})) {
             # print STDERR "Trait minimum value checks if it exists: " . $self->check_trait_min_value->{$trait_cvterm_id} . "\n";
             if ($self->check_trait_format()->{$trait_cvterm_id} =~ m/numeric|counter|percent|boolean/i ) {
                 my $trait_format_checked = looks_like_number($trait_value);
@@ -718,9 +718,9 @@ sub check_measurement {
 
             my @check_values;
             if (exists($self->check_trait_category()->{$trait_cvterm_id}) &&
-                ($self->check_trait_format->{$trait_cvterm_id} eq 'Multicat' || 
-                $self->check_trait_format->{$trait_cvterm_id} eq 'categorical' || 
-                $self->check_trait_format->{$trait_cvterm_id} eq 'qualitative')) {
+                ($self->check_trait_format->{$trait_cvterm_id} =~ m/multicat/i ||
+                $self->check_trait_format->{$trait_cvterm_id} =~ m/categorical/i ||
+                $self->check_trait_format->{$trait_cvterm_id} =~ m/qualitative/i)) {
 
                 # print STDERR "Dealing with a categorical trait!\n\n";
 
@@ -789,7 +789,7 @@ sub check_measurement {
 	    if ($file_contains_multiple_values  && (defined($trait_value) && $trait_value ne '')) {
 		$warning_message .= "Multiple values present in file for single repeat_type term $trait_name\n";
 	    }
-	    
+
             print STDERR "Processing this trait with value $trait_value as a single repeat type trait with overwrite_values set to ".$self->overwrite_values()."...\n";
             if (exists($self->unique_value_trait_stock->{$trait_value, $trait_cvterm_id, $stock_id})) {
                 my $prev = $self->unique_value_trait_stock->{$trait_value, $trait_cvterm_id, $stock_id};

--- a/mason/chado/cvterm.mas
+++ b/mason/chado/cvterm.mas
@@ -204,7 +204,7 @@ my $edit_privs = $curator ;
 <&| /page/info_section.mas, title=>"Cvterm details" &>
 <table style="border-spacing:10px">
 % if ( $allow_edits ) {
-<tr><td><a href="javascript:displayCvtermEditDialog()" id="edit_cvterm_link">[Edit]</td><td><a href="javascript:deleteCvterm()" id="delete_cvterm_link" style="color:red;">[Delete]</a></td></tr>
+<tr><td colspan="2"><a href="javascript:displayCvtermEditDialog()" id="edit_cvterm_link">[Edit] <a href="javascript:deleteCvterm()" id="delete_cvterm_link" style="color:red;">[Delete]</a></td><td></td><td></td></tr>
 % }
 <tr><td>Term id</td><td width="10px">&nbsp;</td><td><b><% $accession %></b></td></tr>
 <tr><td>Term name</td><td>&nbsp;</td><td><b><% $cvterm_name %></b></td></tr>

--- a/mason/chado/cvtermprops.mas
+++ b/mason/chado/cvtermprops.mas
@@ -52,7 +52,7 @@ sub prop_select {
   my $editable = shift;
   my $div_name = shift;
   my $html = "<select id=\"$div_name"."_select"."\">";
-  foreach my $item (@$editable) { 
+  foreach my $item (@$editable) {
       $html .= qq{ <option>$item</option> };
   }
   $html .= qq{ </select> };
@@ -62,33 +62,90 @@ sub prop_select {
 
 </%perl>
 
+<div id="<% $div_name %>_add_dialog" class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Add trait attributes</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+
+	<div id="<% $div_name %>_add_dialog" >
+	  Add <% $prop_select %>
+	  <span id="<% $div_name %>_prop_div">
+	    <input id="<% $div_name %>_prop" />
+	  </span>
+	</div>
+      </div>
+      <div class="modal-footer">
+	<button id="<% $div_name %>_addProp_submit" type="button" class="btn btn-primary">Store attribute</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+
 <div id="<% $div_name %>_content">
 </div>
 
-<div id="<% $div_name %>_add_dialog" >
+<!-- div id="<% $div_name %>_add_dialog" >
 Add <% $prop_select %>
 <input id="<% $div_name %>_prop" />
-</div>
+</div -->
 
 <script defer="defer" >
 
-jQuery(document).ready(function() { 
+jQuery(document).ready(function() {
 
-  jQuery('#<% $div_name %>_add_dialog').dialog( {
-     title: 'Add property',
-     buttons: { 'Cancel': function() { jQuery('#<% $div_name %>_add_dialog').dialog("close"); }, 'Add': {text: 'Add', id: '<% $div_name %>_addProp_submit', click: function() { <% $div_name %>_addProp() } } },
-     autoOpen: false,
-     modal: true
-  });
+var trait_format_choices = '<select id="<% $div_name %>_prop"><option>numeric</option><option>categorical</option><option>date</option><option>photo</option><option>boolean</option></select>';
 
-  <% $div_name %>_getProps();
-  
+var trait_repeat_type_choices = '<select id="<% $div_name %>_prop"><option>single</option><option>multiple</option><option>time_series</option></select>';
+
+var choices = { 'trait_format' : trait_format_choices, 'trait_repeat_type' : trait_repeat_type_choices };
+
+  // jQuery('#<% $div_name %>_add_dialog').dialog( {
+  //    title: 'Add property',
+  //    buttons: { 'Cancel': function() { jQuery('#<% $div_name %>_add_dialog').dialog("close"); }, 'Add': {text: 'Add', id: '<% $div_name %>_addProp_submit', click: function() { <% $div_name %>_addProp() } } },
+  //    autoOpen: false,
+  //    modal: true
+  // });
+
+	<% $div_name %>_getProps();
+     <% $div_name %>_set_options(choices);
+
+ jQuery('#<% $div_name %>_addProp_submit').click( function() {
+	    <% $div_name %>_addProp();
+    });
+
+    jQuery('#<% $div_name %>_select').change( function() {
+	    <% $div_name %>_set_options(choices);
+    });
+
 });
+
+function <% $div_name %>_set_options(choices) {
+    //	alert('SELECT!');
+    	var new_selection = jQuery('#<% $div_name %>_select').find(":selected").val();
+//	alert(new_selection);
+	if (Object.keys(choices).includes(new_selection)) {
+//	    alert('NEW CHOICES: '+JSON.stringify(choices[new_selection]));
+
+	    jQuery('#<% $div_name %>_prop_div').html(choices[new_selection]);
+	}
+	    else {
+//	    alert('INPUT type');
+	    jQuery('#<% $div_name %>_prop_div').html('<input id="<% $div_name %>_prop" />');
+	}
+}
 
 // note: the $div_name prefix is needed when several instances are created on a page
 
-function <% $div_name %>_getProps() { 
-  jQuery.ajax( { 
+function <% $div_name %>_getProps() {
+  jQuery.ajax( {
     type: 'GET',
     url: '/cvterm/prop/get',
     data: { cvterm_id: <% $cvterm_id %> },
@@ -98,20 +155,20 @@ function <% $div_name %>_getProps() {
 }
 
 
-function <% $div_name %>_renderProps(props) { 
+function <% $div_name %>_renderProps(props) {
    var subset = eval(<% $subset_json %>);
 
    // eliminate types without values
    var filteredSet = {};
-   for (var n=0; n<subset.length; n++) {				   
+   for (var n=0; n<subset.length; n++) {
      for (var i=0; i<props.length; i++) {
-       if (subset[n] ==  props[i]['type_name']) { 
+       if (subset[n] ==  props[i]['type_name']) {
          filteredSet[subset[n]]=1;
            }
        }
    }
-    
-   
+
+
    var html = '';
    var prop_string;
    var edit_privs = <% $edit_privs %>;
@@ -119,39 +176,49 @@ function <% $div_name %>_renderProps(props) {
    for (var n in filteredSet) {
       var lines = new Array();
       for(var i=0; i<props.length; i++) {
-        if (n ===  props[i]['type_name']) { 
+        if (n ===  props[i]['type_name']) {
           var lineStr = props[i]['value'];
-          if (jQuery.cookie("sgn_session_id") && allow_edits === 1) { 
-            lineStr = lineStr + '[<a href="javascript:<% $div_name %>_deleteProp(\''+props[i]['value']+'\', '+props[i]['cvtermprop_id']+')">X</a>]';		
+          if (jQuery.cookie("sgn_session_id") && allow_edits === 1) {
+            lineStr = lineStr + '[<a href="javascript:<% $div_name %>_deleteProp(\''+props[i]['value']+'\', '+props[i]['cvtermprop_id']+')">X</a>]';
           }
 	  lines.push(lineStr);
         }
-          
+
       }
-      html = html + '<b>'+n+'</b>&nbsp;&nbsp;'; 
+      html = html + '<b>'+n+'</b>&nbsp;&nbsp;';
       //html  = html + lineStr;
       html = html + lines.join(", ");
       html = html + '<br />\n';
-      
+
    }
    jQuery('#<% $div_name %>_content').html(html);
-		
-}		 
 
-function <% $div_name %>_addPropDialog(prop, typeId) { 
-  jQuery('#<% $div_name %>_add_dialog').dialog("open");
+}
+
+function <% $div_name %>_addPropDialog(prop, typeId) {
+  jQuery('#<% $div_name %>_add_dialog').modal("show");
 
 }
 
 
 
-function <% $div_name %>_addProp() { 
-  var prop_type = jQuery('#<% $div_name %>_select').val();
-  var prop = jQuery('#<% $div_name %>_prop').val();
+function <% $div_name %>_addProp() {
+    var prop_type = jQuery('#<% $div_name %>_select').val();
+    var nodename = jQuery('#<% $div_name %>_prop').prop('nodeName');
+//    alert("NODENAME: "+nodename);
+    var prop;
+    if (nodename === 'INPUT') {
+	prop = jQuery('#<% $div_name %>_prop').val();
+    }
+    if (nodename === 'SELECT') {
+	prop = jQuery('#<% $div_name %>_prop option:selected').text();
+    }
+
+//    alert('PROP READ: '+prop);
 
   if (prop === '') { alert("Please fill in the field."); return; }
-				 
-  jQuery.ajax( { 
+
+  jQuery.ajax( {
     type: 'POST',
     url: '/cvterm/prop/add',
     beforeSend: function(){
@@ -162,35 +229,39 @@ function <% $div_name %>_addProp() {
         jQuery('#working_modal').modal('hide');
         if ("error" in response) { alert ('ERROR '+response.error); }
         if ("message" in response) { alert('Successfully added property: ' + prop + '. ('+response.message+')'); }
+	  <% $div_name %>_getProps();
+	jQuery('#<% $div_name %>_add_dialog').modal('hide');
     },
     error: function(response) {
         jQuery('#working_modal').modal('hide');
         alert('an error occurred while storing the prop ' + response.error);
+	jQuery('#<% $div_name %>_add_dialog').modal('hide');
     }
   });
 
-  <% $div_name %>_getProps();
-  jQuery('#<% $div_name %>_add_dialog').dialog("close");
+
 }
 
 
-function <% $div_name %>_deleteProp(cvtermprop_value, cvtermprop_id) { 
-  if (confirm('Delete cvtermprop '+cvtermprop_value+'?')) { 
-    jQuery.ajax( { 
+function <% $div_name %>_deleteProp(cvtermprop_value, cvtermprop_id) {
+  if (confirm('Delete cvtermprop '+cvtermprop_value+'?')) {
+    jQuery.ajax( {
       method: 'GET',
       url: '/cvterm/prop/delete',
       data: { 'cvtermprop_id' : cvtermprop_id },
-      success: function(response) {  
-        if ('message' in response) {  alert(response.message); } 
-        if ('error'   in response) {  alert(response.error);   }
+      success: function(response) {
+        if ('message' in response) {  alert(response.message); }
+          if ('error'   in response) {  alert(response.error);   }
+	    <% $div_name %>_getProps();
+
       },
       error: function(response) {
         alert('An error occurred. Please try again later.');
       }
-  
+
     });
   }
-  <% $div_name %>_getProps();
+
 }
 
 </script>

--- a/mason/chado/cvtermprops.mas
+++ b/mason/chado/cvtermprops.mas
@@ -101,7 +101,7 @@ Add <% $prop_select %>
 
 jQuery(document).ready(function() {
 
-var trait_format_choices = '<select id="<% $div_name %>_prop"><option>numeric</option><option>categorical</option><option>date</option><option>photo</option><option>boolean</option></select>';
+var trait_format_choices = '<select id="<% $div_name %>_prop"><option>numeric</option><option>qualitative</option><option>nominal</option><option>duration</option><option>ordinal</option><option>text</option><option>multicat</option><option>counter</option><option>categorical</option><option>date</option><option>photo</option><option>boolean</option></select>';
 
 var trait_repeat_type_choices = '<select id="<% $div_name %>_prop"><option>single</option><option>multiple</option><option>time_series</option></select>';
 

--- a/mason/chado/cvtermprops.mas
+++ b/mason/chado/cvtermprops.mas
@@ -51,7 +51,7 @@ $edit_privs ||= 0;
 sub prop_select {
   my $editable = shift;
   my $div_name = shift;
-  my $html = "<select id=\"$div_name"."_select"."\">";
+  my $html = "<select class=\"form-control col-sm-2\" id=\"$div_name"."_select"."\">";
   foreach my $item (@$editable) {
       $html .= qq{ <option>$item</option> };
   }
@@ -72,16 +72,24 @@ sub prop_select {
         </button>
       </div>
       <div class="modal-body">
-
-	<div id="<% $div_name %>_add_dialog" >
-	  Add <% $prop_select %>
-	  <span id="<% $div_name %>_prop_div">
-	    <input id="<% $div_name %>_prop" />
-	  </span>
-	</div>
+        <div id="<% $div_name %>_add_dialog">
+          <form class="form-horizontal" role="form" id="add_cvtermprop_form">
+            <div class="form-group">
+              <label class="control-label col-sm-3">Add</label> 
+              <div class="col-sm-4">
+                <% $prop_select %>
+              </div>
+              <div class="col-sm-4">
+                <span id="<% $div_name %>_prop_div">
+                  <input id="<% $div_name %>_prop"/>
+                </span>
+              </div>
+            </div>
+          </form>
+        </div>
       </div>
       <div class="modal-footer">
-	<button id="<% $div_name %>_addProp_submit" type="button" class="btn btn-primary">Store attribute</button>
+	      <button id="<% $div_name %>_addProp_submit" type="button" class="btn btn-primary">Store attribute</button>
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
       </div>
     </div>
@@ -101,9 +109,9 @@ Add <% $prop_select %>
 
 jQuery(document).ready(function() {
 
-var trait_format_choices = '<select id="<% $div_name %>_prop"><option>Numeric</option><option>Categorical</option><option>Qualitative</option><option>Nominal</option><option>Duration</option><option>Ordinal</option><option>Text</option><option>Multicat</option><option>Counter</option><option>Date</option><option>Photo</option><option>Boolean</option><option>Audio</option><option>Zebra Label Print</option></select>';
+var trait_format_choices = '<select class="form-control" id="<% $div_name %>_prop"><option>Numeric</option><option>Categorical</option><option>Qualitative</option><option>Nominal</option><option>Duration</option><option>Ordinal</option><option>Text</option><option>Multicat</option><option>Counter</option><option>Date</option><option>Photo</option><option>Boolean</option><option>Audio</option><option>Zebra Label Print</option></select>';
 
-var trait_repeat_type_choices = '<select id="<% $div_name %>_prop"><option>single</option><option>multiple</option><option>time_series</option></select>';
+var trait_repeat_type_choices = '<select class="form-control" id="<% $div_name %>_prop"><option>single</option><option>multiple</option><option>time_series</option></select>';
 
 var choices = { 'trait_format' : trait_format_choices, 'trait_repeat_type' : trait_repeat_type_choices };
 

--- a/mason/chado/cvtermprops.mas
+++ b/mason/chado/cvtermprops.mas
@@ -101,7 +101,7 @@ Add <% $prop_select %>
 
 jQuery(document).ready(function() {
 
-var trait_format_choices = '<select id="<% $div_name %>_prop"><option>numeric</option><option>qualitative</option><option>nominal</option><option>duration</option><option>ordinal</option><option>text</option><option>multicat</option><option>counter</option><option>categorical</option><option>date</option><option>photo</option><option>boolean</option></select>';
+var trait_format_choices = '<select id="<% $div_name %>_prop"><option>Numeric</option><option>Categorical</option><option>Qualitative</option><option>Nominal</option><option>Duration</option><option>Ordinal</option><option>Text</option><option>Multicat</option><option>Counter</option><option>Date</option><option>Photo</option><option>Boolean</option><option>Audio</option><option>Zebra Label Print</option></select>';
 
 var trait_repeat_type_choices = '<select id="<% $div_name %>_prop"><option>single</option><option>multiple</option><option>time_series</option></select>';
 

--- a/mason/tools/trait_designer.mas
+++ b/mason/tools/trait_designer.mas
@@ -28,13 +28,13 @@
                 <label class="col-sm-3 control-label">Trait format:</label>
                 <div class="col-sm-9">
                     <select style="width:70%;" class="form-control" id="new_trait_format_select" name="new_trait_format_select" type="select">
-                        <option value="numeric" selected>Numeric</option>
-                        <option value="categorical">Categorical</option>
-                        <option value="percent">Percent</option>
-                        <option value="boolean">Boolean</option>
-                        <option value="date">Date</option>
-                        <option value="text">Text</option>
-                        <option value="counter">Counter</option>
+                        <option value="Numeric" selected>Numeric</option>
+                        <option value="Categorical">Categorical</option>
+                        <option value="Percent">Percent</option>
+                        <option value="Boolean">Boolean</option>
+                        <option value="Date">Date</option>
+                        <option value="Text">Text</option>
+                        <option value="Counter">Counter</option>
                         <option value="ontology">Ontology (parent to child terms)</option>
                     </select>
                 </div>
@@ -83,7 +83,7 @@
                 </div>
             </div>
             <div class="form-group" id="chain_parent_term_container">
-                <label class="col-sm-3 control-label" id="chain_parent_term"><span class="glyphicon glyphicon-question-sign" style="color:blue;font-size:18px" title="Should not be a variable term. 
+                <label class="col-sm-3 control-label" id="chain_parent_term"><span class="glyphicon glyphicon-question-sign" style="color:blue;font-size:18px" title="Should not be a variable term.
 Will be the trait root term by default."></span>&nbsp;Chain to an existing term:</label>
                 <div class="col-sm-9">
                     <input style="width:70%;" class="form-control" id="new_trait_parent_term" name="new_trait_parent_term" type="text" placeholder="Full name, as in 'CGIAR cassava trait ontology|CO_334:0000000'"/>
@@ -139,7 +139,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                     parent_term : parent_term,
                     repeat_type : repeat_type
                 },
-                success: function(response) { 
+                success: function(response) {
                     jQuery('#working_modal').modal("hide");
                     if (response.error) {
                         alert(response.error);
@@ -148,7 +148,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                         window.location.reload();
                     }
                 },
-                error: function(response) { 
+                error: function(response) {
                     jQuery('#working_modal').modal("hide");
                     console.log(response);
                     alert("An error occurred, check console.");
@@ -162,7 +162,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
 
         jQuery('#new_trait_format_select').on('change', function () {
             let trait_type = jQuery(this).val();
-            if (trait_type === 'numeric') {
+            if (trait_type.toLowerCase() === 'numeric') {
                 jQuery('#new_trait_minimum_value_container').show();
                 jQuery('#new_trait_default_value_container').show();
                 jQuery('#new_trait_maximum_value_container').show();
@@ -172,7 +172,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                 jQuery('#new_trait_min_value').val('');
                 jQuery('#new_trait_max_value').val('');
                 jQuery('#new_trait_repeat_select_container').show();
-            } else if (trait_type === 'categorical') {
+            } else if (trait_type.toLowerCase() === 'categorical') {
                 jQuery('#new_trait_minimum_value_container').hide();
                 jQuery('#new_trait_default_value_container').show();
                 jQuery('#new_trait_maximum_value_container').hide();
@@ -182,7 +182,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                 jQuery('#new_trait_min_value').val('');
                 jQuery('#new_trait_max_value').val('');
                 jQuery('#new_trait_repeat_select_container').show();
-            } else if (trait_type === 'ontology') {
+            } else if (trait_type.toLowerCase() === 'ontology') {
                 jQuery('#new_trait_minimum_value_container').hide();
                 jQuery('#new_trait_maximum_value_container').hide();
                 jQuery('#new_trait_add_categories_container').hide();
@@ -191,7 +191,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                 jQuery('#new_trait_default_value').val('');
                 jQuery('#new_trait_min_value').val('');
                 jQuery('#new_trait_max_value').val('');
-            } else if (trait_type === 'percent') { 
+            } else if (trait_type.toLowerCase() === 'percent') {
                 jQuery('#new_trait_minimum_value_container').show();
                 jQuery('#new_trait_default_value_container').show();
                 jQuery('#new_trait_maximum_value_container').show();
@@ -201,7 +201,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                 jQuery('#new_trait_min_value').val('0');
                 jQuery('#new_trait_max_value').val('100');
                 jQuery('#new_trait_repeat_select_container').show();
-            } else if (trait_type === 'counter') {
+            } else if (trait_type.toLowerCase() === 'counter') {
                 jQuery('#new_trait_minimum_value_container').show();
                 jQuery('#new_trait_default_value_container').show();
                 jQuery('#new_trait_maximum_value_container').show();
@@ -211,7 +211,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                 jQuery('#new_trait_min_value').val('0');
                 jQuery('#new_trait_max_value').val('');
                 jQuery('#new_trait_repeat_select_container').show();
-            } else if (trait_type === 'boolean') {
+            } else if (trait_type.toLowerCase() === 'boolean') {
                 jQuery('#new_trait_minimum_value_container').show();
                 jQuery('#new_trait_default_value_container').show();
                 jQuery('#new_trait_maximum_value_container').show();
@@ -221,7 +221,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                 jQuery('#new_trait_min_value').val('0');
                 jQuery('#new_trait_max_value').val('1');
                 jQuery('#new_trait_repeat_select_container').show();
-            } else if (trait_type === 'date') {
+            } else if (trait_type.toLowerCase() === 'date') {
                 jQuery('#new_trait_minimum_value_container').hide();
                 jQuery('#new_trait_maximum_value_container').hide();
                 jQuery('#new_trait_add_categories_container').hide();
@@ -230,7 +230,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                 jQuery('#new_trait_default_value').val('');
                 jQuery('#new_trait_min_value').val('');
                 jQuery('#new_trait_max_value').val('');
-            } else if (trait_type === 'text') {
+            } else if (trait_type.toLowerCase() === 'text') {
                 jQuery('#new_trait_minimum_value_container').hide();
                 jQuery('#new_trait_maximum_value_container').hide();
                 jQuery('#new_trait_add_categories_container').hide();

--- a/sgn.conf
+++ b/sgn.conf
@@ -41,7 +41,7 @@ trait_ontology_cvterm_name Solanaceae trait ontology
 # For displaying ontologies in Ontology Browser
 onto_root_namespaces  GO (Gene Ontology), PO (Plant Ontology), SO (Sequence Ontology), PATO (Phenotype and Trait Ontology), SP (Solanaceae Ontology), UO (Units), CASSTISS (Cass tissues)
 
-allow_trait_edits 0
+allow_trait_edits 1
 allow_treatment_edits 0
 # Marker Metadata Trait Categories
 # Set the DB:Accession of the root term of the ontology used to define trait categories for marker metadata


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
changes the jquery dialog to a bootstrap dialog and adds pull down menus for the trait format and trait repeat type properties

closes #6014 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
