### PR TITLE
Trial Layout: add support for custom plot order

### DIFF
--- a/lib/CXGN/Trial/Download.pm
+++ b/lib/CXGN/Trial/Download.pm
@@ -239,6 +239,9 @@ has 'people_schema' => ( isa => 'Ref', is => 'rw');
 has 'dbh' => (is  => 'rw');
 has 'start_date' => ( isa => 'Maybe[Str]', is => 'rw');
 has 'end_date' => (isa => 'Maybe[Str]', is => 'rw');
+has 'include_plot_order' => (is => 'rw', isa => 'Bool', default => 0);
+has 'plot_order' => (is => 'rw', isa => 'Maybe[Str]', default => undef);
+has 'plot_start' => (is => 'rw', isa => 'Maybe[Str]', default => undef);
 
 
 sub BUILD {

--- a/lib/CXGN/Trial/Download/Plugin/TrialLayoutCSV.pm
+++ b/lib/CXGN/Trial/Download/Plugin/TrialLayoutCSV.pm
@@ -76,7 +76,10 @@ sub download {
             treatment_project_ids => $self->treatment_project_ids,
             selected_columns => $self->selected_columns,
             selected_trait_ids => $self->trait_list,
-            include_measured => $self->include_measured
+            include_measured => $self->include_measured,
+            include_plot_order => $self->include_plot_order,
+            plot_order => $self->plot_order,
+            plot_start => $self->plot_start,
         });
         my $output = $trial_layout_download->get_layout_output();
         if ($output->{error_messages}){

--- a/lib/CXGN/Trial/Download/Plugin/TrialLayoutExcel.pm
+++ b/lib/CXGN/Trial/Download/Plugin/TrialLayoutExcel.pm
@@ -83,7 +83,10 @@ sub download {
         treatment_project_ids => $self->treatment_project_ids,
         selected_columns => $self->selected_columns,
         selected_trait_ids => $self->trait_list,
-        include_measured => $self->include_measured
+        include_measured => $self->include_measured,
+        include_plot_order => $self->include_plot_order,
+        plot_order => $self->plot_order,
+        plot_start => $self->plot_start,
     });
     my $output = $trial_layout_download->get_layout_output();
     if ($output->{error_messages}){

--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -161,6 +161,24 @@ has 'overall_performance_hash' => (
     is => 'rw',
 );
 
+has 'include_plot_order' => (
+    is => 'rw',
+    isa => 'Bool',
+    default => 0
+);
+
+has 'plot_order' => (
+    is => 'rw',
+    isa => 'Maybe[Str]',
+    default => undef
+);
+
+has 'plot_start' => (
+    is => 'rw',
+    isa => 'Maybe[Str]',
+    default => undef
+);
+
 sub get_layout_output {
     my $self = shift;
     my $trial_id = $self->trial_id();
@@ -346,7 +364,10 @@ sub get_layout_output {
         exact_performance_hash => $exact_performance_hash,
         overall_performance_hash => \%overall_performance_hash,
         all_stats => $all_stats,
-        trial_stock_type => $trial_stock_type
+        trial_stock_type => $trial_stock_type,
+        include_plot_order => $self->include_plot_order(),
+        plot_order => $self->plot_order(),
+        plot_start => $self->plot_start(),
     };
 
     my $layout_output;

--- a/lib/CXGN/Trial/TrialLayoutDownload/PlantLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/PlantLayout.pm
@@ -51,8 +51,11 @@ sub retrieve {
     my $all_stats = $self->all_stats;
     my @output;
     my $trial_stock_type = $self->trial_stock_type();
+    my $include_plot_order = $self->include_plot_order() && $self->plot_order() && $self->plot_order() ne '' && $self->plot_start() && $self->plot_start() ne '';
 
-    my @possible_cols = ('plant_name','plant_id','subplot_name','subplot_id','plot_name','plot_id','accession_name','accession_id','plot_number','block_number','is_a_control','range_number','rep_number','row_number','col_number','seedlot_name','seed_transaction_operator','num_seed_per_plot','subplot_number','plant_number','pedigree','location_name','trial_name','year', 'planting_date', 'synonyms','tier','plot_geo_json');
+    my @possible_cols = ('plant_name','plant_id','subplot_name','subplot_id','plot_name','plot_id','accession_name','accession_id','plot_order','plot_number','block_number','is_a_control','range_number','rep_number','row_number','col_number','seedlot_name','seed_transaction_operator','num_seed_per_plot','subplot_number','plant_number','pedigree','location_name','trial_name','year', 'planting_date', 'synonyms','tier','plot_geo_json');
+
+    $selected_cols{plot_order} = 1 if $include_plot_order;
 
     my @header;
     foreach (@possible_cols){
@@ -78,6 +81,16 @@ sub retrieve {
     my $trial_year = $trial->get_year ? $trial->get_year : '';
     my $trial_planting_date = $trial->get_planting_date ? $trial->get_planting_date : '';
     my $pedigree_strings = $self->_get_all_pedigrees(\%design);
+
+    # Add plot order to design, if requested by the user
+    if ( $include_plot_order ) {
+        my $results = CXGN::Trial->get_sorted_plots($schema, [$self->trial_id], $self->plot_order, $self->plot_start);
+        if ( $results->{plots} ) {
+            foreach (@{$results->{plots}}) {
+                $design{$_->{plot_number}}->{plot_order} = $_->{order};
+            }
+        }
+    }
 
     #Turn plot level design into a plant level design that can be sorted on plot_number and then plant index number..
     my @plant_design;
@@ -131,8 +144,10 @@ sub retrieve {
     my @overall_trait_names = sort keys %$overall_performance_hash;
     my @exact_trait_names = sort keys %$exact_performance_hash;
 
+    # sort plots by plot order, if requested, otherwise plot number then subplot and plant
     no warnings 'uninitialized';
-    @plant_design = sort { $a->{plot_number} <=> $b->{plot_number} || $a->{subplot_number} <=> $b->{subplot_number} || $a->{plant_number} <=> $b->{plant_number} } @plant_design;
+    my $sort_key = $include_plot_order ? 'plot_order' : 'plot_number';
+    @plant_design = sort { $a->{$sort_key} <=> $b->{$sort_key} || $a->{subplot_number} <=> $b->{subplot_number} || $a->{plant_number} <=> $b->{plant_number} } @plant_design;
 
     foreach my $design_info (@plant_design) {
         my $line;

--- a/lib/CXGN/Trial/TrialLayoutDownload/PlotLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/PlotLayout.pm
@@ -51,8 +51,11 @@ sub retrieve {
     my $all_stats = $self->all_stats;
     my @output;
     my $trial_stock_type = $self->trial_stock_type();
+    my $include_plot_order = $self->include_plot_order() && $self->plot_order() && $self->plot_order() ne '' && $self->plot_start() && $self->plot_start() ne '';
 
-    my @possible_cols = ('plot_name','plot_id','accession_name','accession_id','plot_number','block_number','is_a_control','rep_number','range_number','row_number','col_number','seedlot_name','seed_transaction_operator','num_seed_per_plot','pedigree','location_name','trial_name','year', 'planting_date', 'synonyms','tier','plot_geo_json',);
+    my @possible_cols = ('plot_name','plot_id','accession_name','accession_id','plot_order','plot_number','block_number','is_a_control','rep_number','range_number','row_number','col_number','seedlot_name','seed_transaction_operator','num_seed_per_plot','pedigree','location_name','trial_name','year', 'planting_date', 'synonyms','tier','plot_geo_json',);
+
+    $selected_cols{plot_order} = 1 if $include_plot_order;
 
     my @header;
     foreach (@possible_cols){
@@ -77,8 +80,21 @@ sub retrieve {
     my $trial_year = $trial->get_year ? $trial->get_year : '';
     my $trial_planting_date = $trial->get_planting_date ? $trial->get_planting_date : '';
 
+    # Add plot order to design, if requested by the user
+    if ( $include_plot_order ) {
+        my $results = CXGN::Trial->get_sorted_plots($schema, [$self->trial_id], $self->plot_order, $self->plot_start);
+        if ( $results->{plots} ) {
+            foreach (@{$results->{plots}}) {
+                $design{$_->{plot_number}}->{plot_order} = $_->{order};
+            }
+        }
+    }
+
     my @plot_design = values %design;
-    @plot_design = sort { $a->{plot_number} <=> $b->{plot_number} } @plot_design;
+
+    # sort plots by plot order, if requested, otherwise plot number
+    my $sort_key = $include_plot_order ? 'plot_order' : 'plot_number';
+    @plot_design = sort { $a->{$sort_key} <=> $b->{$sort_key} } @plot_design;
     my $pedigree_strings = $self->_get_all_pedigrees(\%design);
 
     my @overall_trait_names = sort keys %$overall_performance_hash;

--- a/lib/CXGN/Trial/TrialLayoutDownload/SubplotLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/SubplotLayout.pm
@@ -51,8 +51,11 @@ sub retrieve {
     my $all_stats = $self->all_stats;
     my @output;
     my $trial_stock_type = $self->trial_stock_type();
+    my $include_plot_order = $self->include_plot_order() && $self->plot_order() && $self->plot_order() ne '' && $self->plot_start() && $self->plot_start() ne '';
 
-    my @possible_cols = ('subplot_name','subplot_id','plot_name','plot_id','accession_name','accession_id','plot_number','block_number','is_a_control','rep_number','range_number','row_number','col_number','seedlot_name','seed_transaction_operator','num_seed_per_plot','subplot_number','pedigree','location_name','trial_name','year', 'planting_date', 'synonyms','tier','plot_geo_json',);
+    my @possible_cols = ('subplot_name','subplot_id','plot_name','plot_id','accession_name','accession_id','plot_order','plot_number','block_number','is_a_control','rep_number','range_number','row_number','col_number','seedlot_name','seed_transaction_operator','num_seed_per_plot','subplot_number','pedigree','location_name','trial_name','year', 'planting_date', 'synonyms','tier','plot_geo_json',);
+
+    $selected_cols{plot_order} = 1 if $include_plot_order;
 
     my @header;
     foreach (@possible_cols){
@@ -81,6 +84,16 @@ sub retrieve {
 
     my @overall_trait_names = sort keys %$overall_performance_hash;
     my @exact_trait_names = sort keys %$exact_performance_hash;
+
+    # Add plot order to design, if requested by the user
+    if ( $include_plot_order ) {
+        my $results = CXGN::Trial->get_sorted_plots($schema, [$self->trial_id], $self->plot_order, $self->plot_start);
+        if ( $results->{plots} ) {
+            foreach (@{$results->{plots}}) {
+                $design{$_->{plot_number}}->{plot_order} = $_->{order};
+            }
+        }
+    }
 
     #Turn plot level design into a subplot level design that can be sorted on plot_number and then subplot index number..
     my @subplot_design;
@@ -112,7 +125,9 @@ sub retrieve {
     }
     #print STDERR Dumper \@subplot_design;
 
-    @subplot_design = sort { $a->{plot_number} <=> $b->{plot_number} || $a->{subplot_number} <=> $b->{subplot_number} } @subplot_design;
+    # sort plots by plot order, if requested, otherwise plot number then by subplot number
+    my $sort_key = $include_plot_order ? 'plot_order' : 'plot_number';
+    @subplot_design = sort { $a->{$sort_key} <=> $b->{$sort_key} || $a->{subplot_number} <=> $b->{subplot_number} } @subplot_design;
 
     foreach my $design_info (@subplot_design) {
         my $line;

--- a/lib/CXGN/Trial/TrialLayoutDownload/TissueSampleLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/TissueSampleLayout.pm
@@ -51,8 +51,11 @@ sub retrieve {
     my $all_stats = $self->all_stats;
     my @output;
     my $trial_stock_type = $self->trial_stock_type();
+    my $include_plot_order = $self->include_plot_order() && $self->plot_order() && $self->plot_order() ne '' && $self->plot_start() && $self->plot_start() ne '';
 
-    my @possible_cols = ('tissue_sample_name','tissue_sample_id','plant_name','plant_id','subplot_name','subplot_id','plot_name','plot_id','accession_name','accession_id','plot_number','block_number','is_a_control','range_number','rep_number','row_number','col_number','seedlot_name','seed_transaction_operator','num_seed_per_plot','subplot_number','plant_number','tissue_sample_number','pedigree','location_name','trial_name','year', 'planting_date','synonyms','tier','plot_geo_json');
+    my @possible_cols = ('tissue_sample_name','tissue_sample_id','plant_name','plant_id','subplot_name','subplot_id','plot_name','plot_id','accession_name','accession_id','plot_order','plot_number','block_number','is_a_control','range_number','rep_number','row_number','col_number','seedlot_name','seed_transaction_operator','num_seed_per_plot','subplot_number','plant_number','tissue_sample_number','pedigree','location_name','trial_name','year', 'planting_date','synonyms','tier','plot_geo_json');
+
+    $selected_cols{plot_order} = 1 if $include_plot_order;
 
     my @header;
     foreach (@possible_cols){
@@ -83,6 +86,16 @@ sub retrieve {
 
     my @overall_trait_names = sort keys %$overall_performance_hash;
     my @exact_trait_names = sort keys %$exact_performance_hash;
+
+    # Add plot order to design, if requested by the user
+    if ( $include_plot_order ) {
+        my $results = CXGN::Trial->get_sorted_plots($schema, [$self->trial_id], $self->plot_order, $self->plot_start);
+        if ( $results->{plots} ) {
+            foreach (@{$results->{plots}}) {
+                $design{$_->{plot_number}}->{plot_order} = $_->{order};
+            }
+        }
+    }
 
     #Turn plot level design into a tissue sample level design that can be sorted on plot_number and then tissue sample index number..
     my @tissue_sample_design;
@@ -153,8 +166,10 @@ sub retrieve {
     }
     print STDERR "TrialLayoutDownload::TissueSample sorting tissue design ".localtime()."\n";
 
+    # sort plots by plot order, if requested, otherwise plot number then by subplot, plant, and/or tissue sample numbers
     no warnings 'uninitialized';
-    @tissue_sample_design = sort { $a->{plot_number} <=> $b->{plot_number} || $a->{subplot_number} <=> $b->{subplot_number} || $a->{plant_number} <=> $b->{plant_number} || $a->{tissue_sample_number} <=> $b->{tissue_sample_number} } @tissue_sample_design;
+    my $sort_key = $include_plot_order ? 'plot_order' : 'plot_number';
+    @tissue_sample_design = sort { $a->{$sort_key} <=> $b->{$sort_key} || $a->{subplot_number} <=> $b->{subplot_number} || $a->{plant_number} <=> $b->{plant_number} || $a->{tissue_sample_number} <=> $b->{tissue_sample_number} } @tissue_sample_design;
 
     print STDERR "TrialLayoutDownload::TissueSample turning tissue design into output ".localtime()."\n";
 

--- a/lib/SGN/Controller/BreedersToolbox/Trial.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Trial.pm
@@ -545,6 +545,9 @@ sub trial_download : Chained('trial_init') PathPart('download') Args(1) {
     my $trait_list = $c->req->param("trait_list");
     my $include_measured = $c->req->param('include_measured') || '';
     my $search_type = $c->req->param("search_type") || 'fast';
+    my $include_plot_order = $c->req->param('include_plot_order') eq 'true';
+    my $plot_order = $c->req->param('plot_order');
+    my $plot_start = $c->req->param('plot_start');
 
     my $trial = $c->stash->{trial};
     if ($data_level eq 'plants') {
@@ -644,7 +647,6 @@ sub trial_download : Chained('trial_init') PathPart('download') Args(1) {
     $rel_file = $rel_file . ".$format";
     my $tempfile = $c->config->{basepath}."/".$rel_file;
 
-
     my $download = CXGN::Trial::Download->new({
         bcs_schema => $schema,
         trial_id => $c->stash->{trial_id},
@@ -658,7 +660,10 @@ sub trial_download : Chained('trial_init') PathPart('download') Args(1) {
         selected_columns => $selected_cols,
         include_measured => $include_measured,
         field_crossing_data_order => \@field_crossing_data_order,
-        prop_id => $prop_id
+        prop_id => $prop_id,
+        include_plot_order => $include_plot_order,
+        plot_order => $plot_order,
+        plot_start => $plot_start,
     });
 
     my $error = $download->download();

--- a/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
@@ -6,6 +6,27 @@ $download_type
 $trial_stock_type => undef
 </%args>
 
+<style>
+    div.layout-container {
+        margin: 15px 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 5px 30px;
+        justify-content: flex-start;
+        align-items: center
+    }
+    div.layout-item {
+        display: flex;
+        gap: 15px;
+        align-items: center;
+        max-width: 250px;
+    }
+    div.layout-item label {
+        text-align: right;
+        max-width: 150px;
+    }
+</style>
+
 <div class="modal fade" id="create_fieldbook_dialog_<% $download_type %>" name="create_fieldbook_dialog_<% $download_type %>" tabindex="-1" role="dialog" aria-labelledby="createFieldbookDialog_<% $download_type %>">
   <div class="modal-dialog modal-xl" role="document">
     <div class="modal-content">
@@ -90,31 +111,32 @@ $trial_stock_type => undef
                 </div>
                 <div id="accession_average_performance">
                     <div class="well">
-                        <div class="form-group">
-                            <label class="col-sm-2 control-label">Include existing plot phenotypes: </label>
-                            <div class="col-sm-1" >
-                                 <input id="create_fieldbook_include_measured_<% $download_type %>" type="checkbox" data-toggle="toggle">
+                        <div class="layout-container">
+                            <div class="layout-item">
+                                <label>Include existing plot phenotypes: </label>
+                                <input id="create_fieldbook_include_measured_<% $download_type %>" type="checkbox" data-toggle="toggle" />
                             </div>
-                            <label class="col-sm-3 control-label">Include summary of overall accession performance (for a list of traits): </label>
-                            <div class="col-sm-2" >
-                                <div id="create_fieldbook_with_trait_list_<% $download_type %>">
-                                </div>
+                            <div class="layout-item">
+                                <label>Include summary of overall accession performance (for a list of traits): </label>
+                                <div id="create_fieldbook_with_trait_list_<% $download_type %>"></div>
                             </div>
-                            <label class="col-sm-1 control-label">Include all stats: </label>
-                            <div class="col-sm-1" >
-                                 <input id="create_fieldbook_all_stats_<% $download_type %>" type="checkbox" checked data-toggle="toggle">
+                            <div class="layout-item">
+                                <label>Include all stats: </label>
+                                <input id="create_fieldbook_all_stats_<% $download_type %>" type="checkbox" checked data-toggle="toggle" />
                             </div>
-                            <label class="col-sm-1 control-label">Use trait synonyms: </label>
-                            <div class="col-sm-1" >
-                                 <input id="create_fieldbook_use_synonyms_<% $download_type %>" type="checkbox" checked data-toggle="toggle">
+                            <div class="layout-item">
+                                <label>Use trait synonyms: </label>
+                                <input id="create_fieldbook_use_synonyms_<% $download_type %>" type="checkbox" checked data-toggle="toggle" />
                             </div>
                         </div>
-                        <div style="margin-top: 15px; display: flex; flex-wrap: wrap; gap: 30px; justify-content: flex-start; align-items: center">
-                            <div style="display: flex; gap: 15px; align-items: center;">
+                    </div>
+                    <div class="well">
+                        <div class="layout-container">
+                            <div class="layout-item">
                                 <label>Include Plot Order:</label>
                                 <input id="create_fieldbook_include_plot_order_<% $download_type %>" type="checkbox" data-toggle="toggle">
                             </div>
-                            <div style="display: flex; gap: 15px; align-items: center;">
+                            <div class="layout-item">
                                 <label>Plot&nbsp;Order:</label>
                                 <select class="form-control" name="create_fieldbook_plot_order_<% $download_type %>" id="create_fieldbook_plot_order_<% $download_type %>">
                                     <option value="">--Select plot order--</option>
@@ -124,7 +146,7 @@ $trial_stock_type => undef
                                     <option value="by_row_zigzag">By Row: Zigzag</option>
                                 </select>
                             </div>
-                            <div style="display: flex; gap: 15px; align-items: center;">
+                            <div class="layout-item">
                                 <label>Starting&nbsp;Plot:</label>
                                 <select class="form-control" id="create_fieldbook_plot_start_<% $download_type %>" name="create_fieldbook_plot_start_<% $download_type %>">
                                     <option value="">--Select start plot--</option>
@@ -588,11 +610,14 @@ function open_create_fieldbook_dialog_<% $download_type %>() {
     var trait_list_id = jQuery('#create_fieldbook_with_trait_list_select_<% $download_type %>_list_select').val();
     var format = jQuery('#create_fieldbook_format_<% $download_type %>').val();
     var include_measurements = jQuery('#create_fieldbook_include_measured_<% $download_type %>').prop('checked');
+    var include_plot_order = jQuery('#create_fieldbook_include_plot_order_<% $download_type %>').prop('checked');
+    var plot_order = jQuery('#create_fieldbook_plot_order_<% $download_type %>').val();
+    var plot_start = jQuery('#create_fieldbook_plot_start_<% $download_type %>').val();
     console.log(format);
     //Calls SGN::Controller:BreedersToolbox::Trial
     for ( let i = 0; i < trial_ids.length; i++ ) {
         let trial_id = parseInt(trial_ids[i]);
-        window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&selected_columns="+selected_columns+"&trait_list_id="+trait_list_id+"&include_measured="+include_measurements);
+        window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&selected_columns="+selected_columns+"&trait_list_id="+trait_list_id+"&include_measured="+include_measurements+"&include_plot_order="+include_plot_order+"&plot_order="+plot_order+"&plot_start="+plot_start);
     }
 }
 
@@ -608,9 +633,12 @@ function open_create_fieldbook_dialog_<% $download_type %>() {
     var selected_columns_TrialFieldMapLayout = {'row_number':1,'col_number':1,'accession_name':1};
     var selected_columns = JSON.stringify(selected_columns_TrialFieldMapLayout);
     var format = jQuery('#create_fieldbook_format_<% $download_type %>').val();
+    var include_plot_order = jQuery('#create_fieldbook_include_plot_order_<% $download_type %>').prop('checked');
+    var plot_order = jQuery('#create_fieldbook_plot_order_<% $download_type %>').val();
+    var plot_start = jQuery('#create_fieldbook_plot_start_<% $download_type %>').val();
     for ( let i = 0; i < trial_ids.length; i++ ) {
         let trial_id = parseInt(trial_ids[i]);
-        window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&selected_columns="+selected_columns);
+        window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&selected_columns="+selected_columns+"&include_plot_order="+include_plot_order+"&plot_order="+plot_order+"&plot_start="+plot_start);
     }
 }
 

--- a/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
@@ -11,19 +11,19 @@ $trial_stock_type => undef
         margin: 15px 0;
         display: flex;
         flex-wrap: wrap;
-        gap: 5px 30px;
-        justify-content: flex-start;
-        align-items: center
+        gap: 30px;
+        justify-content: space-around;
+        align-items: flex-end;
     }
     div.layout-item {
         display: flex;
-        gap: 15px;
-        align-items: center;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 5px;
         max-width: 250px;
     }
     div.layout-item label {
-        text-align: right;
-        max-width: 150px;
+        text-align: left;
     }
 </style>
 
@@ -87,24 +87,14 @@ $trial_stock_type => undef
                     <div class="well">
                         <center><h4>Choose the columns you want to include (Or simply use defaults and click "Submit")</h4></center>
                         <hr>
-                        <div class="row">
-                            <div class="col-sm-6">
-                                <div class="form-group">
-                                    <label class="col-sm-3 control-label">Included Columns: </label>
-                                    <div class="col-sm-9" >
-                                        <div id="create_fieldbook_included_columns_<% $download_type %>">
-                                        </div>
-                                    </div>
-                                </div>
+                        <div class="layout-container" style="align-items: flex-start !important";>
+                            <div class="layout-item">
+                                <label>Included Columns: </label>
+                                <div id="create_fieldbook_included_columns_<% $download_type %>"></div>
                             </div>
-                            <div class="col-sm-6">
-                                <div class="form-group">
-                                    <label class="col-sm-3 control-label">Not Included Columns: </label>
-                                    <div class="col-sm-9" >
-                                        <div id="create_fieldbook_not_included_columns_<% $download_type %>">
-                                        </div>
-                                    </div>
-                                </div>
+                            <div class="layout-item">
+                                <label>Not Included Columns: </label>
+                                <div id="create_fieldbook_not_included_columns_<% $download_type %>"></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds support for customizable plot order to the `TrialLayoutDownload::PlotLayout`, `TrialLayoutDownload::SubplotLayout`, `TrialLayoutDownload::PlantLayout`, and `TrialLayoutDownload::TissueSampleLayout` plugins

It also improves the display of the layout options on smaller screens

<img width="756" height="913" alt="image" src="https://github.com/user-attachments/assets/3cd74ea2-b975-4e16-8850-4d4c6419037f" />

Fixes #6029 



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
