### PR TITLE
output a pedigree on labeldesigner that only has a female parent.

### DIFF
--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -99,6 +99,9 @@ my %ADDITIONAL_LIST_DATA = (
                 if ( $parents->{'mother'} && $parents->{'father'} ) {
                     $pedigree = $parents->{'mother'} . '/' . $parents->{'father'};
                 }
+		elsif ( $parents->{'mother'}) {
+		    $pedigree = $parents->{'mother'} .'/NA';
+		}
 
                 # Add pedigree to return hash
                 for my $index (0 .. $#$list_item_db_ids ) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Also outputs a pedigree where the male parent is missing, with NA as male parent. Important for open pollinated plants.

Fixes #6056

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
