### PR TITLE
fix trial detail page d3 plots disappearance

### DIFF
--- a/js/source/entries/fieldmap.js
+++ b/js/source/entries/fieldmap.js
@@ -568,7 +568,7 @@ export function init() {
             let tempNumCols = this.meta_data.num_cols;
             this.meta_data.num_cols = this.meta_data.num_rows;
             this.meta_data.num_rows = tempNumCols;
-            d3.select("svg").remove();
+            d3.select("#fieldmap_chart").selectAll("svg").remove();
             this.add_borders();
             this.render();
         }
@@ -1402,7 +1402,7 @@ export function init() {
         }
 
         load() {
-            d3.select("svg").remove();
+            d3.select("#fieldmap_chart").selectAll("svg").remove();
             this.change_dimensions(this.meta_data.num_cols, this.meta_data.num_rows);
             this.add_borders();
             this.render();

--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -441,7 +441,7 @@ $trial_stock_type => undef
 
                     <form class="form-horizontal" role="form" method="post" enctype="multipart/form-data" encoding="multipart/form-data" id="trait_deletion_form" name="trait_deletion_form">
 
-                    <p3><b>Please, confirm the deletion of selected trait...</b></p3> </br></br>
+                    <p3><b>Please, confirm the deletion of selected trait...</b></p3></br>
                     <center><p2> ...trait is deleted permanently from the database...</p2></center>
 
                     </form>
@@ -987,6 +987,14 @@ jQuery(document).ready( function() {
 
     }
 
+    function clear_fieldlayout_heatmap() {
+        d3.select("#container_heatmap").selectAll("svg").remove();
+        d3.select("#fieldmap_chart").selectAll("svg").remove();
+        d3.select("#container_fm").selectAll("svg").remove();
+        d3.select("#container_heatmap_geo").selectAll("svg").remove();
+        d3.select("#container_heatmap_geo_div").remove();
+    }
+
     var r = 0;
     var toggleWidthFM = 0;
     jQuery('#rotate_map').click(function(){
@@ -1387,7 +1395,7 @@ jQuery(document).ready( function() {
     });
 
     jQuery('#pheno_heatmap_offswitch').click( function() {
-        d3.select("svg").remove();
+        clear_fieldlayout_heatmap();
         jQuery("#trait_heatmap").css("display", "none");
         jQuery("#trial_heatmap_div").css("display", "none");
         jQuery("#container_heatmap").css("display", "none");
@@ -1402,19 +1410,17 @@ jQuery(document).ready( function() {
     function on_change_view() {
         selected = jQuery("#trait_list_dropdown").val();
         if (selected == 'fieldmap'){
-            d3.select("svg").remove();
+            clear_fieldlayout_heatmap();
             jQuery("#view_ctrl_button").css("display", "none");
             jQuery("#container_heatmap").css("display", "none");
             jQuery("#container_legend").css("display", "block");
             jQuery("#ctrldiv").css("display", "none");
             jQuery("#include_linked_trials").css("display", "block");
-            d3.select("#container_heatmap_geo_div").remove();
             FieldMap.heatmap_selected = false;
             FieldMap.load();
         } else if (selected == 'geofieldmap'){
             jQuery('#working_modal').modal("show");
-            d3.select("svg").remove();
-            d3.select("#container_heatmap_geo_div").remove();
+            clear_fieldlayout_heatmap();
             d3.select('#container_heatmap_geo').append('div').attr("id","container_heatmap_geo_div");
             jQuery("#container_heatmap").css("display", "none");
             jQuery("#d3legend").css("display", "none");
@@ -1427,8 +1433,7 @@ jQuery(document).ready( function() {
             geo_field_map_view();
             jQuery('#working_modal').modal("hide");
         } else  if (selected != ''){
-            d3.select("svg").remove();
-            d3.select("#container_heatmap_geo_div").remove();
+            clear_fieldlayout_heatmap();
             jQuery("#delete_button_fm").css("display", "none");
             jQuery("#ctrldiv").css("display", "none");
             jQuery("#view_ctrl_button").show();

--- a/mason/breeders_toolbox/trial/trial_coords.mas
+++ b/mason/breeders_toolbox/trial/trial_coords.mas
@@ -47,7 +47,7 @@ $trial_id
   <li><span class="checks"></span> Checks</li>
   <li><span class="rep_odd_number"></span> Odd Rep Numbers (e.g. 1,3,...)</li>
   <li><span class="rep_even_number"></span> Even Rep Numbers (e.g. 2,4,...)</li>
-</ul> </br></br> <b>Field Layout Columns </b></div></p>
+</ul> </br><b>Field Layout Columns </b></div></p>
 
  <div id="container" ></div>
  <div id="trial_coords" >loading...</div>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
-- In the field layout heatmap related section, there were non-specific calls for svg elements  removals. Whenever the section was drawing plots, it was removing any svg element in the trial detail page, including analysis tools and histogram plots. Making these svg remove calls specific to the field layout heatmap elements solves the problem.

fixes #6041

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
