### PR TITLE
add crosses and families to validator 

### DIFF
--- a/lib/CXGN/List/Validate/Plugin/PlotsOrSubplotOrPlantsOrCrossesOrFamiliesOrTissueSamplesOrAnalysisInstances.pm
+++ b/lib/CXGN/List/Validate/Plugin/PlotsOrSubplotOrPlantsOrCrossesOrFamiliesOrTissueSamplesOrAnalysisInstances.pm
@@ -1,0 +1,38 @@
+
+package CXGN::List::Validate::Plugin::PlotsOrSubplotOrPlantsOrCrossesOrFamiliesOrTissueSamplesOrAnalysisInstances;
+
+use Moose;
+use SGN::Model::Cvterm;
+
+sub name {
+    return "plots_or_subplots_or_plants_or_crosses_or_families_or_tissue_samples_or_analysis_instances";
+}
+
+sub validate {
+    my $self = shift;
+    my $schema = shift;
+    my $list = shift;
+
+    my $plant_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant', 'stock_type')->cvterm_id();
+    my $plot_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
+    my $cross_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'cross', 'stock_type')->cvterm_id();
+    my $family_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'family', 'stock_type')->cvterm_id();
+    my $subplot_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'subplot', 'stock_type')->cvterm_id();
+    my $tissue_sample_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample', 'stock_type')->cvterm_id();
+    my $analysis_instance_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'analysis_instance', 'stock_type')->cvterm_id();
+
+    my @missing = ();
+    foreach my $l (@$list) {
+        my $rs = $schema->resultset("Stock::Stock")->search({
+            type_id=> [$plot_type_id, $plant_type_id, $subplot_type_id, $tissue_sample_type_id, $family_type_id, $cross_type_id,  $analysis_instance_type_id],
+            uniquename => $l,
+            is_obsolete => {'!=' => 't'},
+        });
+        if ($rs->count() == 0) {
+            push @missing, $l;
+        }
+    }
+    return { missing => \@missing };
+}
+
+1;

--- a/lib/CXGN/List/Validate/Plugin/PlotsOrSubplotOrPlantsOrCrossesOrFamiliesOrTissueSamplesOrAnalysisInstances.pm
+++ b/lib/CXGN/List/Validate/Plugin/PlotsOrSubplotOrPlantsOrCrossesOrFamiliesOrTissueSamplesOrAnalysisInstances.pm
@@ -16,7 +16,7 @@ sub validate {
     my $plant_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant', 'stock_type')->cvterm_id();
     my $plot_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
     my $cross_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'cross', 'stock_type')->cvterm_id();
-    my $family_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'family', 'stock_type')->cvterm_id();
+    my $family_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'family_name', 'stock_type')->cvterm_id();
     my $subplot_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'subplot', 'stock_type')->cvterm_id();
     my $tissue_sample_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample', 'stock_type')->cvterm_id();
     my $analysis_instance_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'analysis_instance', 'stock_type')->cvterm_id();

--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -441,7 +441,7 @@ sub verify {
     my $trait_validator = CXGN::List::Validate->new(
         composable_validation_check_name => $self->{composable_validation_check_name}
     );
-    my @plots_missing = @{$plot_validator->validate($schema,'plots_or_subplots_or_plants_or_tissue_samples_or_analysis_instances',\@plot_list)->{'missing'}};
+    my @plots_missing = @{$plot_validator->validate($schema,'plots_or_subplots_or_plants_or_crosses_or_families_or_tissue_samples_or_analysis_instances',\@plot_list)->{'missing'}};
     my $traits_validation = $trait_validator->validate($schema,'traits',\@trait_list);
     my @traits_missing = @{$traits_validation->{'missing'}};
     my @traits_wrong_ids = @{$traits_validation->{'wrong_ids'}};
@@ -549,8 +549,8 @@ sub verify {
                 foreach my $value_array (@$measurements_array) {
                     # print STDERR "Value array = ".Dumper($value_array)."\n";
 		    my $multiple_values = 0;
-		    if (scalar(@$measurements_array) > 1) { $multiple_values = 1; } 
-                    ($warnings, $errors) = $self->check_measurement($plot_name, $trait_name, $value_array, $multiple_values); 
+		    if (scalar(@$measurements_array) > 1) { $multiple_values = 1; }
+                    ($warnings, $errors) = $self->check_measurement($plot_name, $trait_name, $value_array, $multiple_values);
                     $error_message .= $errors;
                     $warning_message .= $warnings;
                 }
@@ -609,7 +609,7 @@ sub check_measurement {
     my $trait_name = shift;
     my $value_array = shift;
     my $file_contains_multiple_values = shift;
-    
+
     my $error_message = "";
     my $warning_message = "";
 
@@ -655,7 +655,7 @@ sub check_measurement {
         }
 
         #check that trait value is valid for trait name (but only if we have a trait_value)
-        if ((defined($trait_value) && $trait_value ne '' && $trait_value ne 'NA' && $trait_value ne '.') && exists($self->check_trait_format()->{$trait_cvterm_id})) { 
+        if ((defined($trait_value) && $trait_value ne '' && $trait_value ne 'NA' && $trait_value ne '.') && exists($self->check_trait_format()->{$trait_cvterm_id})) {
             # print STDERR "Trait minimum value checks if it exists: " . $self->check_trait_min_value->{$trait_cvterm_id} . "\n";
             if ($self->check_trait_format()->{$trait_cvterm_id} =~ m/numeric|counter|percent|boolean/i ) {
                 my $trait_format_checked = looks_like_number($trait_value);
@@ -718,8 +718,8 @@ sub check_measurement {
 
             my @check_values;
             if (exists($self->check_trait_category()->{$trait_cvterm_id}) &&
-                ($self->check_trait_format->{$trait_cvterm_id} eq 'Multicat' || 
-                $self->check_trait_format->{$trait_cvterm_id} eq 'categorical' || 
+                ($self->check_trait_format->{$trait_cvterm_id} eq 'Multicat' ||
+                $self->check_trait_format->{$trait_cvterm_id} eq 'categorical' ||
                 $self->check_trait_format->{$trait_cvterm_id} eq 'qualitative')) {
 
                 # print STDERR "Dealing with a categorical trait!\n\n";
@@ -789,7 +789,7 @@ sub check_measurement {
 	    if ($file_contains_multiple_values  && (defined($trait_value) && $trait_value ne '')) {
 		$warning_message .= "Multiple values present in file for single repeat_type term $trait_name\n";
 	    }
-	    
+
             print STDERR "Processing this trait with value $trait_value as a single repeat type trait with overwrite_values set to ".$self->overwrite_values()."...\n";
             if (exists($self->unique_value_trait_stock->{$trait_value, $trait_cvterm_id, $stock_id})) {
                 my $prev = $self->unique_value_trait_stock->{$trait_value, $trait_cvterm_id, $stock_id};


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
StorePhenotypes apparently cannot store phenotypes for crosses or families. This PR should potentially fix this

Closes #6058.
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
