### PR TITLE
Add check for plot name appearing more than once

### DIFF
--- a/lib/CXGN/File/Parse.pm
+++ b/lib/CXGN/File/Parse.pm
@@ -119,6 +119,21 @@ COLUMN ARRAYS
     }
   );
 
+UNIQUE-ONLY COLUMNS
+  - Specify columns that are not allowed to have duplicate data entries
+  - By default, columns can have row values that are duplicated (appear in multiple rows)
+  - This is useful for ensuring some one-to-one data entries are caught in parsing
+  - Specify columns that should not have duplicate entries in a hash with the column name as a key
+  - For columns that can have repeated entries, just leave them out of the hash
+
+  my $parser = CXGN::File::Parse->new(
+    file => '/path/to/data.xlsx',
+    required_columns => ['accession_name', 'species_name'],
+    unique_only_columns => {
+      'accession_name' => 1
+    }
+  );
+
 CASE SENSITIVITY
   - Column names are case-insensitive for any names provided in required_columns, optional_columns, or column_aliases (known column names)
   - If the file contains a column name in a different case than the known column name, the column name in the file
@@ -245,6 +260,12 @@ has column_arrays => (
   is => "ro"
 );
 
+# Hash of column names that must contain unique data values
+has unique_only_columns => (
+  isa => "HashRef",
+  is => "ro"
+);
+
 
 #
 # PROCESS INITIAL ARGUMENTS
@@ -298,6 +319,7 @@ sub parse {
   my $required_columns = $self->required_columns();
   my $optional_columns = $self->optional_columns();
   my $column_arrays = $self->column_arrays();
+  my $unique_only_columns = $self->unique_only_columns();
 
   # If type is not defined, use the file extension
   if ( !$type ) {
@@ -388,17 +410,29 @@ sub parse {
         }
       }
 
-      # Check the data for missing required values
+      # Check the data for missing required values and disallowed duplicates
+      my $seen = {};
       foreach my $d (@$data) {
         foreach my $c ( @{$parsed->{required_columns}} ) {
           my $v = $d->{$c};
+          my $r = $d->{_row};
           if ( !defined($v) || $v eq '' ) {
-            my $r = $d->{_row};
             push @{$parsed->{errors}}, "Required column $c does not have a value in row $r";
           }
+          if ($unique_only_columns->{$c} && $seen->{$c}->{$v}) {
+            push @{$parsed->{errors}}, "Column $c requires unique values, but $v on row $r appears more than once";
+          }
+          $seen->{$c}->{$v} = 1;
+        }
+        foreach my $c ( (@{$parsed->{optional_columns}}, @{$parsed->{additional_columns}}) ) {
+          my $v = $d->{$c};
+          my $r = $d->{_row};
+          if ($unique_only_columns->{$c} && $seen->{$c}->{$v}) {
+            push @{$parsed->{errors}}, "Column $c requires unique values, but $v on row $r appears more than once";
+          }
+          $seen->{$c}->{$v} = 1;
         }
       }
-
     }
 
     # Add columns that are arrays, as defined in the CXGN::File::Parse constructor

--- a/lib/CXGN/File/Parse.pm
+++ b/lib/CXGN/File/Parse.pm
@@ -419,7 +419,7 @@ sub parse {
           if ( !defined($v) || $v eq '' ) {
             push @{$parsed->{errors}}, "Required column $c does not have a value in row $r";
           }
-          if ($unique_only_columns->{$c} && $seen->{$c}->{$v}) {
+          if (($v ne '' && defined($v)) && $unique_only_columns->{$c} && $seen->{$c}->{$v}) {
             push @{$parsed->{errors}}, "Column $c requires unique values, but $v on row $r appears more than once";
           }
           $seen->{$c}->{$v} = 1;
@@ -427,7 +427,7 @@ sub parse {
         foreach my $c ( (@{$parsed->{optional_columns}}, @{$parsed->{additional_columns}}) ) {
           my $v = $d->{$c};
           my $r = $d->{_row};
-          if ($unique_only_columns->{$c} && $seen->{$c}->{$v}) {
+          if (($v ne '' && defined($v)) && $unique_only_columns->{$c} && $seen->{$c}->{$v}) {
             push @{$parsed->{errors}}, "Column $c requires unique values, but $v on row $r appears more than once";
           }
           $seen->{$c}->{$v} = 1;

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessions.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessions.pm
@@ -122,13 +122,28 @@ sub _parse_with_plugin {
 
     my $parsed_data = $self->_parsed_data()->{parsed};
 
+    my @error_messages = ();
+    my %seen = ();
     foreach my $row (@$parsed_data) {
+        if (! $seen{$row->{'plot_name'}}) {
+            $seen{$row->{'plot_name'}} = 1;
+        } else {
+            my $plot_name = $row->{'plot_name'};
+            push @error_messages, "$plot_name appears in the plot list more than once.";
+        }
         $parsed_entries->{$row->{'plot_name'}} = {
             'old_plot_name' => $row->{'plot_name'},
             'new_plot_name' => $row->{'new_plot_name'} ? $row->{'new_plot_name'} : '',
             'new_accession_name' => $row->{'accession_name'},
             'new_accession_id' => $parsed_accession_ids->{$row->{'accession_name'}}
         };
+    }
+
+    if (scalar(@error_messages) > 0) {
+        $self->_set_parse_errors({
+            'error_messages' => \@error_messages
+        });
+        return 0;
     }
 
     $self->_set_parsed_data($parsed_entries);

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessions.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessions.pm
@@ -30,6 +30,10 @@ sub _validate_with_plugin {
             'plot_name' => ['plot name'],
             'new_plot_name' => ['new plot name'],
             'accession_name' => ['accession name', 'accession', 'cross_unique_id', 'cross unique id', 'family_name', 'family name']
+        },
+        unique_only_columns =>  {
+            'plot_name' => 1,
+            'new_plot_name' => 1
         }
     );
 
@@ -122,28 +126,13 @@ sub _parse_with_plugin {
 
     my $parsed_data = $self->_parsed_data()->{parsed};
 
-    my @error_messages = ();
-    my %seen = ();
     foreach my $row (@$parsed_data) {
-        if (! $seen{$row->{'plot_name'}}) {
-            $seen{$row->{'plot_name'}} = 1;
-        } else {
-            my $plot_name = $row->{'plot_name'};
-            push @error_messages, "$plot_name appears in the plot list more than once.";
-        }
         $parsed_entries->{$row->{'plot_name'}} = {
             'old_plot_name' => $row->{'plot_name'},
             'new_plot_name' => $row->{'new_plot_name'} ? $row->{'new_plot_name'} : '',
             'new_accession_name' => $row->{'accession_name'},
             'new_accession_id' => $parsed_accession_ids->{$row->{'accession_name'}}
         };
-    }
-
-    if (scalar(@error_messages) > 0) {
-        $self->_set_parse_errors({
-            'error_messages' => \@error_messages
-        });
-        return 0;
     }
 
     $self->_set_parsed_data($parsed_entries);

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -2264,7 +2264,11 @@ sub trial_change_plot_accessions_upload : Chained('trial') PathPart('change_plot
         $c->detach();
     }
     unlink $upload_tempfile;
-    my $parser = CXGN::Trial::ParseUpload->new(chado_schema => $schema, filename => $archived_filename_with_path, trial_id => $trial_id);
+    my $parser = CXGN::Trial::ParseUpload->new(
+        chado_schema => $schema, 
+        filename => $archived_filename_with_path, 
+        trial_id => $trial_id
+    );
     $parser->load_plugin('TrialChangePlotAccessions');
     my $parsed_data = $parser->parse();
     #print STDERR Dumper $parsed_data;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Adds a unique_only_columns hash to the generic file parser to denote column names that cannot have duplicated row entries

<!-- If there are relevant issues, link them here: -->
Closes #6069 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
