### PR TITLE
Remove treatment projects and integrate new treatments into downloads

### DIFF
--- a/lib/CXGN/BrAPI/v2/Observations.pm
+++ b/lib/CXGN/BrAPI/v2/Observations.pm
@@ -295,7 +295,7 @@ sub _search {
     my $counter = 0;
 
     foreach (@$data){
-        if ( ($_->{phenotype_value} && $_->{phenotype_value} ne "") || $_->{phenotype_value} eq '0' ) {
+        if ( ($_->{phenotype_value} && $_->{phenotype_value} ne "") || ($_->{phenotype_value} && $_->{phenotype_value} eq '0') ) {
             my $observation_id = "$_->{phenotype_id}";
             my $additional_info;
             my $external_references;
@@ -310,8 +310,14 @@ sub _search {
 	        if ($obs_timestamp) {
                 my ($obs_date, $obs_time) = split / /, $obs_timestamp;
 		        my ($obs_year, $obs_month, $obs_day) = split /-/, $obs_date;
-		        my ($start_year, $start_month, $start_day) = split /\-/, $start_date;
-		        my ($end_year, $end_month, $end_day) = split /\-/, $end_date;
+		        my ($start_year, $start_month, $start_day);
+                if ($start_date) {
+                    ($start_year, $start_month, $start_day) = split /\-/, $start_date;
+                }
+		        my ($end_year, $end_month, $end_day);
+                if ($end_date) {
+                    ($end_year, $end_month, $end_day) = split /\-/, $end_date;
+                } 
 
 		        if ($obs_year && $obs_month && $obs_day && $start_year && $start_month && $start_day && $end_year && $end_month && $end_day) { 
 		            my $obs_date_obj = DateTime->new({ year => $obs_year, month => $obs_month, day => $obs_day });

--- a/lib/CXGN/Fieldbook/DownloadTrial.pm
+++ b/lib/CXGN/Fieldbook/DownloadTrial.pm
@@ -18,7 +18,7 @@ my $create_fieldbook = CXGN::Fieldbook::DownloadTrial->new({
     user_id => $c->user()->get_object()->get_sp_person_id(),
     user_name => $c->user()->get_object()->get_username(),
     data_level => 'plots',
-    treatment_project_ids => [1],
+    treatment_ids => ['test_treatment|EXPERIMENT_TREATMENT:0000001'],
     selected_columns => {"plot_name"=>1,"block_number"=>1,"plot_number"=>1},
     include_measured => 1,
     selected_trait_ids => [2,3],
@@ -112,7 +112,7 @@ has 'data_level' => (
 
 has 'file_metadata' => (isa => 'Str', is => 'rw', predicate => 'has_file_metadata');
 
-has 'treatment_project_ids' => (
+has 'selected_treatment_ids' => (
     isa => 'ArrayRef[Int]|Undef',
     is => 'rw'
 );
@@ -207,7 +207,7 @@ sub download {
         schema => $schema,
         trial_id => $trial_id,
         data_level => $self->data_level,
-        treatment_project_ids => $self->treatment_project_ids,
+        selected_treatment_ids => $self->selected_treatment_ids,
         selected_columns => $self->selected_columns,
         include_measured => $self->include_measured,
         all_stats => $self->all_stats,

--- a/lib/CXGN/Fieldbook/DownloadTrial.pm
+++ b/lib/CXGN/Fieldbook/DownloadTrial.pm
@@ -18,7 +18,7 @@ my $create_fieldbook = CXGN::Fieldbook::DownloadTrial->new({
     user_id => $c->user()->get_object()->get_sp_person_id(),
     user_name => $c->user()->get_object()->get_username(),
     data_level => 'plots',
-    treatment_ids => ['test_treatment|EXPERIMENT_TREATMENT:0000001'],
+    selected_treatment_ids => ['test_treatment|EXPERIMENT_TREATMENT:0000001'],
     selected_columns => {"plot_name"=>1,"block_number"=>1,"plot_number"=>1},
     include_measured => 1,
     selected_trait_ids => [2,3],

--- a/lib/CXGN/Fieldbook/DownloadTrial.pm
+++ b/lib/CXGN/Fieldbook/DownloadTrial.pm
@@ -112,9 +112,10 @@ has 'data_level' => (
 
 has 'file_metadata' => (isa => 'Str', is => 'rw', predicate => 'has_file_metadata');
 
-has 'selected_treatment_ids' => (
-    isa => 'ArrayRef[Int]|Undef',
-    is => 'rw'
+has 'include_treatments' => (
+    isa => 'Str',
+    is => 'rw',
+    default => 'true'
 );
 
 has 'selected_columns' => (
@@ -207,7 +208,7 @@ sub download {
         schema => $schema,
         trial_id => $trial_id,
         data_level => $self->data_level,
-        selected_treatment_ids => $self->selected_treatment_ids,
+        include_treatments => $self->include_treatments,
         selected_columns => $self->selected_columns,
         include_measured => $self->include_measured,
         all_stats => $self->all_stats,

--- a/lib/CXGN/Trial/Download.pm
+++ b/lib/CXGN/Trial/Download.pm
@@ -100,7 +100,7 @@ $c->stash->{rest} = { filename => $urlencode{$tempfile.".xls"} };
 For downloading a trial's layout (as used from CXGN::Trial::Download->trial_download):
 
 A trial's layout can optionally include treatment and phenotype summary
-information, mapping to treatment_project_ids and trait_list.
+information, mapping to treatment_ids and trait_list.
 These keys can be ignored if you don't need them in the layout.
 
 As a XLS:
@@ -118,7 +118,7 @@ my $download = CXGN::Trial::Download->new({
     filename => $tempfile,
     format => $plugin,
     data_level => $data_level,
-    treatment_project_ids => \@treatment_project_ids,
+    treatment_ids => \@treatment_ids,
     selected_columns => $selected_cols,
 });
 my $error = $download->download();
@@ -223,7 +223,7 @@ has 'trait_contains' => (isa => 'ArrayRef[Str]|Undef', is => 'rw');
 has 'phenotype_min_value' => (isa => 'Str', is => 'rw');
 has 'phenotype_max_value' => (isa => 'Str', is => 'rw');
 has 'search_type' => (isa => 'Str', is => 'rw');
-has 'treatment_project_ids' => (isa => 'ArrayRef[Int]|Undef', is => 'rw');
+has 'treatment_ids' => (isa => 'ArrayRef[Int]|Undef', is => 'rw');
 has 'selected_columns' => (isa => 'HashRef|Undef', is => 'rw');
 has 'include_notes' => (isa => 'Str', is => 'rw');
 has 'filename' => (isa => 'Str', is => 'ro',

--- a/lib/CXGN/Trial/Download.pm
+++ b/lib/CXGN/Trial/Download.pm
@@ -223,7 +223,7 @@ has 'trait_contains' => (isa => 'ArrayRef[Str]|Undef', is => 'rw');
 has 'phenotype_min_value' => (isa => 'Str', is => 'rw');
 has 'phenotype_max_value' => (isa => 'Str', is => 'rw');
 has 'search_type' => (isa => 'Str', is => 'rw');
-has 'treatment_ids' => (isa => 'ArrayRef[Int]|Undef', is => 'rw');
+has 'include_treatments' => (isa => 'Str', is => 'rw', default => 'true');
 has 'selected_columns' => (isa => 'HashRef|Undef', is => 'rw');
 has 'include_notes' => (isa => 'Str', is => 'rw');
 has 'filename' => (isa => 'Str', is => 'ro',

--- a/lib/CXGN/Trial/Download/Plugin/TrialLayoutCSV.pm
+++ b/lib/CXGN/Trial/Download/Plugin/TrialLayoutCSV.pm
@@ -14,7 +14,7 @@ This plugin module is loaded from CXGN::Trial::Download
 For downloading a trial's layout (as used from CXGN::Trial::Download->trial_download):
 
 A trial's layout can optionally include treatment and phenotype summary
-information, mapping to treatment_project_ids and trait_list.
+information, mapping to treatment_ids and trait_list.
 These keys can be ignored if you don't need them in the layout.
 
 As a XLS:
@@ -31,7 +31,7 @@ my $download = CXGN::Trial::Download->new({
     filename => $tempfile,
     format => $plugin,
     data_level => $data_level,
-    treatment_project_ids => \@treatment_project_ids,
+    treatment_ids => \@treatment_ids,
     selected_columns => $selected_cols,
 });
 my $error = $download->download();
@@ -73,7 +73,7 @@ sub download {
             schema => $self->bcs_schema,
             trial_id => $trial_id,
             data_level => $self->data_level,
-            treatment_project_ids => $self->treatment_project_ids,
+            selected_treatment_ids => $self->treatment_ids,
             selected_columns => $self->selected_columns,
             selected_trait_ids => $self->trait_list,
             include_measured => $self->include_measured,

--- a/lib/CXGN/Trial/Download/Plugin/TrialLayoutCSV.pm
+++ b/lib/CXGN/Trial/Download/Plugin/TrialLayoutCSV.pm
@@ -66,14 +66,12 @@ sub download {
 
     my $it = 0;
     foreach my $trial_id (@trial_ids) {
-        my $trial = CXGN::Trial->new( { bcs_schema => $self->bcs_schema, trial_id => $trial_id });
-        my $treatments = $trial->get_treatments();
 
         my $trial_layout_download = CXGN::Trial::TrialLayoutDownload->new({
             schema => $self->bcs_schema,
             trial_id => $trial_id,
             data_level => $self->data_level,
-            selected_treatment_ids => $self->treatment_ids,
+            include_treatments => $self->include_treatments,
             selected_columns => $self->selected_columns,
             selected_trait_ids => $self->trait_list,
             include_measured => $self->include_measured,

--- a/lib/CXGN/Trial/Download/Plugin/TrialLayoutExcel.pm
+++ b/lib/CXGN/Trial/Download/Plugin/TrialLayoutExcel.pm
@@ -14,7 +14,7 @@ This plugin module is loaded from CXGN::Trial::Download
 For downloading a trial's layout (as used from CXGN::Trial::Download->trial_download):
 
 A trial's layout can optionally include treatment and phenotype summary
-information, mapping to treatment_project_ids and trait_list.
+information, mapping to treatment_ids and trait_list.
 These keys can be ignored if you don't need them in the layout.
 
 As a XLS:
@@ -30,7 +30,7 @@ my $download = CXGN::Trial::Download->new({
     filename => $tempfile,
     format => $plugin,
     data_level => $data_level,
-    treatment_project_ids => \@treatment_project_ids,
+    treatment_ids => \@treatment_ids,
     selected_columns => $selected_cols,
 });
 my $error = $download->download();
@@ -80,7 +80,7 @@ sub download {
         schema => $self->bcs_schema,
         trial_id => $self->trial_id,
         data_level => $self->data_level,
-        treatment_project_ids => $self->treatment_project_ids,
+        selected_treatment_ids => $self->treatment_ids,
         selected_columns => $self->selected_columns,
         selected_trait_ids => $self->trait_list,
         include_measured => $self->include_measured,

--- a/lib/CXGN/Trial/Download/Plugin/TrialLayoutExcel.pm
+++ b/lib/CXGN/Trial/Download/Plugin/TrialLayoutExcel.pm
@@ -80,7 +80,7 @@ sub download {
         schema => $self->bcs_schema,
         trial_id => $self->trial_id,
         data_level => $self->data_level,
-        selected_treatment_ids => $self->treatment_ids,
+        include_treatments => $self->include_treatments,
         selected_columns => $self->selected_columns,
         selected_trait_ids => $self->trait_list,
         include_measured => $self->include_measured,

--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -206,10 +206,15 @@ sub get_layout_output {
         trial_id => $trial_id
     });
 
-    my $treatments = $trial->get_treatments();
-    my $traits = $trial->get_traits_assayed();
-    my @treatment_ids = map { $_->{trait_name} } @{$treatments};
-    my @trait_ids = map {$_->[1] if $_->[1] !~ m/_TREATMENT/} @{$traits};
+    my $trial_treatments = $trial->get_treatments();
+    my $trial_traits = $trial->get_traits_assayed();
+    my @trial_treatment_names = map { $_->{trait_name} } @{$trial_treatments};
+    my @trial_trait_names = map {$_->[1] if $_->[1] !~ m/_TREATMENT/} @{$trial_traits};
+
+    my $t = CXGN::List::Transform->new();
+    my @selected_trait_names_all = @{$t->transform($schema, 'trait_ids_2_trait_names', \@selected_traits)->{'transform'}};
+    my @selected_trait_names = uniq(());
+    
 
     my $trial_layout;
     try {
@@ -339,15 +344,15 @@ sub get_layout_output {
 
     # filter through exact performance hash and keep traits and treatments as requested
     my $new_exact_hash = {};
-    my @combined_terms = (@selected_traits);
+    my @combined_terms = (@selected_trait_names);
     if ($include_measured eq 'true') {
-        @combined_terms = (@combined_terms, @trait_ids);
+        @combined_terms = (@combined_terms, @trial_trait_names);
     }
     if ($include_treatments eq 'true') {
-        @combined_terms = (@combined_terms, @treatment_ids);
+        @combined_terms = (@combined_terms, @trial_treatment_names);
     }
     foreach my $term (@combined_terms) {
-        $new_exact_hash->{$term} = $exact_performance_hash->{$term} ? $exact_performance_hash->{$term} : {};
+        $new_exact_hash->{$term} = $exact_performance_hash->{$term};
     }
     $exact_performance_hash = $new_exact_hash;
 
@@ -356,9 +361,15 @@ sub get_layout_output {
     my @overall_trait_names = sort keys %overall_performance_hash;
     my @traits = (@exact_trait_names,@overall_trait_names);
 
+    print STDERR "\n=================================\n";
+    print STDERR Dumper \@traits;
+    print STDERR Dumper \@exact_trait_names;
+    print STDERR Dumper \@overall_trait_names;
+    print STDERR "\n=================================\n";
+
     if ($use_synonyms eq 'true') {
         print STDERR "Getting synonyms\n";
-        my $t = CXGN::List::Transform->new();
+        
         my $trait_id_list = $t->transform($schema, 'traits_2_trait_ids', [@traits]);
         my @trait_ids = @{$trait_id_list->{'transform'}};
         my $synonym_list = $t->transform($schema, 'trait_ids_2_synonyms', $trait_id_list->{'transform'});

--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -339,7 +339,7 @@ sub get_layout_output {
 
     # filter through exact performance hash and keep traits and treatments as requested
     my $new_exact_hash = {};
-    my @combined_terms = ();
+    my @combined_terms = (@selected_traits);
     if ($include_measured eq 'true') {
         @combined_terms = (@combined_terms, @trait_ids);
     }
@@ -347,7 +347,7 @@ sub get_layout_output {
         @combined_terms = (@combined_terms, @treatment_ids);
     }
     foreach my $term (@combined_terms) {
-        $new_exact_hash->{$term} = $exact_performance_hash->{$term};
+        $new_exact_hash->{$term} = $exact_performance_hash->{$term} ? $exact_performance_hash->{$term} : {};
     }
     $exact_performance_hash = $new_exact_hash;
 

--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -333,7 +333,11 @@ sub get_layout_output {
     my $trait_names_list = $trt_transform->transform($schema, 'trait_ids_2_trait_names', \@selected_traits);
     @selected_traits = @{$trait_names_list->{transform}};
     my $new_exact_hash = {};
-    foreach my $term ((@selected_traits,@selected_treatments)) {
+    my @combined_terms = @selected_treatments;
+    if ($include_measured) {
+        @combined_terms = (@combined_terms, @selected_traits);
+    }
+    foreach my $term (@combined_terms) {
         $new_exact_hash->{$term} = $exact_performance_hash->{$term};
     }
     $exact_performance_hash = $new_exact_hash;

--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -117,6 +117,11 @@ has 'selected_trait_ids'=> (
     isa => 'ArrayRef[Int]|Undef',
 );
 
+has 'selected_treatment_ids' => (
+    is => 'ro',
+    isa => 'ArrayRef[Int]|Undef'
+);
+
 has 'trial_stock_type'=> (
     is => 'rw',
     isa => 'Str',
@@ -189,6 +194,7 @@ sub get_layout_output {
     my $use_synonyms = $self->use_synonyms();
     my %selected_cols = %{$self->selected_columns};
     my @selected_traits = $self->selected_trait_ids() ? @{$self->selected_trait_ids} : ();
+    my @selected_treatments = $self->selected_treatment_ids() ? @{$self->selected_treatment_ids} : ();
     my %errors;
     my @error_messages;
     my $trial_stock_type = $self->trial_stock_type();
@@ -264,58 +270,49 @@ sub get_layout_output {
     my $exact_performance_hash;
 
     if ($data_level eq 'plots') {
-        if ($include_measured eq 'true') {
-            print STDERR "Getting exact trait values\n";
-            my $exact = CXGN::Phenotypes::Exact->new({
-                bcs_schema=>$schema,
-                trial_id=>$trial_id,
-                data_level=>'plot'
-            });
-            $exact_performance_hash = $exact->search(); #this gets treatments too!
-            #print STDERR "Exact Performance hash is ".Dumper($exact_performance_hash)."\n";
-        }
+        print STDERR "Getting exact trait values\n";
+        my $exact = CXGN::Phenotypes::Exact->new({
+            bcs_schema=>$schema,
+            trial_id=>$trial_id,
+            data_level=>'plot'
+        });
+        $exact_performance_hash = $exact->search(); #this gets treatments too!
     } elsif ($data_level eq 'plants') {
         if (!$has_plants){
             push @error_messages, "Trial does not have plants, so you should not try to download a plant level layout.";
             $errors{'error_messages'} = \@error_messages;
             return \%errors;
         }
-        if ($include_measured eq 'true') {
-            my $exact = CXGN::Phenotypes::Exact->new({
-                bcs_schema=>$schema,
-                trial_id=>$trial_id,
-                data_level=>'plant'
-            });
-            $exact_performance_hash = $exact->search();
-        }
+        my $exact = CXGN::Phenotypes::Exact->new({
+            bcs_schema=>$schema,
+            trial_id=>$trial_id,
+            data_level=>'plant'
+        });
+        $exact_performance_hash = $exact->search();
     } elsif ($data_level eq 'subplots') {
         if (!$has_subplots){
             push @error_messages, "Trial does not have subplots, so you should not try to download a subplot level layout.";
             $errors{'error_messages'} = \@error_messages;
             return \%errors;
         }
-        if ($include_measured eq 'true') {
-            my $exact = CXGN::Phenotypes::Exact->new({
-                bcs_schema=>$schema,
-                trial_id=>$trial_id,
-                data_level=>'subplot'
-            });
-            $exact_performance_hash = $exact->search();
-        }
+        my $exact = CXGN::Phenotypes::Exact->new({
+            bcs_schema=>$schema,
+            trial_id=>$trial_id,
+            data_level=>'subplot'
+        });
+        $exact_performance_hash = $exact->search();
     } elsif ($data_level eq 'field_trial_tissue_samples') {
         if (!$has_tissue_samples){
             push @error_messages, "Trial does not have tissue samples, so you should not try to download a tissue sample level layout.";
             $errors{'error_messages'} = \@error_messages;
             return \%errors;
         }
-        if ($include_measured eq 'true') {
-            my $exact = CXGN::Phenotypes::Exact->new({
-                bcs_schema=>$schema,
-                trial_id=>$trial_id,
-                data_level=>'tissue_sample'
-            });
-            $exact_performance_hash = $exact->search();
-        }
+        my $exact = CXGN::Phenotypes::Exact->new({
+            bcs_schema=>$schema,
+            trial_id=>$trial_id,
+            data_level=>'tissue_sample'
+        });
+        $exact_performance_hash = $exact->search();
     } elsif ($data_level eq 'plate') {
         #to make the download in the header for genotyping trials more easily understood, the terms change here
         if (exists($selected_cols{'plot_name'})){
@@ -329,15 +326,27 @@ sub get_layout_output {
         $selected_cols{'exported_tissue_sample_name'} = 1;
     }
 
+    # filter through exact performance hash and keep only selected treatments and traits
+    my $trt_transform = CXGN::List::Transform->new();
+    my $treatment_names_list = $trt_transform->transform($schema, 'trait_ids_2_trait_names', \@selected_treatments);
+    @selected_treatments = @{$treatment_names_list->{transform}};
+    my $trait_names_list = $trt_transform->transform($schema, 'trait_ids_2_trait_names', \@selected_traits);
+    @selected_traits = @{$trait_names_list->{transform}};
+    my $new_exact_hash = {};
+    foreach my $term ((@selected_traits,@selected_treatments)) {
+        $new_exact_hash->{$term} = $exact_performance_hash->{$term};
+    }
+    $exact_performance_hash = $new_exact_hash;
+
     #combine sorted exact and overall trait names and if requested convert to synonyms
     my @exact_trait_names = sort keys %$exact_performance_hash;
     my @overall_trait_names = sort keys %overall_performance_hash;
-    my @traits = (@exact_trait_names, @overall_trait_names);
+    my @traits = (@exact_trait_names,@overall_trait_names);
 
     if ($use_synonyms eq 'true') {
         print STDERR "Getting synonyms\n";
         my $t = CXGN::List::Transform->new();
-        my $trait_id_list = $t->transform($schema, 'traits_2_trait_ids', \@traits);
+        my $trait_id_list = $t->transform($schema, 'traits_2_trait_ids', [@traits]);
         my @trait_ids = @{$trait_id_list->{'transform'}};
         my $synonym_list = $t->transform($schema, 'trait_ids_2_synonyms', $trait_id_list->{'transform'});
         my @missing = @{$synonym_list->{'missing'}};

--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -210,11 +210,17 @@ sub get_layout_output {
     my $trial_traits = $trial->get_traits_assayed();
     my @trial_treatment_names = map { $_->{trait_name} } @{$trial_treatments};
     my @trial_trait_names = map {$_->[1] if $_->[1] !~ m/_TREATMENT/} @{$trial_traits};
+    my %trial_trait_names_map = map { $_ => 1 } @trial_trait_names;
 
     my $t = CXGN::List::Transform->new();
     my @selected_trait_names_all = @{$t->transform($schema, 'trait_ids_2_trait_names', \@selected_traits)->{'transform'}};
-    my @selected_trait_names = uniq(());
-    
+    my @selected_trait_names = ();
+    foreach my $trait (@selected_trait_names_all) { #only select traits that are actually measured in this trial
+        if (defined($trial_trait_names_map{$trait})) {
+            push @selected_trait_names, $trait;
+        }
+    }
+    @selected_traits = @{$t->transform($schema, 'traits_2_trait_ids', \@selected_trait_names)->{'transform'}};
 
     my $trial_layout;
     try {
@@ -360,12 +366,6 @@ sub get_layout_output {
     my @exact_trait_names = sort keys %$exact_performance_hash;
     my @overall_trait_names = sort keys %overall_performance_hash;
     my @traits = (@exact_trait_names,@overall_trait_names);
-
-    print STDERR "\n=================================\n";
-    print STDERR Dumper \@traits;
-    print STDERR Dumper \@exact_trait_names;
-    print STDERR Dumper \@overall_trait_names;
-    print STDERR "\n=================================\n";
 
     if ($use_synonyms eq 'true') {
         print STDERR "Getting synonyms\n";

--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -117,9 +117,10 @@ has 'selected_trait_ids'=> (
     isa => 'ArrayRef[Int]|Undef',
 );
 
-has 'selected_treatment_ids' => (
+has 'include_treatments' => (
     is => 'ro',
-    isa => 'ArrayRef[Int]|Undef'
+    isa => 'Str',
+    default => 'true'
 );
 
 has 'trial_stock_type'=> (
@@ -194,11 +195,21 @@ sub get_layout_output {
     my $use_synonyms = $self->use_synonyms();
     my %selected_cols = %{$self->selected_columns};
     my @selected_traits = $self->selected_trait_ids() ? @{$self->selected_trait_ids} : ();
-    my @selected_treatments = $self->selected_treatment_ids() ? @{$self->selected_treatment_ids} : ();
+    my $include_treatments = $self->include_treatments();
     my %errors;
     my @error_messages;
     my $trial_stock_type = $self->trial_stock_type();
     print STDERR "TrialLayoutDownload for Trial id: ($trial_id) ".localtime()."\n";
+
+    my $trial = CXGN::Project->new({
+        bcs_schema => $schema,
+        trial_id => $trial_id
+    });
+
+    my $treatments = $trial->get_treatments();
+    my $traits = $trial->get_traits_assayed();
+    my @treatment_ids = map { $_->{trait_name} } @{$treatments};
+    my @trait_ids = map {$_->[1] if $_->[1] !~ m/_TREATMENT/} @{$traits};
 
     my $trial_layout;
     try {
@@ -326,16 +337,14 @@ sub get_layout_output {
         $selected_cols{'exported_tissue_sample_name'} = 1;
     }
 
-    # filter through exact performance hash and keep only selected treatments and traits
-    my $trt_transform = CXGN::List::Transform->new();
-    my $treatment_names_list = $trt_transform->transform($schema, 'trait_ids_2_trait_names', \@selected_treatments);
-    @selected_treatments = @{$treatment_names_list->{transform}};
-    my $trait_names_list = $trt_transform->transform($schema, 'trait_ids_2_trait_names', \@selected_traits);
-    @selected_traits = @{$trait_names_list->{transform}};
+    # filter through exact performance hash and keep traits and treatments as requested
     my $new_exact_hash = {};
-    my @combined_terms = @selected_treatments;
-    if ($include_measured) {
-        @combined_terms = (@combined_terms, @selected_traits);
+    my @combined_terms = ();
+    if ($include_measured eq 'true') {
+        @combined_terms = (@combined_terms, @trait_ids);
+    }
+    if ($include_treatments eq 'true') {
+        @combined_terms = (@combined_terms, @treatment_ids);
     }
     foreach my $term (@combined_terms) {
         $new_exact_hash->{$term} = $exact_performance_hash->{$term};

--- a/lib/SGN/Controller/AJAX/FieldBook.pm
+++ b/lib/SGN/Controller/AJAX/FieldBook.pm
@@ -57,7 +57,7 @@ sub create_fieldbook_from_trial_POST : Args(0) {
     my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado', $sp_person_id);
     my $trial_id = $c->req->param('trial_id');
     my $data_level = $c->req->param('data_level') || 'plots';
-    my $treatment_project_ids = $c->req->param('treatment_project_id') ? [$c->req->param('treatment_project_id')] : [];
+    my $treatments = $c->req->param('treatments');
     my $include_plot_order = $c->req->param('include_plot_order') eq 'true';
     my $plot_order = $c->req->param('plot_order');
     my $plot_start = $c->req->param('plot_start');
@@ -124,6 +124,8 @@ sub create_fieldbook_from_trial_POST : Args(0) {
     my $use_synonyms = $c->req->param('use_synonyms') || '';
     my $selected_trait_list_id = $c->req->param('trait_list');
     my @selected_traits;
+    my $selected_treatment_list_id = $c->req->param('treatments');
+    my @selected_treatments;
     if ($selected_trait_list_id){
         my $list = CXGN::List->new({ dbh => $c->dbc->dbh, list_id => $selected_trait_list_id });
         my @trait_list = @{$list->elements()};
@@ -136,6 +138,18 @@ sub create_fieldbook_from_trial_POST : Args(0) {
         }
         my $lt = CXGN::List::Transform->new();
         @selected_traits = @{$lt->transform($schema, "traits_2_trait_ids", \@trait_list)->{transform}};
+    }
+    if ($treatments){
+        $treatments = [$treatments];
+        my $validator = CXGN::List::Validate->new();
+        my @absent_treatments = @{$validator->validate($schema, 'traits', $treatments)->{'missing'}};
+        if (scalar(@absent_treatments)>0){
+            $c->stash->{rest} = {error =>  "Treatment list is not valid because of these terms: ".join ',',@absent_treatments };
+            $c->detach();
+	    return;
+        }
+        my $lt = CXGN::List::Transform->new();
+        @selected_treatments = @{$lt->transform($schema, "traits_2_trait_ids", $treatments)->{transform}};
     }
 
     my $dir = $c->tempfiles_subdir('/other');
@@ -151,7 +165,7 @@ sub create_fieldbook_from_trial_POST : Args(0) {
         user_id => $c->user()->get_object()->get_sp_person_id(),
         user_name => $c->user()->get_object()->get_username(),
         data_level => $data_level,
-        treatment_project_ids => $treatment_project_ids,
+        selected_treatment_ids => \@selected_treatments,
         selected_columns => $selected_columns,
         include_measured => $include_measured,
         all_stats => $all_stats,

--- a/lib/SGN/Controller/AJAX/FieldBook.pm
+++ b/lib/SGN/Controller/AJAX/FieldBook.pm
@@ -57,7 +57,7 @@ sub create_fieldbook_from_trial_POST : Args(0) {
     my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado', $sp_person_id);
     my $trial_id = $c->req->param('trial_id');
     my $data_level = $c->req->param('data_level') || 'plots';
-    my $treatments = $c->req->param('treatments');
+    my $include_treatments = $c->req->param('treatments');
     my $include_plot_order = $c->req->param('include_plot_order') eq 'true';
     my $plot_order = $c->req->param('plot_order');
     my $plot_start = $c->req->param('plot_start');
@@ -124,8 +124,6 @@ sub create_fieldbook_from_trial_POST : Args(0) {
     my $use_synonyms = $c->req->param('use_synonyms') || '';
     my $selected_trait_list_id = $c->req->param('trait_list');
     my @selected_traits;
-    my $selected_treatment_list_id = $c->req->param('treatments');
-    my @selected_treatments;
     if ($selected_trait_list_id){
         my $list = CXGN::List->new({ dbh => $c->dbc->dbh, list_id => $selected_trait_list_id });
         my @trait_list = @{$list->elements()};
@@ -138,18 +136,6 @@ sub create_fieldbook_from_trial_POST : Args(0) {
         }
         my $lt = CXGN::List::Transform->new();
         @selected_traits = @{$lt->transform($schema, "traits_2_trait_ids", \@trait_list)->{transform}};
-    }
-    if ($treatments){
-        $treatments = [$treatments];
-        my $validator = CXGN::List::Validate->new();
-        my @absent_treatments = @{$validator->validate($schema, 'traits', $treatments)->{'missing'}};
-        if (scalar(@absent_treatments)>0){
-            $c->stash->{rest} = {error =>  "Treatment list is not valid because of these terms: ".join ',',@absent_treatments };
-            $c->detach();
-	    return;
-        }
-        my $lt = CXGN::List::Transform->new();
-        @selected_treatments = @{$lt->transform($schema, "traits_2_trait_ids", $treatments)->{transform}};
     }
 
     my $dir = $c->tempfiles_subdir('/other');
@@ -165,7 +151,7 @@ sub create_fieldbook_from_trial_POST : Args(0) {
         user_id => $c->user()->get_object()->get_sp_person_id(),
         user_name => $c->user()->get_object()->get_username(),
         data_level => $data_level,
-        selected_treatment_ids => \@selected_treatments,
+        include_treatments => $include_treatments,
         selected_columns => $selected_columns,
         include_measured => $include_measured,
         all_stats => $all_stats,

--- a/lib/SGN/Controller/AJAX/FieldBook.pm
+++ b/lib/SGN/Controller/AJAX/FieldBook.pm
@@ -57,7 +57,7 @@ sub create_fieldbook_from_trial_POST : Args(0) {
     my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado', $sp_person_id);
     my $trial_id = $c->req->param('trial_id');
     my $data_level = $c->req->param('data_level') || 'plots';
-    my $include_treatments = $c->req->param('treatments');
+    my $include_treatments = $c->req->param('treatments') || 'true';
     my $include_plot_order = $c->req->param('include_plot_order') eq 'true';
     my $plot_order = $c->req->param('plot_order');
     my $plot_start = $c->req->param('plot_start');

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -245,6 +245,7 @@ sub get_treatments_select : Path('/ajax/html/select/treatments') Args(0) {
 
     my $trial = CXGN::Trial->new({ bcs_schema => $schema,people_schema=>$people_schema, metadata_schema=>$metadata_schema, phenome_schema=>$phenome_schema,trial_id => $trial_id });
     my $data = $trial->get_treatments();
+    my @treatments = map {$_->{trait_name}} @{$data};
 
     if ($empty) {
         unshift @$data, [ 0, "None" ];
@@ -252,7 +253,7 @@ sub get_treatments_select : Path('/ajax/html/select/treatments') Args(0) {
     my $html = simple_selectbox_html(
       name => $name,
       id => $id,
-      choices => $data,
+      choices => \@treatments,
     );
     $c->stash->{rest} = { select => $html };
 }

--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -795,7 +795,9 @@ sub get_trial_design {
         my $trial_management_regime = $trial->get_management_regime();
 
         my $treatments = $trial->get_treatments();
+        my $traits = $trial->get_traits_assayed();
         my @treatment_ids = map { $_->{trait_id} } @{$treatments};
+        my @trait_ids = map {$_->[0]} @{$traits};
         # print STDERR "treatment ids are @treatment_ids\n";
         my $trial_layout_download = CXGN::Trial::TrialLayoutDownload->new({
             schema => $schema,
@@ -803,7 +805,7 @@ sub get_trial_design {
             data_level => $type,
             selected_treatment_ids => \@treatment_ids,
             selected_columns => $selected_columns{$type},
-            selected_trait_ids => [],
+            selected_trait_ids => \@trait_ids,
             use_synonyms => 'false',
             include_measured => 'true'
         });

--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -794,18 +794,13 @@ sub get_trial_design {
 
         my $trial_management_regime = $trial->get_management_regime();
 
-        my $treatments = $trial->get_treatments();
-        my $traits = $trial->get_traits_assayed();
-        my @treatment_ids = map { $_->{trait_id} } @{$treatments};
-        my @trait_ids = map {$_->[0]} @{$traits};
-        # print STDERR "treatment ids are @treatment_ids\n";
         my $trial_layout_download = CXGN::Trial::TrialLayoutDownload->new({
             schema => $schema,
             trial_id => $trial_id,
             data_level => $type,
-            selected_treatment_ids => \@treatment_ids,
+            include_treatments => 'true',
             selected_columns => $selected_columns{$type},
-            selected_trait_ids => \@trait_ids,
+            selected_trait_ids => [],
             use_synonyms => 'false',
             include_measured => 'true'
         });

--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -794,14 +794,14 @@ sub get_trial_design {
 
         my $trial_management_regime = $trial->get_management_regime();
 
-        # my $treatments = $trial->get_treatments();
-        # my @treatment_ids = map { $_->{trait_id} } @{$treatments};
+        my $treatments = $trial->get_treatments();
+        my @treatment_ids = map { $_->{trait_id} } @{$treatments};
         # print STDERR "treatment ids are @treatment_ids\n";
         my $trial_layout_download = CXGN::Trial::TrialLayoutDownload->new({
             schema => $schema,
             trial_id => $trial_id,
             data_level => $type,
-            # treatment_ids => \@treatment_ids,
+            selected_treatment_ids => \@treatment_ids,
             selected_columns => $selected_columns{$type},
             selected_trait_ids => [],
             use_synonyms => 'false',

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -6537,7 +6537,7 @@ sub stock_entry_summary_trial : Chained('trial') PathPart('stock_entry_summary')
             $parent_stock_link = qq{<a href="/family/$parent_stock_id">$parent_stock_name</a>};
         }
 
-        push @summary, [$parent_stock_link, qq{<a href="/stock/$plot_id/view">$plot_name</a>}, qq{<a href="/stock/$plant_id/view">$plant_name</a>}, qq{<a href="/stock/$tissue_sample_id/view">$tissue_sample_name</a>}];
+        push @summary, [$parent_stock_link, qq{<a href="/stock/$plot_id/view">$plot_name</a>}, $plant_id ? qq{<a href="/stock/$plant_id/view">$plant_name</a>} : '', $tissue_sample_id ? qq{<a href="/stock/$tissue_sample_id/view">$tissue_sample_name</a>} : ''];
     }
 
 

--- a/lib/SGN/Controller/BreedersToolbox/Trial.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Trial.pm
@@ -544,6 +544,7 @@ sub trial_download : Chained('trial_init') PathPart('download') Args(1) {
     my $timestamp_option = $c->req->param("timestamp") || 0;
     my $trait_list = $c->req->param("trait_list");
     my $include_measured = $c->req->param('include_measured') || '';
+    my $include_treatments = $c->req->param('treatments') || 'true';
     my $search_type = $c->req->param("search_type") || 'fast';
     my $include_plot_order = $c->req->param('include_plot_order') eq 'true';
     my $plot_order = $c->req->param('plot_order');
@@ -587,9 +588,6 @@ sub trial_download : Chained('trial_init') PathPart('download') Args(1) {
         my $lt = CXGN::List::Transform->new();
         @trait_list = @{$lt->transform($schema, "traits_2_trait_ids", \@selected_trait_names)->{transform}};
     }
-
-    my $treatments = $trial->get_treatments();
-    my @treatment_ids = map {$_->{trait_id}} @{$treatments};
 
     if ($trait_list && $trait_list ne 'null') {
         @trait_list = @{_parse_list_from_json($trait_list)};
@@ -653,7 +651,7 @@ sub trial_download : Chained('trial_init') PathPart('download') Args(1) {
         data_level => $data_level,
         search_type => $search_type,
         include_timestamp => $timestamp_option,
-        treatment_ids => \@treatment_ids,
+        include_treatments => $include_treatments,
         selected_columns => $selected_cols,
         include_measured => $include_measured,
         field_crossing_data_order => \@field_crossing_data_order,

--- a/lib/SGN/Controller/BreedersToolbox/Trial.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Trial.pm
@@ -588,11 +588,8 @@ sub trial_download : Chained('trial_init') PathPart('download') Args(1) {
         @trait_list = @{$lt->transform($schema, "traits_2_trait_ids", \@selected_trait_names)->{transform}};
     }
 
-    # my @treatment_project_ids;
-    # my $treatments = $trial->get_treatments();
-    # foreach (@$treatments){
-    #     push @treatment_project_ids, $_->[0];
-    # }
+    my $treatments = $trial->get_treatments();
+    my @treatment_ids = map {$_->{trait_id}} @{$treatments};
 
     if ($trait_list && $trait_list ne 'null') {
         @trait_list = @{_parse_list_from_json($trait_list)};
@@ -656,7 +653,7 @@ sub trial_download : Chained('trial_init') PathPart('download') Args(1) {
         data_level => $data_level,
         search_type => $search_type,
         include_timestamp => $timestamp_option,
-        #treatment_project_ids => \@treatment_project_ids,
+        treatment_ids => \@treatment_ids,
         selected_columns => $selected_cols,
         include_measured => $include_measured,
         field_crossing_data_order => \@field_crossing_data_order,

--- a/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
@@ -62,12 +62,14 @@ $trial_stock_type => undef
                             </div>
                         </div>
                     </div>
-                    <div id="management_factore">
+                    <div>
                         <div class="form-group">
-                            <label class="col-sm-3 control-label">Treatment: </label>
+                            <label class="col-sm-3 control-label">Include treatments: </label>
                             <div class="col-sm-9" >
-                                <div id="create_fieldbook_treatment_<% $download_type %>">
-                                </div>
+                                <select class="form-control" id="create_fieldbook_include_treatments_<% $download_type %>">
+                                    <option value="true">Yes</option>
+                                    <option value="false">No</option>
+                                </select>
                             </div>
                         </div>
                     </div>
@@ -215,13 +217,13 @@ jQuery(document).ready(function() {
         jQuery('#create_fieldbook_with_trait_list_TrialLayout').html(lo.listSelect('create_fieldbook_with_trait_list_select_TrialLayout', [ 'traits' ], 'select', undefined, undefined));
         jQuery('#accession_average_performance').css("display", "inline-block");
         jQuery('#selected_columns_well').css("display", "inline-block");
-        jQuery('#management_factore').css("display", "inline-block");
+        jQuery('#include_treatments_select_div').css("display", "inline-block");
         jQuery('#create_fieldbook_dialog_TrialLayout').modal('show');
         show_fieldbook_treatments_TrialLayout();
     });
 
     // jQuery("#trial_fieldmap_download_layout_button").click( function () {
-    //     jQuery('#management_factore').css("display", "none");
+    //     jQuery('#include_treatments_select_div').css("display", "none");
     //     jQuery("#create_fieldbook_format_TrialFieldMapLayout option[value='xlsx']").prop('selected', true);
     //     jQuery("#create_fieldbook_format_TrialFieldMapLayout").prop('disabled', 'disabled');
     //     jQuery("#create_fieldbook_data_level_TrialFieldMapLayout").prop('disabled', 'disabled');
@@ -513,17 +515,6 @@ function include_column_<% $download_type %>(name){
 
 % if ($download_type eq 'Fieldbook'){
 
-function show_fieldbook_treatments_<% $download_type %>(){
-    var selected_trial_id = jQuery("#html_select_trial_for_create_fieldbook_<% $download_type %>").val();
-    if ( selected_trial_id && !selected_trial_id.includes(',') ) {
-        jQuery("#management_factore").show();
-        get_select_box('treatments', 'create_fieldbook_treatment_<% $download_type %>', { 'name':'html_select_treatment_create_fieldbook_<% $download_type %>', 'id':'html_select_treatment_create_fieldbook_<% $download_type %>', 'trial_id':selected_trial_id, 'empty':1 });
-    }
-    else {
-        jQuery("#management_factore").hide();
-    }
-}
-
 function open_create_fieldbook_dialog_<% $download_type %>() {
     var trial_stock_type = "<% $trial_stock_type %>";
     let trial_ids = jQuery('#html_select_trial_for_create_fieldbook_<% $download_type %>').val().split(',').filter((e) => !!e && e !== '');
@@ -539,7 +530,7 @@ function open_create_fieldbook_dialog_<% $download_type %>() {
             data: {
                 'trial_id': parseInt(trial_id),
                 'data_level': jQuery('#create_fieldbook_data_level_<% $download_type %>').val(),
-                'treatments': jQuery("#html_select_treatment_create_fieldbook_<% $download_type %>").val(),
+                'treatments': jQuery("#create_fieldbook_include_treatments_<% $download_type %>").val(),
                 'selected_columns':JSON.stringify(selected_columns_<% $download_type %>),
                 'include_measured': jQuery('#create_fieldbook_include_measured_<% $download_type %>').prop('checked'),
                 'all_stats': jQuery('#create_fieldbook_all_stats_<% $download_type %>').prop('checked'),
@@ -589,7 +580,6 @@ function open_create_fieldbook_dialog_<% $download_type %>() {
 % } elsif ($download_type eq 'TrialLayout') {
 
 function show_fieldbook_treatments_<% $download_type %>(){
-    jQuery('#create_fieldbook_treatment_<% $download_type %>').html('Include All Treatments In Download');
     jQuery('#create_fieldbook_format_div_<% $download_type %>').show();
 }
 
@@ -598,6 +588,7 @@ function open_create_fieldbook_dialog_<% $download_type %>() {
     var data_level = jQuery('#create_fieldbook_data_level_<% $download_type %>').val();
     var selected_columns = JSON.stringify(selected_columns_<% $download_type %>);
     var trait_list_id = jQuery('#create_fieldbook_with_trait_list_select_<% $download_type %>_list_select').val();
+    var treatments = jQuery("#create_fieldbook_include_treatments_<% $download_type %>").val();
     var format = jQuery('#create_fieldbook_format_<% $download_type %>').val();
     var include_measurements = jQuery('#create_fieldbook_include_measured_<% $download_type %>').prop('checked');
     var include_plot_order = jQuery('#create_fieldbook_include_plot_order_<% $download_type %>').prop('checked');
@@ -607,7 +598,7 @@ function open_create_fieldbook_dialog_<% $download_type %>() {
     //Calls SGN::Controller:BreedersToolbox::Trial
     for ( let i = 0; i < trial_ids.length; i++ ) {
         let trial_id = parseInt(trial_ids[i]);
-        window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&selected_columns="+selected_columns+"&trait_list_id="+trait_list_id+"&include_measured="+include_measurements+"&include_plot_order="+include_plot_order+"&plot_order="+plot_order+"&plot_start="+plot_start);
+        window.open("/breeders/trial/"+trial_id+"/download/layout?format="+format+"&dataLevel="+data_level+"&treatments="+treatments+"&selected_columns="+selected_columns+"&trait_list_id="+trait_list_id+"&include_measured="+include_measurements+"&include_plot_order="+include_plot_order+"&plot_order="+plot_order+"&plot_start="+plot_start);
     }
 }
 

--- a/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
+++ b/mason/breeders_toolbox/trial/download_layout_interface_dialog.mas
@@ -539,7 +539,7 @@ function open_create_fieldbook_dialog_<% $download_type %>() {
             data: {
                 'trial_id': parseInt(trial_id),
                 'data_level': jQuery('#create_fieldbook_data_level_<% $download_type %>').val(),
-                'treatment_project_id': jQuery("#html_select_treatment_create_fieldbook_<% $download_type %>").val(),
+                'treatments': jQuery("#html_select_treatment_create_fieldbook_<% $download_type %>").val(),
                 'selected_columns':JSON.stringify(selected_columns_<% $download_type %>),
                 'include_measured': jQuery('#create_fieldbook_include_measured_<% $download_type %>').prop('checked'),
                 'all_stats': jQuery('#create_fieldbook_all_stats_<% $download_type %>').prop('checked'),

--- a/t/unit_fixture/CXGN/Fieldbook/DownloadTrial.t
+++ b/t/unit_fixture/CXGN/Fieldbook/DownloadTrial.t
@@ -189,8 +189,7 @@ is($contents->[0]->{'sheets'}, '1', "check that type of file is correct");
 
 my $columns = $contents->[1]->{'cell'};
 #print STDERR Dumper scalar(@$columns);
-ok(scalar(@$columns) == 17, "check number of col in created file.");
-
+ok(scalar(@$columns) == 15, "check number of col in created file.");
 print STDERR Dumper $columns;
 is_deeply ($columns,[
           [],
@@ -414,14 +413,6 @@ is_deeply ($columns,[
             '/',
             '/',
             '/'
-          ],
-          [
-            undef,
-            'fresh root weight|CO_334:0000012'
-          ],
-          [
-            undef,
-            'harvest index variable|CO_334:0000015'
           ]
         ], "check selectable fieldbook cols");
 

--- a/t/unit_fixture/CXGN/Fieldbook/DownloadTrial.t
+++ b/t/unit_fixture/CXGN/Fieldbook/DownloadTrial.t
@@ -189,7 +189,7 @@ is($contents->[0]->{'sheets'}, '1', "check that type of file is correct");
 
 my $columns = $contents->[1]->{'cell'};
 #print STDERR Dumper scalar(@$columns);
-ok(scalar(@$columns) == 15, "check number of col in created file.");
+ok(scalar(@$columns) == 17, "check number of col in created file.");
 
 print STDERR Dumper $columns;
 is_deeply ($columns,[
@@ -414,6 +414,14 @@ is_deeply ($columns,[
             '/',
             '/',
             '/'
+          ],
+          [
+            undef,
+            'fresh root weight|CO_334:0000012'
+          ],
+          [
+            undef,
+            'harvest index variable|CO_334:0000015'
           ]
         ], "check selectable fieldbook cols");
 

--- a/t/unit_mech/AJAX/Fieldbook.t
+++ b/t/unit_mech/AJAX/Fieldbook.t
@@ -27,13 +27,12 @@ my $data_level = 'plots';
 my $selected_columns = encode_json {'plot_name'=>1,'block_number'=>1,'plot_number'=>1,'rep_number'=>1,'row_number'=>1,'col_number'=>1,'accession_name'=>1,'is_a_control'=>1,'pedigree'=>1,'location_name'=>1,'trial_name'=>1,'year'=>1,'synonyms'=>1,'tier'=>1,'seedlot_name'=>1,'seed_transaction_operator'=>1,'num_seed_per_plot'=>1};
 my $trait_list = 13;
 
-$mech->post_ok('http://localhost:3010/ajax/fieldbook/create', ['trial_id'=>$trial_id, 'data_level'=>$data_level, 'selected_columns'=>$selected_columns, 'trait_list'=>$trait_list] );
+$mech->post_ok('http://localhost:3010/ajax/fieldbook/create', ['trial_id'=>$trial_id, 'data_level'=>$data_level, 'selected_columns'=>$selected_columns, 'trait_list'=>$trait_list, 'include_measured' => 'false', 'treatments' => 'false'] );
 $response = decode_json $mech->content;
 print STDERR Dumper $response;
 my $file_name = $response->{file};
 
 my $contents = ReadData ($file_name);
-#print STDERR Dumper $contents;
 
 my $cells = $contents->[1]->{cell};
 print STDERR Dumper $cells;


### PR DESCRIPTION

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Trial layout and fieldbook downloads could still access treatment projects. This removes treatment projects and adds treatment cvterms to the download

Important change: treatments are now included in the trial download as an all or nothing choice. Users can choose to include treatments or not include treatments when creating the download. 

<!-- If there are relevant issues, link them here: -->
Closes #6079 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
