### PR TITLE
Fix server errors when clicking next step in upload genotyping dialog

### DIFF
--- a/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
+++ b/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
@@ -1194,27 +1194,6 @@ jQuery(document).ready(function(){
             jQuery('#upload_genotype_data_format_ssr').hide();
         }
 
-
-    jQuery('#upload_genotyping_data_protocol_missing_button').click(function(){
-        if (data_type == 'ssr') {
-            selected = [];
-            jQuery('input[name="upload_genotyping_data_protocol_select"]:checked').each(function() {
-                selected.push(jQuery(this).val());
-            });
-            if (selected.length == 0){
-                jQuery('#upload_ssr_protocol_dialog').modal('show');
-                jQuery("#upload_ssr_species_name_input").autocomplete({
-                    source: '/organism/autocomplete'
-                });
-            } else if (selected.length > 0) {
-                alert('If you selected a protocol, do not try to make a new one at the same time!');
-            }
-        } else {
-            jQuery('#upload_genotype_data_protocol_details').show();
-        }
-        return false;
-    });
-
     });
 
     var upload_genotyping_data_trial_table = jQuery('#upload_genotyping_data_project_search_results').DataTable( {
@@ -1248,6 +1227,7 @@ jQuery(document).ready(function(){
             Workflow.complete('#upload_genotyping_data_type_check_button');
             Workflow.focus('#upload_genotypes_workflow', 2);
         }
+        return false;
     });
 
     jQuery('#upload_genotyping_data_project_check_button').click(function(){
@@ -1280,6 +1260,27 @@ jQuery(document).ready(function(){
         }
         return false;
     });
+
+    jQuery('#upload_genotyping_data_protocol_missing_button').click(function(){
+        if (data_type == 'ssr') {
+            selected = [];
+            jQuery('input[name="upload_genotyping_data_protocol_select"]:checked').each(function() {
+                selected.push(jQuery(this).val());
+            });
+            if (selected.length == 0){
+                jQuery('#upload_ssr_protocol_dialog').modal('show');
+                jQuery("#upload_ssr_species_name_input").autocomplete({
+                    source: '/organism/autocomplete'
+                });
+            } else if (selected.length > 0) {
+                alert('If you selected a protocol, do not try to make a new one at the same time!');
+            }
+        } else {
+            jQuery('#upload_genotype_data_protocol_details').show();
+        }
+        return false;
+    });
+
 
     var ssr_protocol_id;
 

--- a/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
+++ b/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
@@ -1262,6 +1262,7 @@ jQuery(document).ready(function(){
     });
 
     jQuery('#upload_genotyping_data_protocol_missing_button').click(function(){
+        var data_type = jQuery('#genotype_data_type_select').val();
         if (data_type == 'ssr') {
             selected = [];
             jQuery('input[name="upload_genotyping_data_protocol_select"]:checked').each(function() {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Clicking the next step button on the select data type step caused a server error because the button's event handler was not stopping propagation. The form was being submitted with an empty file.

Additionally, the click handler for the upload genotyping protocol button was incorrectly nested under the data type dropdown change handler.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
