### PR TITLE
Fix exif verification

### DIFF
--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -387,8 +387,7 @@ sub verify_exif_POST {
             }
             # Get cvterm_id of recorded trait
             my $cvterm_name = $decoded_json->{observation_variable}->{observation_variable_name};
-            my $trait_cvterm = SGN::Model::Cvterm->get_cvterm_row_from_trait_name($schema, $cvterm_name);
-            my $cvterm_id = $trait_cvterm->cvterm_id();
+            my $cvterm_id = SGN::Model::Cvterm->find_trait_by_name($schema, $cvterm_name);
 
             $decoded_json->{stock_name} = $stock_name;
             if ($cvterm_id) {

--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -386,8 +386,8 @@ sub verify_exif_POST {
                 }
             }
             # Get cvterm_id of recorded trait
-            my $cvterm_name = $decoded_json->{observation_variable}->{observation_variable_name};
-            my $cvterm_id = SGN::Model::Cvterm->find_trait_by_name($schema, $cvterm_name);
+            my $trait_id = $decoded_json->{observation_variable}->{external_db_id};
+            my $cvterm_id = SGN::Model::Cvterm->find_trait_by_id($schema, $trait_id);
 
             $decoded_json->{stock_name} = $stock_name;
             if ($cvterm_id) {


### PR DESCRIPTION
Fixes exif error occurring when observation_variable_name field does not have both the trait name and ID  in this format trait_name|trait_ID. Just the trait name will not work as well


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
