### PR TITLE
Add hyperlinks to images and stocks on field trial detail popup

### DIFF
--- a/js/source/entries/fieldmap.js
+++ b/js/source/entries/fieldmap.js
@@ -678,7 +678,7 @@ export function init() {
                 if (plot.type == "data") {
 
                     var image_ids = plot.plotImageDbIds || [];
-                    var replace_accession = plot.germplasmName;
+                    var replace_accession = `<a href="/stock/${plot.germplasmDbId}/view">${plot.germplasmName}</a>`;
                     var replace_plot_id = plot.observationUnitDbId;
                     var replace_plot_name = plot.observationUnitName;
                     plot;
@@ -698,7 +698,7 @@ export function init() {
                     var old_plot_id = jQuery("#hm_plot_id").html(replace_plot_id);
                     var old_plot_accession = jQuery("#hm_plot_accession").html(
                         plot.additionalInfo?.intercropGermplasm ? 
-                            [replace_accession, ...plot.additionalInfo.intercropGermplasm.map((e) => e.germplasmName)].join(', ') : 
+                            [replace_accession, ...plot.additionalInfo.intercropGermplasm.map((e) => `<a href="/stock/${e.germplasmDbId}/view">${e.germplasmName}</a>`)].join(', ') : 
                             replace_accession
                     );
 

--- a/js/source/entries/fieldmap.js
+++ b/js/source/entries/fieldmap.js
@@ -693,7 +693,7 @@ export function init() {
                     jQuery("#hm_edit_plot_information").html(
                         //"<b>Selected Plot Information: </b>"
                     );
-                    jQuery("#hm_plot_name").html(replace_plot_name);
+                    jQuery("#hm_plot_name").html(`<a href="/stock/${replace_plot_id}/view">${replace_plot_name}</a>`);
                     jQuery("#hm_plot_number").html(replace_plot_number);
                     var old_plot_id = jQuery("#hm_plot_id").html(replace_plot_id);
                     var old_plot_accession = jQuery("#hm_plot_accession").html(
@@ -744,7 +744,16 @@ export function init() {
                                                 nestedUl.classList.add("hidden");
                                                 li.appendChild(nestedUl);
                                             } else {
-                                                li.textContent = `${key}: ${obj[key]}`;
+                                                if (key == "name") {
+                                                    let label = document.createTextNode(`${key}: `);
+                                                    let a = document.createElement("a");
+                                                    a.href = `/stock/${obj['stock_id']}/view`;
+                                                    a.textContent = obj[key];
+                                                    li.appendChild(label);
+                                                    li.appendChild(a);
+                                                } else {
+                                                    li.textContent = `${key}: ${obj[key]}`;
+                                                }
                                             }
 
                                             ul.appendChild(li);

--- a/lib/SGN/Controller/AJAX/HTMLSelect.pm
+++ b/lib/SGN/Controller/AJAX/HTMLSelect.pm
@@ -2349,10 +2349,14 @@ sub get_trial_plot_select : Path('/ajax/html/select/plots_from_trial/') Args(0) 
                 $accession_list .= "</a>"
             }
         }
+        my $coords = 'NA';
+        if (defined($row) && defined($column)) {
+            $coords = "$row, $column";
+        }
 
         $accession_list .= "</td>";
 
-        $html .= "<tr><td><input id=\"select_plot_$plot_name\" type=\"checkbox\" class=\"exp_design_plot_select\"></td><td><a href=\"/stock/$plot_id/view\">$plot_name</a></td><td>$plot_number</td><td>$row, $column</td><td>$rep</td><td>$block</td>$accession_list</tr>";
+        $html .= "<tr><td><input id=\"select_plot_$plot_name\" type=\"checkbox\" class=\"exp_design_plot_select\"></td><td><a href=\"/stock/$plot_id/view\">$plot_name</a></td><td>$plot_number</td><td>$coords</td><td>$rep</td><td>$block</td>$accession_list</tr>";
     }
 
     $html .= "</tbody></table>";
@@ -2535,8 +2539,9 @@ sub get_trial_plant_select : Path('/ajax/html/select/plants_from_trial/') Args(0
 
     while (my ($plant_id, $plant_name, $plot_id, $plot_name, $row, $column, $accession_id, $accession_name, $synonyms, $subplot_id, $subplot_name) = $h->fetchrow_array()) {
         my $coordinates = "NA";
+        $synonyms = $synonyms ? $synonyms : '';
         if ($row && $column){
-            $coordinates = "($row,$column)";
+            $coordinates = "$row, $column";
         }
         my $subplot_data = "";
         if ($subplot_id && $subplot_name) {

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -4404,13 +4404,14 @@ sub retrieve_plot_image : Chained('trial') PathPart('retrieve_plot_images') Args
       my $image_img  = $image_ob->get_image_url("medium");
       my $small_image = $image_ob->get_image_url("thumbnail");
       my $image_page  = "/image/view/$image_id";
+      my $image_page_ref = "<a href=\"$image_page\">$image_name</a>";
 
       my $colorbox =
         qq|<a href="$image_img"  class="stock_image_group" rel="gallery-figures"><img src="$small_image" alt="$image_description" onclick="close_view_plot_image_dialog()"/></a> |;
       my $fhtml =
         qq|<tr><td width=120>|
           . $colorbox
-            . $image_name
+            . $image_page_ref
               . "</td><td>"
                 . $image_description
                   . "</td></tr>";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Adds relevant hyperlinks to popup dialog on field layout viewer. 
<img width="941" height="832" alt="image" src="https://github.com/user-attachments/assets/2630b20b-5932-4ea5-b341-d185803baa8b" />
<img width="849" height="805" alt="image" src="https://github.com/user-attachments/assets/6337d42e-6cf3-411a-be7d-fd21a3896a2b" />


<!-- If there are relevant issues, link them here: -->
Closes #6089 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
