### PR TITLE
File upload unique columns

### DIFF
--- a/lib/CXGN/File/Parse.pm
+++ b/lib/CXGN/File/Parse.pm
@@ -123,15 +123,13 @@ UNIQUE-ONLY COLUMNS
   - Specify columns that are not allowed to have duplicate data entries
   - By default, columns can have row values that are duplicated (appear in multiple rows)
   - This is useful for ensuring some one-to-one data entries are caught in parsing
-  - Specify columns that should not have duplicate entries in a hash with the column name as a key
+  - Specify columns that should not have duplicate entries as an array of column names
   - For columns that can have repeated entries, just leave them out of the hash
 
   my $parser = CXGN::File::Parse->new(
     file => '/path/to/data.xlsx',
     required_columns => ['accession_name', 'species_name'],
-    unique_only_columns => {
-      'accession_name' => 1
-    }
+    unique_only_columns => ['accession_name']
   );
 
 CASE SENSITIVITY
@@ -260,9 +258,9 @@ has column_arrays => (
   is => "ro"
 );
 
-# Hash of column names that must contain unique data values
+# Array of column names that must contain unique data values
 has unique_only_columns => (
-  isa => "HashRef",
+  isa => "ArrayRef[Str]",
   is => "ro"
 );
 
@@ -319,7 +317,8 @@ sub parse {
   my $required_columns = $self->required_columns();
   my $optional_columns = $self->optional_columns();
   my $column_arrays = $self->column_arrays();
-  my $unique_only_columns = $self->unique_only_columns();
+  my $unique_only_columns_array = $self->unique_only_columns();
+  my %unique_only_columns = map { $_ => 1 } @$unique_only_columns_array;
 
   # If type is not defined, use the file extension
   if ( !$type ) {
@@ -419,18 +418,45 @@ sub parse {
           if ( !defined($v) || $v eq '' ) {
             push @{$parsed->{errors}}, "Required column $c does not have a value in row $r";
           }
-          if (($v ne '' && defined($v)) && $unique_only_columns->{$c} && $seen->{$c}->{$v}) {
-            push @{$parsed->{errors}}, "Column $c requires unique values, but $v on row $r appears more than once";
+          elsif ( $unique_only_columns{$c} ) {
+            if ( ref($v) eq 'ARRAY' ) {
+              foreach (@$v) {
+                if ( $_ ne '' && defined($_) ) {
+                  $seen->{$c}->{$_}->{$r} = 1;
+                }
+              }
+            }
+            else {
+              $seen->{$c}->{$v}->{$r} = 1;
+            }
           }
-          $seen->{$c}->{$v} = 1;
         }
         foreach my $c ( (@{$parsed->{optional_columns}}, @{$parsed->{additional_columns}}) ) {
           my $v = $d->{$c};
           my $r = $d->{_row};
-          if (($v ne '' && defined($v)) && $unique_only_columns->{$c} && $seen->{$c}->{$v}) {
-            push @{$parsed->{errors}}, "Column $c requires unique values, but $v on row $r appears more than once";
+
+          if ( $v ne '' && defined($v) && $unique_only_columns{$c} ) {
+            if ( ref($v) eq 'ARRAY' ) {
+              foreach (@$v) {
+                if ( $_ ne '' && defined($_) ) {
+                  $seen->{$c}->{$_}->{$r} = 1;
+                }
+              }
+            }
+            else {
+              $seen->{$c}->{$v}->{$r} = 1;
+            }
           }
-          $seen->{$c}->{$v} = 1;
+        }
+      }
+
+      # Check for duplicated values in unique only columns
+      foreach my $c ( sort keys %$seen ) {
+        foreach my $v ( sort keys %{$seen->{$c}} ) {
+          my @rows = sort keys %{$seen->{$c}->{$v}};
+          if ( scalar @rows > 1 ) {
+            push @{$parsed->{errors}}, "Column $c requires unique values, but $v appears more than once in rows " . join(',', @rows);
+          }
         }
       }
     }

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
@@ -33,7 +33,8 @@ sub _validate_with_plugin {
             'Category' => [ 'Categories' ],
             'Reference' => [ 'References' ]
         },
-        column_arrays => [ 'Allele', 'Category', 'Reference' ]
+        column_arrays => [ 'Allele', 'Category', 'Reference' ],
+        unique_only_columns => [ 'Marker', 'Alias', 'Allele' ]
     );
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{errors};

--- a/lib/CXGN/Location/ParseUpload/Plugin/LocationsGeneric.pm
+++ b/lib/CXGN/Location/ParseUpload/Plugin/LocationsGeneric.pm
@@ -29,7 +29,8 @@ sub parse {
       },
       column_arrays => {
         'Program' => '&'
-      }
+      },
+      unique_only_columns => [ 'Name', 'Abbreviation' ]
     );
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{errors};

--- a/lib/CXGN/Pedigree/ParseUpload/Plugin/CrossesGeneric.pm
+++ b/lib/CXGN/Pedigree/ParseUpload/Plugin/CrossesGeneric.pm
@@ -29,7 +29,8 @@ sub _validate_with_plugin {
             'female_parent' => ['female', 'female parent'],
             'male_parent' => ['male parent', 'male'],
             'cross_combination' => ['cross combination']
-        }
+        },
+        unique_only_columns => [ 'cross_unique_id' ]
     );
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{errors};

--- a/lib/CXGN/Pedigree/ParseUpload/Plugin/PedigreesGeneric.pm
+++ b/lib/CXGN/Pedigree/ParseUpload/Plugin/PedigreesGeneric.pm
@@ -26,7 +26,8 @@ sub _validate_with_plugin {
             'female parent accession' => ['female_parent_accession', 'female_parent', 'female parent'],
             'type' => ['cross_type', 'cross type'],
             'male parent accession' => ['male_parent_accession', 'male_parent', 'male parent']
-        }
+        },
+        unique_only_columns => [ 'progeny name' ]
     );
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{errors};

--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetSimpleGeneric.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetSimpleGeneric.pm
@@ -43,8 +43,7 @@ sub validate {
         required_columns => [ 'observationunit_name' ],
         column_aliases => {
             'observationunit_name' => [ 'plot_name', 'subplot_name', 'plant_name', 'observationUnitName', 'plotName', 'subplotName', 'plantName' ]
-        },
-        unique_only_columns => [ 'observationunit_name' ]
+        }
     );
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{errors};
@@ -99,8 +98,7 @@ sub parse {
         required_columns => [ "observationunit_name" ],
         column_aliases => {
             'observationunit_name' => [ 'plot_name', 'subplot_name', 'plant_name', 'observationUnitName', 'plotName', 'subplotName', 'plantName' ]
-        },
-        unique_only_columns => [ 'observationunit_name' ]
+        }
     );
     my $parsed = $parser->parse();
     my $parsed_data = $parsed->{data};

--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetSimpleGeneric.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/PhenotypeSpreadsheetSimpleGeneric.pm
@@ -43,7 +43,8 @@ sub validate {
         required_columns => [ 'observationunit_name' ],
         column_aliases => {
             'observationunit_name' => [ 'plot_name', 'subplot_name', 'plant_name', 'observationUnitName', 'plotName', 'subplotName', 'plantName' ]
-        }
+        },
+        unique_only_columns => [ 'observationunit_name' ]
     );
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{errors};
@@ -98,7 +99,8 @@ sub parse {
         required_columns => [ "observationunit_name" ],
         column_aliases => {
             'observationunit_name' => [ 'plot_name', 'subplot_name', 'plant_name', 'observationUnitName', 'plotName', 'subplotName', 'plantName' ]
-        }
+        },
+        unique_only_columns => [ 'observationunit_name' ]
     );
     my $parsed = $parser->parse();
     my $parsed_data = $parsed->{data};

--- a/lib/CXGN/Stock/ParseUpload/Plugin/AccessionsGeneric.pm
+++ b/lib/CXGN/Stock/ParseUpload/Plugin/AccessionsGeneric.pm
@@ -60,7 +60,8 @@ sub _validate_with_plugin {
         'introgression_end_position_bp' => ['introgression_end_position_bp', 'introgression_end_position_bps', 'introgression_end_position_bp(s)'],
         'number_of_insertions' => ['number of insertions'],
       },
-      column_arrays => [ 'synonyms' ]
+      column_arrays => [ 'synonyms' ],
+      unique_only_columns => [ 'accession_name' ]
     );
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{errors};
@@ -83,17 +84,6 @@ sub _validate_with_plugin {
       ];
       $self->_set_parse_errors(\%errors);
       return;
-    }
-
-    # check for duplicate accession entries
-    my %accession_name_counts;
-    foreach my $row (@$parsed_data) {
-      $accession_name_counts{$row->{'accession_name'}}++;
-    }
-    foreach my $k (keys %accession_name_counts) {
-      if ($accession_name_counts{$k} > 1) {
-        push @error_messages, "Accession $k occures $accession_name_counts{$k} times in the file. Accession names must be unique. Please remove duplicated accession names.";
-      }
     }
 
     # check validity of species names

--- a/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotFromAccessionGeneric.pm
+++ b/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotFromAccessionGeneric.pm
@@ -28,6 +28,7 @@ sub _validate_with_plugin {
             'box_name' => ['box name'],
             'weight_gram' => ['weight(g)'],
         },
+        unique_only_columns => [ 'seedlot_name' ]
     );
 
     my $parsed = $parser->parse();
@@ -51,7 +52,6 @@ sub _validate_with_plugin {
         return;
     }
 
-    my %duplicated_seedlot_names;
     my @accession_source_pairs;
     for my $row ( @$parsed_data ) {
         my $row_num = $row->{_row};
@@ -63,12 +63,6 @@ sub _validate_with_plugin {
 
         if ($seedlot_name =~ /\s/ || $seedlot_name =~ /\// || $seedlot_name =~ /\\/ ) {
             push @error_messages, "Cell A$row_num: seedlot_name must not contain spaces or slashes.";
-        }
-
-        if ($duplicated_seedlot_names{$seedlot_name}) {
-            push @error_messages, "Cell A$row_num: duplicated seedlot name: $seedlot_name. Seedlot name must be unique.";
-        } else {
-            $duplicated_seedlot_names{$seedlot_name}++;
         }
 
         if (!$amount || $amount eq '') {

--- a/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotFromCrossGeneric.pm
+++ b/lib/CXGN/Stock/Seedlot/ParseUpload/Plugin/SeedlotFromCrossGeneric.pm
@@ -28,6 +28,7 @@ sub _validate_with_plugin {
             'box_name' => ['box name'],
             'weight_gram' => ['weight(g)'],
         },
+        unique_only_columns => [ 'seedlot_name' ]
     );
 
     my $parsed = $parser->parse();
@@ -51,7 +52,6 @@ sub _validate_with_plugin {
         return;
     }
 
-    my %duplicated_seedlot_names;
     for my $row ( @$parsed_data ) {
         my $row_num = $row->{_row};
         my $seedlot_name = $row->{'seedlot_name'};
@@ -60,12 +60,6 @@ sub _validate_with_plugin {
 
         if ($seedlot_name =~ /\s/ || $seedlot_name =~ /\// || $seedlot_name =~ /\\/ ) {
             push @error_messages, "Cell A$row_num: seedlot_name must not contain spaces or slashes.";
-        }
-
-        if ($duplicated_seedlot_names{$seedlot_name}) {
-            push @error_messages, "Cell A$row_num: duplicated seedlot name: $seedlot_name. Seedlot name must be unique.";
-        } else {
-            $duplicated_seedlot_names{$seedlot_name}++;
         }
 
         if (!$amount || $amount eq '') {

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessions.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialChangePlotAccessions.pm
@@ -31,10 +31,7 @@ sub _validate_with_plugin {
             'new_plot_name' => ['new plot name'],
             'accession_name' => ['accession name', 'accession', 'cross_unique_id', 'cross unique id', 'family_name', 'family name']
         },
-        unique_only_columns =>  {
-            'plot_name' => 1,
-            'new_plot_name' => 1
-        }
+        unique_only_columns => ['plot_name', 'new_plot_name']
     );
 
     my $parsed = $parser->parse();

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialMetadataGeneric.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialMetadataGeneric.pm
@@ -60,7 +60,8 @@ sub _validate_with_plugin {
         column_aliases => {
             'name' => [ 'new_trial_name' ],
             'type' => [ 'trial_type' ]
-        }
+        },
+        unique_only_columns => [ 'trial_name', 'new_trial_name' ]
     );
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{'errors'};

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialSpatialLayoutGeneric.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialSpatialLayoutGeneric.pm
@@ -32,7 +32,8 @@ sub _validate_with_plugin {
     my $parser = CXGN::File::Parse->new(
         file => $filename,
         required_columns => \@REQUIRED_COLUMNS,
-        optional_columns => \@OPTIONAL_COLUMNS
+        optional_columns => \@OPTIONAL_COLUMNS,
+        unique_only_columns => [ 'plot_name' ]
     );
     my $parsed = $parser->parse();
     my $parsed_errors = $parsed->{'errors'};

--- a/lib/CXGN/Trial/ParseUpload/Plugin/TrialUsedSeedlotsGeneric.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/TrialUsedSeedlotsGeneric.pm
@@ -33,6 +33,7 @@ sub _validate_with_plugin {
             'num_seed_per_plot' => ['num seed per plot'],
             'weight_gram_seed_per_plot' => ['weight gram seed per plot'],
         },
+        unique_only_columns => [ 'plot_name' ]
     );
 
     my $parsed = $parser->parse();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

For the Generic File Parser:

- changes the `unique_only_columns` option from a hash to an array, to keep it similar to the other options
- changes the unique column value checks to work with values that are returned as arrays as well as scalars
- adds the unique column checks to these uploads:
    -  Marker Metadata
    -  Locations
    -  Crosses
    -  Pedigrees
    -  ~~Phenotypes~~ (repetitive measurements and NIRS may have multiple rows per OU)
    -  Accessions
    -  Seedlot From Accession
    -  Seedlot From Cross
    -  Trial Metadata
    -  Trial Spatial Layout
    -  Trial Used Seedlots


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
