### PR TITLE
Vector Generic Upload: change unique_only_columns def from hash to array

### DIFF
--- a/lib/CXGN/Stock/Vector/ParseUpload/Plugin/VectorsGeneric.pm
+++ b/lib/CXGN/Stock/Vector/ParseUpload/Plugin/VectorsGeneric.pm
@@ -24,7 +24,7 @@ sub _validate_with_plugin {
         file => $filename,
         required_columns => ['uniquename'],
         optional_columns => $editable_vector_stockprops,
-        unique_only_columns => {'uniquename' => 1},
+        unique_only_columns => ['uniquename'],
         column_aliases => {
             'uniquename' => ['Uniquename', 'Name', 'name', 'vector_name', 'vector name'],
             'Strain' => ['strain'],


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


Changes the `unique_only_columns` definition in the Vector Generic Upload plugin from a hash to an array


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
