### PR TITLE
Tweak treatment and trait designers

### DIFF
--- a/lib/SGN/Controller/AJAX/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Trait.pm
@@ -44,11 +44,7 @@ sub create_trait :Path('/ajax/trait/create') {
 
     $name =~ s/^\s+//;
     $name =~ s/\s+$//;
-    $name =~ s/_/ /g;
-    $name =~ s/[^\p{Alpha} ]//g;
-    if ($format ne "ontology") {
-        $name = lc($name);
-    }
+    $name =~ s/[^[:ascii:]]//g;
 
     $definition =~ s/^\s+//;
     $definition =~ s/\s+$//;

--- a/lib/SGN/Controller/AJAX/Treatment.pm
+++ b/lib/SGN/Controller/AJAX/Treatment.pm
@@ -44,11 +44,7 @@ sub create_treatment :Path('/ajax/treatment/create') {
 
     $name =~ s/^\s+//;
     $name =~ s/\s+$//;
-    $name =~ s/_/ /g;
-    $name =~ s/[^\p{Alpha} ]//g;
-    if ($format ne "ontology") {
-        $name = lc($name);
-    }
+    $name =~ s/[^[:ascii:]]//g;
 
     $definition =~ s/^\s+//;
     $definition =~ s/\s+$//;

--- a/mason/tools/trait_designer.mas
+++ b/mason/tools/trait_designer.mas
@@ -15,7 +15,7 @@
         <div class="form-group">
                 <label class="col-sm-3 control-label"> New trait name: </label>
                 <div class="col-sm-9">
-                    <input style="width:70%;" class="form-control" id="new_trait_name" name="new_trait_name" type="text" placeholder="Special characters not allowed."/>
+                    <input style="width:70%;" class="form-control" id="new_trait_name" name="new_trait_name" type="text" placeholder="ASCII characters only. Non-ASCII characters will be removed."/>
                 </div>
             </div>
             <div class="form-group">

--- a/mason/tools/treatment_designer.mas
+++ b/mason/tools/treatment_designer.mas
@@ -16,7 +16,7 @@
         <div class="form-group">
                 <label class="col-sm-3 control-label"> New treatment name: </label>
                 <div class="col-sm-9">
-                    <input style="width:70%;" class="form-control" id="new_treatment_name" name="new_treatment_name" type="text" placeholder="Special characters not allowed."/>
+                    <input style="width:70%;" class="form-control" id="new_treatment_name" name="new_treatment_name" type="text" placeholder="ASCII characters only. Non-ASCII characters will be removed."/>
                 </div>
             </div>
             <div class="form-group">


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Makes treatment and trait designer accept numbers and special characters for new trait names. Non ASCII (unicode) characters are filtered. 

<!-- If there are relevant issues, link them here: -->
Closes #6110 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
