### PR TITLE
Tweak phenotype summary statistics UI

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
@@ -32,6 +32,7 @@ function disable_ui() {
 
 function enable_ui() {
     jQuery('#working_modal').modal("hide");
+    jQuery('.modal-backdrop').hide();
 }
 
 jQuery(document).ready(function ($) {
@@ -423,18 +424,20 @@ jQuery(document).ready(function ($) {
                 'email_address_upload': email_address,
                 'email_option_enabled': email_option_enabled,
             },
-            // beforeSend: function(){
+            // beforeSend: function(){ //UI gets disabled before ajax call if email option is not enabled
             //     disable_ui();
             // },
             success: function (response) {
                 console.log("email_option_enabled on success:", email_option_enabled);
-                if (!email_option_enabled) {
-                    enable_ui();
-                }
+                // if (!email_option_enabled) { //no need to explicitly enable UI if UI was not disabled previously
+                //     enable_ui();
+                // }
 		        //alert("ADD ACCESSIONS: "+JSON.stringify(response));
                 if (response.error) {
+                    enable_ui();
                     alert(response.error);
                 } else {
+                    enable_ui();
                     var html = 'The following stocks were added!<br/>';
                     for (var i=0; i<response.added.length; i++){
                         html = html + '<a href="/stock/'+response.added[i][0]+'/view">'+response.added[i][1]+'</a><br/>';
@@ -445,7 +448,7 @@ jQuery(document).ready(function ($) {
             },
             error: function (response) {
                 console.log("email_option_enabled on error:", email_option_enabled);
-                if (!email_option_enabled) {
+                if (email_option_enabled) {
                     enable_ui();
                 }
                 alert('An error occurred in processing. sorry'+response.responseText);

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -370,7 +370,8 @@ sub phenotype_summary : Chained('trial') PathPart('phenotypes') Args(0) {
     my $start_date = $c->req->param('start_date');
     my $end_date = $c->req->param('end_date');
     my $include_dateless_items = $c->req->param('include_dateless_items');
-    my $split_by_treatments = $c->req->param('split_by_treatments');
+    my $group_by_treatments = $c->req->param('group_by_treatments');
+    my $group_by_accession = $c->req->param('group_by_accession');
     my $select_clause_additional = '';
     my $group_by_additional = '';
     my $order_by_additional = '';
@@ -378,17 +379,36 @@ sub phenotype_summary : Chained('trial') PathPart('phenotypes') Args(0) {
     my $rel_type_id;
     my $total_complete_number;
     # print STDERR "trial phenotypes: START DATE: $start_date. END DATE: $end_date, INLCUDE DATELESS $include_dateless_items, DIPLAY = $display\n";
+    my $stocks_per_accession;
     if ($display eq 'plots') {
-        $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
-        $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot_of', 'stock_relationship')->cvterm_id();
-        my $plots = $c->stash->{trial}->get_plots();
-        $total_complete_number = scalar (@$plots);
+        if ($group_by_accession) {
+            $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
+            $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot_of', 'stock_relationship')->cvterm_id();
+            $select_clause_additional = ', accession.uniquename, accession.stock_id';
+            $group_by_additional = ', accession.stock_id, accession.uniquename';
+            $stocks_per_accession = $c->stash->{trial}->get_plots_per_accession();
+            $order_by_additional = ' , accession.uniquename DESC';
+        } else {
+            $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
+            $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot_of', 'stock_relationship')->cvterm_id();
+            my $plots = $c->stash->{trial}->get_plots();
+            $total_complete_number = scalar (@$plots);
+        }
     }
     if ($display eq 'plants') {
-        $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant', 'stock_type')->cvterm_id();
-        $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant_of', 'stock_relationship')->cvterm_id();
-        my $plants = $c->stash->{trial}->get_plants();
-        $total_complete_number = scalar (@$plants);
+        if ($group_by_accession) {
+            $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant', 'stock_type')->cvterm_id();
+            $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant_of', 'stock_relationship')->cvterm_id();
+            $select_clause_additional = ', accession.uniquename, accession.stock_id';
+            $group_by_additional = ', accession.stock_id, accession.uniquename';
+            $stocks_per_accession = $c->stash->{trial}->get_plants_per_accession();
+            $order_by_additional = ' , accession.uniquename DESC';
+        } else {
+            $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant', 'stock_type')->cvterm_id();
+            $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant_of', 'stock_relationship')->cvterm_id();
+            my $plants = $c->stash->{trial}->get_plants();
+            $total_complete_number = scalar (@$plants);
+        }
     }
     if ($display eq 'subplots') {
         $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'subplot', 'stock_type')->cvterm_id();
@@ -397,35 +417,19 @@ sub phenotype_summary : Chained('trial') PathPart('phenotypes') Args(0) {
         $total_complete_number = scalar (@$subplots);
     }
     if ($display eq 'tissue_samples') {
-        $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample', 'stock_type')->cvterm_id();
-        $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample_of', 'stock_relationship')->cvterm_id();
-        my $subplots = $c->stash->{trial}->get_subplots();
-        $total_complete_number = scalar (@$subplots);
-    }
-    my $stocks_per_accession;
-    if ($display eq 'plots_accession') {
-        $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
-        $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot_of', 'stock_relationship')->cvterm_id();
-        $select_clause_additional = ', accession.uniquename, accession.stock_id';
-        $group_by_additional = ', accession.stock_id, accession.uniquename';
-        $stocks_per_accession = $c->stash->{trial}->get_plots_per_accession();
-        $order_by_additional = ' , accession.uniquename DESC';
-    }
-    if ($display eq 'plants_accession') {
-        $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant', 'stock_type')->cvterm_id();
-        $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant_of', 'stock_relationship')->cvterm_id();
-        $select_clause_additional = ', accession.uniquename, accession.stock_id';
-        $group_by_additional = ', accession.stock_id, accession.uniquename';
-        $stocks_per_accession = $c->stash->{trial}->get_plants_per_accession();
-        $order_by_additional = ' , accession.uniquename DESC';
-    }
-    if ($display eq 'tissue_samples_accession') {
-        $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample', 'stock_type')->cvterm_id();
-        $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample_of', 'stock_relationship')->cvterm_id();
-        $select_clause_additional = ', accession.uniquename, accession.stock_id';
-        $group_by_additional = ', accession.stock_id, accession.uniquename';
-        $stocks_per_accession = $c->stash->{trial}->get_plants_per_accession();
-        $order_by_additional = ' , accession.uniquename DESC';
+        if ($group_by_accession) {
+            $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample', 'stock_type')->cvterm_id();
+            $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample_of', 'stock_relationship')->cvterm_id();
+            $select_clause_additional = ', accession.uniquename, accession.stock_id';
+            $group_by_additional = ', accession.stock_id, accession.uniquename';
+            $stocks_per_accession = $c->stash->{trial}->get_plants_per_accession();
+            $order_by_additional = ' , accession.uniquename DESC';
+        } else {
+            $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample', 'stock_type')->cvterm_id();
+            $rel_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample_of', 'stock_relationship')->cvterm_id();
+            my $subplots = $c->stash->{trial}->get_subplots();
+            $total_complete_number = scalar (@$subplots);
+        }
     }
     if ($display eq 'analysis_instance') {
         $stock_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'analysis_instance', 'stock_type')->cvterm_id();
@@ -435,7 +439,7 @@ sub phenotype_summary : Chained('trial') PathPart('phenotypes') Args(0) {
     my $treatment_select = '';
     my $treatment_with = '';
     my $treatment_join = '';
-    if ($split_by_treatments) {
+    if ($group_by_treatments) {
         $treatment_with = "WITH treatment_by_stock AS (
             SELECT
                 nes.stock_id AS stock_id,
@@ -572,7 +576,7 @@ sub phenotype_summary : Chained('trial') PathPart('phenotypes') Args(0) {
             $total_complete_number = scalar (@{$stocks_per_accession->{$stock_id}});
             push @return_array, qq{<a href="/stock/$stock_id/view">$stock_name</a>};
         }
-        if ($split_by_treatments) {
+        if ($group_by_treatments) {
             if ($select_clause_additional) {
                 push @return_array, qq{<a href="/cvterm/$treatment_id/view">$treatment</a>};
             }
@@ -646,7 +650,7 @@ sub phenotype_summary : Chained('trial') PathPart('phenotypes') Args(0) {
             $total_complete_number = scalar (@{$stocks_per_accession->{$stock_id}});
             push @return_array, qq{<a href="/stock/$stock_id/view">$stock_name</a>};
         }
-        if ($split_by_treatments) {
+        if ($group_by_treatments) {
             if ($select_clause_additional) {
                 push @return_array, qq{<a href="/cvterm/$treatment_id/view">$treatment</a>};
             }

--- a/mason/breeders_toolbox/trial/phenotype_summary.mas
+++ b/mason/breeders_toolbox/trial/phenotype_summary.mas
@@ -148,12 +148,12 @@ input[type="text"] {
                         <div class="col-sm-10" >
                             <select class="form-control" id="display_trial_phenosummary_hist">
 %  if ($trial_stock_type eq 'analysis_instance') {
-                                <option value="analysis_instance">Values for Analysis</option>
+                                <option id="phenosummary_hist_analysis_instance_level" value="analysis_instance">Values for Analysis</option>
 %  } else {
-                                <option value="plot">Plots</option>
-                                <option value="plant">Plants</option>
-                                <option value="subplot">Subplots</option>
-                                <option value="tissue_sample">Tissue Samples</option>
+                                <option id="phenosummary_hist_plot_level" value="plot">Plots</option>
+                                <option id="phenosummary_hist_plant_level" value="plant">Plants</option>
+                                <option id="phenosummary_hist_subplot_level" value="subplot">Subplots</option>
+                                <option id="phenosummary_hist_tissue_sample_level" value="tissue_sample">Tissue Samples</option>
 %  }
                             </select>
                         </div>
@@ -184,6 +184,18 @@ input[type="text"] {
     jQuery(document).ready(function () {
         var type = "<% $trial_stock_type %>";
         var trial_id = "<% $trial_id %>";
+
+        var observation_levels = ['plot', 'plant', 'subplot', 'tissue_sample'];
+    	for (let observation_level of observation_levels) {
+    	    get_observation_variable_count(trial_id, observation_level)
+    	    .then(function(count) {
+				if (count < 1) {
+                    jQuery(`#pheno_summary_${observation_level}_level`).prop('disabled', true);
+                    jQuery(`#phenosummary_hist_${observation_level}_level`).prop('disabled', true);
+                } 
+    	    });
+    	}
+
     	jQuery.ajax( {
             url: '/ajax/breeders/trial/'+ trial_id + '/collect_date_range',
     	}).done( function(r) {
@@ -399,7 +411,7 @@ input[type="text"] {
             "ajax": '/ajax/breeders/trial/'+ trial_id + '/phenotypes?display='+jQuery('input[name="pheno_summary_table_data_level"]:checked').val() + '&trial_stock_type='+type + '&start_date='+start_date+'&end_date='+end_date+'&include_dateless_items=1&group_by_treatments='+group_by_treatments+'&group_by_accession='+group_by_accession,
             "processing": true,
             'language':{
-                "zeroRecords": " ",
+                "zeroRecords": "No data available",
                 "processing": "Loading..."
             }
         });
@@ -436,6 +448,47 @@ input[type="text"] {
           return false;
         });
     }
+
+    function get_observation_variable_count(trial_id, observation_level) {
+        return jQuery.ajax({
+            url: "/brapi/v2/search/observations",
+            method: "POST",
+            data: { studyDbIds: [trial_id], observationLevel: [observation_level] }
+        })
+        .then(function(result) {
+            //console.log('Search Results DbId:', result.result.searchResultsDbId);
+            var searchResultsDbId = result.result.searchResultsDbId;
+            return fetch_observations(searchResultsDbId);
+        })
+        .then(function(observations) {
+            var variableIds = observations.map(function(obs) { return obs.observationVariableDbId; });
+            var unique_obs_VariableIds = Array.from(new Set(variableIds));
+            return unique_obs_VariableIds.length;
+        });
+    }
+
+    function fetch_observations(searchResultsDbId) {
+    	var observations = [];
+    	function fetchPage(page) {
+    	    return jQuery.ajax({
+    	        url: "/brapi/v2/search/observations/" + searchResultsDbId,
+    	        method: "GET",
+    	        data: { page: page, pageSize: 10000 }
+    	    })
+    	    .then(function(result) {
+    	        observations = observations.concat(result.result.data);
+    	        var currentPage = result.metadata.pagination.currentPage;
+    	        var totalPages = result.metadata.pagination.totalPages;
+    	        if (currentPage < totalPages - 1) {
+    	            return fetchPage(currentPage + 1);
+    	        } else {
+					//console.log('All pages fetched. Total observations:', observations.length);
+    	            return observations;
+    	        }
+    	    });
+    	}
+    	return fetchPage(0);
+	}
 
     function trait_summary_hist_display_change(value) {
         var start_date = jQuery('#summary_start_date').val();

--- a/mason/breeders_toolbox/trial/phenotype_summary.mas
+++ b/mason/breeders_toolbox/trial/phenotype_summary.mas
@@ -45,7 +45,7 @@ input[type="text"] {
 
 
 <div class="well well-sm table-responsive">
-    <center><h4>Raw Data Statistics</h4></center>
+
     <br/>
 
     <form class="form-horizontal" role="form" >
@@ -59,28 +59,35 @@ input[type="text"] {
 	            <input type="text" id="summary_end_date" title="summary_end_date" />
             </div>
             <div style="display: flex; align-items: center;">
-                <label for="display_trial_phenosummary" style="margin-right: 10px;">Display: </label>
-                <select class="form-control" id="display_trial_phenosummary">
-%  if ($trial_stock_type eq 'analysis_instance') {
-                    <option value="analysis_instance">Values for Analysis</option>
-%  } else {
-                    <option value="plots">Trait Values for Plots in this Trial</option>
-                    <option value="plants">Trait Values for Plants in this Trial</option>
-                    <option value="subplots">Trait Values for Subplots in this Trial</option>
-                    <option value="tissue_samples">Trait Values for Tissue Samples in this Trial</option>
-                    <option id = "plots_stock_option" value="plots_accession"></option>
-                    <option id = "plants_stock_option" value="plants_accession"></option>
-                    <option id = "tissue_samples_stock_option" value="tissue_samples_accession"></option>
-%  }
-                </select>&nbsp;&nbsp;&nbsp;
-                <label for="split_by_treatments_check" style="margin-right: 10px;">Split results by treatments: </label>
-                <input type="checkbox" id="split_by_treatments_check" title="split_by_treatments_check" />
+                <label for="display_trial_phenosummary" style="margin-right: 10px;">Data Level: </label>
+                <div>
+% if ($trial_stock_type eq 'analysis_instance') {
+                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_analysis_level" value="analysis_instance" checked>
+                    <label for="pheno_summary_analysis_level">Analysis values</label><br>
+% } else {
+                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_plot_level" value="plots" checked>
+                    <label for="pheno_summary_plot_level">Plots</label><br>
+                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_subplot_level" value="subplots">
+                    <label for="pheno_summary_subplot_level">Subplots</label><br>
+                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_plant_level" value="plants">
+                    <label for="pheno_summary_plant_level">Plants</label><br>
+                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_tissue_sample_level" value="tissue_samples">
+                    <label for="pheno_summary_tissue_sample_level">Tissue Samples</label><br>
+                </div>
+                &nbsp;&nbsp;&nbsp;
+                <label for="group_by_accession_check" style="margin-right: 10px;">Group by accession: </label>
+                <input type="checkbox" id="group_by_accession_check" title="group_by_accession_check" />
+                &nbsp;&nbsp;
+                <label for="group_by_treatments_check" style="margin-right: 10px;">Group by treatments: </label>
+                <input type="checkbox" id="group_by_treatments_check" title="group_by_treatments_check" />
+% } 
+                
             </div>
         </div>
     </form>
     <br>
     <div style="display:flex; align-items:center; white-space:nowrap; width:70%; margin-center: auto;">
-        <label for="summary_phenotype_slider_range" style="margin-right: 10px;">Choose DateRange slider:</label>
+        <label for="summary_phenotype_slider_range" style="margin-right: 10px;">Choose Date Range:</label>
         <div id="summary_phenotype_slider_range" style="width: 80%; margin: 10px auto;"></div>
     </div>
     <hr>
@@ -137,16 +144,16 @@ input[type="text"] {
                         </div>
                     </div>
                     <div class="form-group form-group-sm">
-                        <label class="col-sm-2 control-label">Display: </label>
+                        <label class="col-sm-2 control-label">Data level: </label>
                         <div class="col-sm-10" >
                             <select class="form-control" id="display_trial_phenosummary_hist">
 %  if ($trial_stock_type eq 'analysis_instance') {
                                 <option value="analysis_instance">Values for Analysis</option>
 %  } else {
-                                <option value="plot">Values for Plots in this Trial</option>
-                                <option value="plant">Values for Plants in this Trial</option>
-                                <option value="subplot">Values for Subplots in this Trial</option>
-                                <option value="tissue_sample">Values for Tissue Samples in this Trial</option>
+                                <option value="plot">Plots</option>
+                                <option value="plant">Plants</option>
+                                <option value="subplot">Subplots</option>
+                                <option value="tissue_sample">Tissue Samples</option>
 %  }
                             </select>
                         </div>
@@ -247,7 +254,38 @@ input[type="text"] {
             console.error("the status:", xhr.status);
             console.error("the error:", error);
         });
-        jQuery("#split_by_treatments_check").change( function() {
+        jQuery("#group_by_treatments_check").change( function() {
+            var html = setup_tables(type);
+            jQuery('#pheno_summary_table_div').empty().html(html);
+            datatables_display_phenosummary(type);
+        });
+        jQuery("#group_by_accession_check").change( function() {
+            var html = setup_tables(type);
+            jQuery('#pheno_summary_table_div').empty().html(html);
+            datatables_display_phenosummary(type);
+        });
+        jQuery('input[name="pheno_summary_table_data_level"]').on('change', function() {
+            let level = jQuery('input[name="pheno_summary_table_data_level"]:checked').val();
+
+            switch (level) {
+                case 'plots' :
+                    jQuery('#display_trial_phenosummary_hist').val('plot').trigger('change');
+                    jQuery('#group_by_accession_check').prop('disabled', false);
+                    break;
+                case 'subplots' :
+                    jQuery('#group_by_accession_check').prop('checked', false);
+                    jQuery('#group_by_accession_check').prop('disabled', true);
+                    break;
+                case 'plants' :
+                    jQuery('#display_trial_phenosummary_hist').val('plant').trigger('change');
+                    jQuery('#group_by_accession_check').prop('disabled', false);
+                    break;
+                case 'tissue_samples' :
+                    jQuery('#display_trial_phenosummary_hist').val('tissue_sample').trigger('change');
+                    jQuery('#group_by_accession_check').prop('disabled', false);
+                    break;
+            }
+
             var html = setup_tables(type);
             jQuery('#pheno_summary_table_div').empty().html(html);
             datatables_display_phenosummary(type);
@@ -297,17 +335,17 @@ input[type="text"] {
         var tissue_samples_stock_text = '';
 
         if (type == 'family_name') {
-            plots_stock_text = 'Trait Values for Plots in this Trial grouped by Family Name';
-            plants_stock_text = 'Trait Values for Plants in this Trial grouped by Family Name';
-            tissue_samples_stock_text = 'Trait Values for Tissue Samples in this Trial grouped by Family Name';
+            plots_stock_text = 'Plots grouped by Family Name';
+            plants_stock_text = 'Plants grouped by Family Name';
+            tissue_samples_stock_text = 'Tissue Samples grouped by Family Name';
         } else if (type == 'cross') {
-            plots_stock_text = 'Trait Values for Plots in this Trial grouped by Cross Unique ID';
-            plants_stock_text = 'Trait Values for Plants in this Trial grouped by Cross Unique ID';
-            tissue_samples_stock_text = 'Trait Values for Tissue Samples in this Trial grouped by Cross Unique ID';
+            plots_stock_text = 'Plots grouped by Cross Unique ID';
+            plants_stock_text = 'Plants grouped by Cross Unique ID';
+            tissue_samples_stock_text = 'Tissue Samples grouped by Cross Unique ID';
         } else {
-            plots_stock_text = 'Trait Values for Plots in this Trial grouped by Accession';
-            plants_stock_text = 'Trait Values for Plants in this Trial grouped by Accession';
-            tissue_samples_stock_text = 'Trait Values for Tissue Samples in this Trial grouped by Accession';
+            plots_stock_text = 'Plots grouped by Accession';
+            plants_stock_text = 'Plants grouped by Accession';
+            tissue_samples_stock_text = 'Tissue Samples grouped by Accession';
         }
         jQuery('#plots_stock_option').text(plots_stock_text);
         jQuery('#plants_stock_option').text(plants_stock_text);
@@ -318,7 +356,8 @@ input[type="text"] {
     function datatables_display_phenosummary(type) {
         var start_date = jQuery('#summary_start_date').val();
         var end_date = jQuery('#summary_end_date').val();
-        var split_by_treatments = jQuery('#split_by_treatments_check').prop('checked') ? 1 : 0;
+        var group_by_treatments = jQuery('#group_by_treatments_check').prop('checked') ? 1 : 0;
+        var group_by_accession = jQuery('#group_by_accession_check').prop('checked') ? 1 : 0;
 
         //alert('datatables_display_phenosummary: START: '+start_date+' END: '+end_date);
         var summary_table = jQuery('#phenotype_summary_data').DataTable( {
@@ -336,7 +375,7 @@ input[type="text"] {
             "buttons":  [
                 'pageLength','copy', 'excel', 'csv', 'pdf'
             ],
-            "ajax": '/ajax/breeders/trial/'+ trial_id + '/phenotypes?display='+jQuery('#display_trial_phenosummary').val() + '&trial_stock_type='+type + '&start_date='+start_date+'&end_date='+end_date+'&include_dateless_items=1&split_by_treatments='+split_by_treatments,
+            "ajax": '/ajax/breeders/trial/'+ trial_id + '/phenotypes?display='+jQuery('input[name="pheno_summary_table_data_level"]:checked').val() + '&trial_stock_type='+type + '&start_date='+start_date+'&end_date='+end_date+'&include_dateless_items=1&group_by_treatments='+group_by_treatments+'&group_by_accession='+group_by_accession,
             "processing": true,
             'language':{
                 "zeroRecords": " ",
@@ -348,8 +387,7 @@ input[type="text"] {
 
         var selection_changed = function () {
             var selected_rows = summary_table.rows({'selected':true});
-            var table_type = jQuery('#display_trial_phenosummary').val();
-            var list_type = table_type.match('accession') ? 'accessions' : 'traits';
+            var list_type = jQuery('#group_by_accession_check').prop('checked') ? 'accessions' : 'traits';
             jQuery("#selected_row_count").text(selected_rows.count());
             // console.log(selected_rows.data());
 
@@ -463,16 +501,16 @@ input[type="text"] {
 
     function setup_tables(type) {
         var html = '';
-        var display = jQuery('#display_trial_phenosummary').val();
-        var split_by_treatments = jQuery('#split_by_treatments_check').prop('checked') ? 1 : 0;
+        var display = jQuery('input[name="pheno_summary_table_data_level"]:checked').val()
+        var group_by_treatments = jQuery('#group_by_treatments_check').prop('checked') ? 1 : 0;
+        var group_by_accession = jQuery('#group_by_accession_check').prop('checked') ? 1 : 0;
         var treatment_html = '';
-        if (split_by_treatments) {
+        if (group_by_treatments) {
             treatment_html = '<th>Treatment</th>';
         }
-        if (display == 'plots' || display == 'plants' || display == 'subplots' || display == 'tissue_samples') {
+        if (!group_by_accession) {
             html = html +'<table id="phenotype_summary_data" class="display"><thead><tr>'+treatment_html+'<th>Trait</th><th>Mean</th><th>Min</th><th>Max</th><th>Std Dev</th><th>CV</th><th>Count</th><th>Percent Missing</th><th>Histogram</th></tr></thead><tbody></tbody></table>';
-        }
-        if (display == 'plots_accession' || display == 'plants_accession' || display == 'tissue_samples_accession') {
+        } else {
             if (type == 'family_name') {
                 html = html +'<table id="phenotype_summary_data" class="display"><thead><tr><th>Family Name</th>'+treatment_html+'<th>Trait</th><th>Mean</th><th>Min</th><th>Max</th><th>Std Dev</th><th>CV</th><th>Count</th><th>Percent Missing</th><th>Histogram</th></tr></thead><tbody></tbody></table>';
             } else if (type == 'cross') {

--- a/mason/breeders_toolbox/trial/phenotype_summary.mas
+++ b/mason/breeders_toolbox/trial/phenotype_summary.mas
@@ -49,7 +49,7 @@ input[type="text"] {
     <br/>
 
     <form class="form-horizontal" role="form" >
-        <div style="display: flex; align-items: center; justify-content: center; gap: 20px;">
+        <div style="display: flex; align-items: flex-start; gap: 25px; width: max-content; margin: 0 auto;">
             <div>
                 <label for="summary_start_date">Start Date: </label>
 	            <input type="text" id="summary_start_date" title="summary_start_date" />
@@ -58,31 +58,31 @@ input[type="text"] {
                 <label for="summary_end_date">End Date: </label>
 	            <input type="text" id="summary_end_date" title="summary_end_date" />
             </div>
-            <div style="display: flex; align-items: center;">
-                <label for="display_trial_phenosummary" style="margin-right: 10px;">Data Level: </label>
-                <div>
+            <div>
+                <label>Data Level: </label>
+                <div style="margin-top: 4px;">
 % if ($trial_stock_type eq 'analysis_instance') {
-                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_analysis_level" value="analysis_instance" checked>
-                    <label for="pheno_summary_analysis_level">Analysis values</label><br>
+                    <div><input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_analysis_level" value="analysis_instance" checked> <label for="pheno_summary_analysis_level">Analysis values</label></div>
 % } else {
-                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_plot_level" value="plots" checked>
-                    <label for="pheno_summary_plot_level">Plots</label><br>
-                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_subplot_level" value="subplots">
-                    <label for="pheno_summary_subplot_level">Subplots</label><br>
-                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_plant_level" value="plants">
-                    <label for="pheno_summary_plant_level">Plants</label><br>
-                    <input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_tissue_sample_level" value="tissue_samples">
-                    <label for="pheno_summary_tissue_sample_level">Tissue Samples</label><br>
+                    <div><input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_plot_level" value="plots" checked> <label for="pheno_summary_plot_level">Plots</label></div>
+                    <div><input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_subplot_level" value="subplots"> <label for="pheno_summary_subplot_level">Subplots</label></div>
+                    <div><input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_plant_level" value="plants"> <label for="pheno_summary_plant_level">Plants</label></div>
+                    <div><input type="radio" name="pheno_summary_table_data_level" id="pheno_summary_tissue_sample_level" value="tissue_samples"> <label for="pheno_summary_tissue_sample_level">Tissue Samples</label></div>
+% }
                 </div>
-                &nbsp;&nbsp;&nbsp;
-                <label for="group_by_accession_check" style="margin-right: 10px;">Group by accession: </label>
-                <input type="checkbox" id="group_by_accession_check" title="group_by_accession_check" />
-                &nbsp;&nbsp;
-                <label for="group_by_treatments_check" style="margin-right: 10px;">Group by treatments: </label>
-                <input type="checkbox" id="group_by_treatments_check" title="group_by_treatments_check" />
-% } 
-                
             </div>
+% if ($trial_stock_type ne 'analysis_instance') {
+            <div style="display: flex; flex-direction: column; gap: 10px;">
+                <div style="display: flex; align-items: center; gap: 6px;">
+                    <input type="checkbox" id="group_by_accession_check" title="group_by_accession_check" />
+                    <label for="group_by_accession_check">Group by accession</label>
+                </div>
+                <div style="display: flex; align-items: center; gap: 6px;">
+                    <input type="checkbox" id="group_by_treatments_check" title="group_by_treatments_check" />
+                    <label for="group_by_treatments_check">Group by treatments</label>
+                </div>
+            </div>
+% }
         </div>
     </form>
     <br>
@@ -265,6 +265,7 @@ input[type="text"] {
             datatables_display_phenosummary(type);
         });
         jQuery('input[name="pheno_summary_table_data_level"]').on('change', function() {
+            
             let level = jQuery('input[name="pheno_summary_table_data_level"]:checked').val();
 
             switch (level) {
@@ -273,6 +274,7 @@ input[type="text"] {
                     jQuery('#group_by_accession_check').prop('disabled', false);
                     break;
                 case 'subplots' :
+                    jQuery('#display_trial_phenosummary_hist').val('subplot').trigger('change');
                     jQuery('#group_by_accession_check').prop('checked', false);
                     jQuery('#group_by_accession_check').prop('disabled', true);
                     break;
@@ -306,6 +308,25 @@ input[type="text"] {
 
         jQuery("#display_trial_phenosummary_hist").change(function(){
             trait_summary_hist_display_change(this.value);
+            jQuery(`#pheno_summary_${this.value}_level`).prop('checked', true);
+            switch (this.value) {
+                case 'plot':
+                    jQuery('#group_by_accession_check').prop('disabled', false);
+                    break;
+                case 'tissue_sample':
+                    jQuery('#group_by_accession_check').prop('disabled', false);
+                    break;
+                case 'subplot':
+                    jQuery('#group_by_accession_check').prop('checked', false);
+                    jQuery('#group_by_accession_check').prop('disabled', true);
+                    break;
+                case 'plant':
+                    jQuery('#group_by_accession_check').prop('disabled', false);
+                    break;
+            }
+            var html = setup_tables(type);
+            jQuery('#pheno_summary_table_div').empty().html(html);
+            datatables_display_phenosummary(type);
         });
 
         jQuery('#trial_detail_traits_assayed_onswitch').click( function() {
@@ -437,19 +458,19 @@ input[type="text"] {
                     }
                     traits_assayed_html = traits_assayed_html +"</select>";
                     jQuery("#traits_assayed_dropdown").html(traits_assayed_html);
-                    jQuery("#traits_assayed_dropdown>select").change(function(){
+                    jQuery("#trial_summary_hist_dropdown").change(function(){
                       trait_summary_hist_change(this.value);
                     });
 
                     jQuery('#traits_assayed_histogram_cvterm_link').html("<a href='/cvterm/"+response.traits_assayed[0][0][0]+"/view'>Definition</a>");
 
 
-		    let trait_value = jQuery('#trial_summary_hist_dropdown').val();
+                let trait_value = jQuery('#trial_summary_hist_dropdown').val();
 
-		    if (trait_value == null) {
-			jQuery('#working_modal').modal("hide");
-			return;
-		    }			
+                if (trait_value == null) {
+                jQuery('#working_modal').modal("hide");
+                return;
+		        }			
 
                     jQuery.ajax( {
                         url : '/ajax/breeders/trial/'+ trial_id +'/trait_phenotypes/?trait='+trait_value+'&display='+value+'&start_date='+start_date+'&end_date='+end_date+'&include_dateless_items=1',

--- a/t/unit_mech/AJAX/BreedersToolbox/TrialMetadata.t
+++ b/t/unit_mech/AJAX/BreedersToolbox/TrialMetadata.t
@@ -40,7 +40,7 @@ is_deeply($response, {'data' => [['<a href="/cvterm/70741/view">dry matter conte
 
 		#	  '<a href="/cvterm/70741/view">dry matter content percentage|CO_334:0000092</a>','26.02','15.00','500.00','22.61','86.89%',465,'32.8%','<a href="#raw_data_histogram_well" onclick="trait_summary_hist_change(70741)"><span class="glyphicon glyphicon-stats"></span></a>'],['<a href="/cvterm/70666/view">fresh root weight|CO_334:0000012</a>','5.91','0.04','38.76','5.37','90.80%',469,'32.23%','<a href="#raw_data_histogram_well" onclick="trait_summary_hist_change(70666)"><span class="glyphicon glyphicon-stats"></span></a>'],['<a href="/cvterm/70773/view">fresh shoot weight measurement in kg|CO_334:0000016</a>','14.33','0.50','555.00','26.62','185.78%',494,'28.61%','<a href="#raw_data_histogram_well" onclick="trait_summary_hist_change(70773)"><span class="glyphicon glyphicon-stats"></span></a>']]}, "check trial detail page");
 
-$mech->get_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/phenotypes?display=plots_accession');
+$mech->get_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/phenotypes?display=plots&group_by_accession=1');
 $response = decode_json $mech->content;
 my @response = @{$response->{data}};
 my @last_n = @response[-4..-1];


### PR DESCRIPTION

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Changes the pheno summary statistics UI to use radio buttons for selecting data level and a checkbox for grouping by accessions. Radio buttons are synced with histogram data level selector


<!-- If there are relevant issues, link them here: -->
Closes #6112 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
