### PR TITLE
fix upload accession

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
@@ -25,6 +25,7 @@ var infoToAdd;
 var accessionListFound;
 var speciesNames;
 var doFuzzySearch;
+var upload_in_progress = false;
 
 function disable_ui() {
     jQuery('#working_modal').modal("show");
@@ -412,6 +413,8 @@ jQuery(document).ready(function ($) {
             disable_ui();
         }
 
+        upload_in_progress = true;
+
         $.ajax({
             type: 'POST',
             url: '/ajax/accession_list/add',
@@ -428,10 +431,6 @@ jQuery(document).ready(function ($) {
             // },
             success: function (response) {
                 console.log("email_option_enabled on success:", email_option_enabled);
-                if (!email_option_enabled) {
-                    enable_ui();
-                }
-		        //alert("ADD ACCESSIONS: "+JSON.stringify(response));
                 if (response.error) {
                     alert(response.error);
                 } else {
@@ -445,13 +444,22 @@ jQuery(document).ready(function ($) {
             },
             error: function (response) {
                 console.log("email_option_enabled on error:", email_option_enabled);
-                if (!email_option_enabled) {
-                    enable_ui();
-                }
                 alert('An error occurred in processing. sorry'+response.responseText);
-            }
+            },
+            complete: function () {
+                upload_in_progress = false;
+                if (!email_option_enabled) enable_ui();
+            },
         });
     }
+
+    jQuery(window).on('beforeunload', function (e) {
+        if (upload_in_progress) {
+            e.preventDefault();
+            e.returnValue = ''; // required for Chrome
+            return '';          // required for some older browsers
+        }
+    });
 
     function verify_species_name() {
         var speciesName = $("#species_name_input").val();

--- a/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/Accessions.js
@@ -527,10 +527,10 @@ jQuery(document).ready(function ($) {
 		        alert('ERROR! Try again later.');
 		    }
 	        );
+	    } else {
+	        add_accessions(infoToAdd, speciesNames, emailAddress, email_option_enabled);
+	        $('#review_absent_dialog').modal("hide");
 	    }
-
-	    add_accessions(infoToAdd, speciesNames, emailAddress, email_option_enabled);
-	    $('#review_absent_dialog').modal("hide");
 
         //window.location.href='/breeders/accessions';
     });
@@ -581,7 +581,7 @@ jQuery(document).ready(function ($) {
             }
             else if (response.success) {
                 fullParsedData = response.full_data;
-                doFuzzySearch = jQuery('#fuzzy_check_upload_accessions').prop('checked');;
+                doFuzzySearch = jQuery('#fuzzy_check_upload_accessions').prop('checked');
                 review_verification_results(doFuzzySearch, response, response.list_id);
             }
             else {
@@ -593,15 +593,15 @@ jQuery(document).ready(function ($) {
 
     $('[name="add_accessions_link"]').click(function () {
         var list = new CXGN.List();
-        accessionList;
-        accession_list_id;
-        validSpecies;
-        fuzzyResponse;
-        fullParsedData;
-        infoToAdd;
-        accessionListFound;
-        speciesNames;
-        doFuzzySearch;
+        accessionList	= [];
+        accession_list_id = undefined;
+        validSpecies	= undefined;
+        fuzzyResponse	= undefined;
+        fullParsedData	= undefined;
+        infoToAdd	= [];
+        accessionListFound	= {};
+        speciesNames	= [];
+        doFuzzySearch	= undefined;
         $('#add_accessions_dialog').modal("show");
         $('#review_found_matches_dialog').modal("hide");
         $('#review_fuzzy_matches_dialog').modal("hide");
@@ -645,7 +645,7 @@ function openWindowWithPost(fuzzyResponse) {
 }
 
 function verify_accession_list(accession_list_id) {
-    accession_list = JSON.stringify(list.getList(accession_list_id));
+    accessionList = JSON.stringify(list.getList(accession_list_id));
     doFuzzySearch = jQuery('#fuzzy_check').prop('checked');
 
     jQuery.ajax({
@@ -655,7 +655,7 @@ function verify_accession_list(accession_list_id) {
         //async: false,
         dataType: "json",
         data: {
-            'accession_list': accession_list,
+            'accession_list': accessionList,
             'do_fuzzy_search': doFuzzySearch,
         },
         beforeSend: function(){
@@ -712,7 +712,7 @@ function review_verification_results(doFuzzySearch, verifyResponse, accession_li
 
     if (verifyResponse.fuzzy.length > 0 && doFuzzySearch) {
         fuzzyResponse = verifyResponse.fuzzy;
-        var fuzzy_html = '<table id="add_accession_fuzzy_table" class="table"><thead><tr><th class="col-xs-4">Name in Your List</th><th class="col-xs-4">Existing Name(s) in Database</th><th class="col-xs-4">Options&nbsp;&nbsp;&nbsp&nbsp;<input type="checkbox" id="add_accession_fuzzy_option_all"/> Use Same Option for All</th></tr></thead><tbody>';
+        var fuzzy_html = '<table id="add_accession_fuzzy_table" class="table"><thead><tr><th class="col-xs-4">Name in Your List</th><th class="col-xs-4">Existing Name(s) in Database</th><th class="col-xs-4">Options&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" id="add_accession_fuzzy_option_all"/> Use Same Option for All</th></tr></thead><tbody>';
         for( i=0; i < verifyResponse.fuzzy.length; i++) {
             fuzzy_html = fuzzy_html + '<tr id="add_accession_fuzzy_option_form'+i+'"><td>'+ verifyResponse.fuzzy[i].name + '<input type="hidden" name="fuzzy_name" value="'+ verifyResponse.fuzzy[i].name + '" /></td>';
             fuzzy_html = fuzzy_html + '<td><select class="form-control" name ="fuzzy_select">';
@@ -758,7 +758,7 @@ function review_verification_results(doFuzzySearch, verifyResponse, accession_li
         }
     });
 
-    jQuery(document).on('click', '#review_fuzzy_matches_continue', function(){
+    jQuery(document).off('click', '#review_fuzzy_matches_continue').on('click', '#review_fuzzy_matches_continue', function(){
         process_fuzzy_options(accession_list_id);
     });
 


### PR DESCRIPTION
upload accessions using list was not working correctly. called add_accessions with empty data then called again with correct data
added "beforeunload" check so large upload will not get interrupted


fixes #5861
fixes #5455 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
