### PR TITLE
BrAPI: fix PUT /trials response returning trialName in trialDescription

### DIFF
--- a/lib/CXGN/BrAPI/v2/Trials.pm
+++ b/lib/CXGN/BrAPI/v2/Trials.pm
@@ -351,7 +351,7 @@ sub update {
     my @folder_studies;
     my %additional_info;
     my $folder_id = $folder->folder_id;
-    my $folder_description = $folder->name; #description doesn't exist 
+    my $folder_description = $self->bcs_schema->resultset('Project::Project')->find({ project_id => $folder_id })->description() // '';
     my $breeding_program_id = $folder->breeding_program->project_id();
 
     # external references


### PR DESCRIPTION
## Summary
- One-line fix in `lib/CXGN/BrAPI/v2/Trials.pm`. The PUT response was returning `$folder->name` in the `trialDescription` field of the response payload, with a comment "description doesn't exist".
- The DB write earlier in the same function (`$folder->description($description || '')` at line 322) was correct, so persistence has always been fine. Only the response payload was wrong.
- Read the description directly from the project row instead.
- Any BrAPI client that uses the PUT response to update its in-memory representation of the trial silently overwrites its local `trialDescription` with the trial name.

## Reproducer
1. `POST /brapi/v2/trials` to create a trial.
2. `PUT /brapi/v2/trials/{id}` with the existing body and a modified `trialDescription`.
3. The PUT response's `trialDescription` field contains the trial's name, not the value sent.
4. A subsequent GET returns the correct (sent) value.

## Verification
Reproduced and verified the fix on the breedbase_dockerfile dev stack at `sgn-454.0`: PUT round-trip now returns the correct `trialDescription`; subsequent GET confirms the database value matches.