### PR TITLE
SGN::Controller::Folder: handle non-folder project ids gracefully

### DIFF
--- a/lib/SGN/Controller/Folder.pm
+++ b/lib/SGN/Controller/Folder.pm
@@ -23,9 +23,30 @@ sub folder_page :Path("/folder") Args(1) {
     my $c = shift;
     my $folder_id = shift;
 
-    #print STDERR Dumper $folder_id;
-
     my $folder_project = $self->schema->resultset("Project::Project")->find( { project_id => $folder_id } );
+    if (!$folder_project) {
+        $c->stash->{message} = "The requested folder ($folder_id) does not exist or has been deleted.";
+        $c->stash->{template} = 'generic_message.mas';
+        return;
+    }
+
+    # If the requested id is actually a breeding program, redirect to the program page
+    # rather than treating it as a folder. The trial detail mason template renders an
+    # unconditional /folder/{folder_id} link for the Folder cell; for trials whose
+    # recorded parent is the breeding program directly (no intermediate folder), that
+    # link resolves to /folder/{breeding_program_id} and used to 500 here.
+    my $breeding_program_cvterm = SGN::Model::Cvterm->get_cvterm_row($self->schema, 'breeding_program', 'project_property');
+    if ($breeding_program_cvterm) {
+        my $is_program = $self->schema->resultset('Project::Projectprop')->find({
+            project_id => $folder_id,
+            type_id    => $breeding_program_cvterm->cvterm_id(),
+        });
+        if ($is_program) {
+            $c->res->redirect("/breeders/program/$folder_id");
+            return;
+        }
+    }
+
     my $folder = CXGN::Trial::Folder->new({ bcs_schema => $self->schema, folder_id => $folder_id });
 
     my $children = $folder->children();


### PR DESCRIPTION
## Summary
- `/folder/{id}` did not validate that the requested id refers to an actual folder. When called with a breeding-program id, downstream `CXGN::Trial::Folder` accessors and the mason template failed with HTTP 500.
- This happens because the trial detail page (`mason/breeders_toolbox/trial/trial_details.mas` line 249) renders an unconditional `<a href="/folder/{$folder_id}">...</a>` for the Folder cell. For any trial whose recorded parent is the breeding program directly (no intermediate folder), `$folder_id` is the program's project id, the link resolves to `/folder/{program_id}`, and this route 500s.
- Also: `/folder/<nonexistent_id>` previously crashed on undef access rather than returning the friendly "does not exist" message that the existing fall-through path was meant to provide.

## Fix
- Detect when the requested id is a breeding program (via the `breeding_program` projectprop) and redirect to `/breeders/program/{id}`.
- Return the graceful "does not exist" message at the top of the handler when the project is not found, before any downstream code tries to use it.

## Reproducer
1. Open any trial whose Folder cell shows the breeding program's name (rather than a real folder name).
2. Click the link.
3. Before this patch: HTTP 500 Server Error.
4. After this patch: HTTP 302 redirect to the breeding program page.

## Notes
- This is a controller-level fix that handles the historical bad state without requiring data migration. Two underlying issues remain and could be addressed separately: the cvterm mismatch in `CXGN::Trial::Folder::associate_parent` (line 489 uses a `project_relationship` cvterm in a `projectprop.type_id` check, which silently prevents folder relationships from being recorded when the parent is the breeding program) and the unconditional URL generation in `trial_details.mas`.

## Verification
On the `breedbase_dockerfile` dev stack at `sgn-454.0`:
- `GET /folder/<breeding_program_id>` now returns HTTP 302 to `/breeders/program/<id>` (was HTTP 500).
- `GET /folder/<nonexistent_id>` now returns HTTP 200 with the friendly "does not exist" message (was HTTP 500).
- `GET /folder/<actual_folder_id>` continues to render the folder page as before.