### PR TITLE
Fix Pheno Download, when hdp_type is not defined

### DIFF
--- a/lib/CXGN/Trial/Download.pm
+++ b/lib/CXGN/Trial/Download.pm
@@ -214,7 +214,7 @@ has 'plant_list' => (isa => 'ArrayRef[Int]|Undef', is => 'rw' );
 has 'location_list' => (isa => 'ArrayRef[Int]|Undef', is => 'rw' );
 has 'year_list' => (isa => 'ArrayRef[Int]|Undef', is => 'rw' );
 has 'protocol_list' => (isa => 'ArrayRef[Int]|Undef', is => 'rw' );
-has 'hdp_type' => (isa => 'Str', is => 'rw');
+has 'hdp_type' => (isa => 'Str|Undef', is => 'rw');
 has 'instance_list' => (isa => 'ArrayRef[Int]|Undef', is => 'rw' );
 has 'include_timestamp' => (isa => 'Bool', is => 'ro', default => 0);
 has 'include_pedigree_parents' => (isa => 'Bool', is => 'ro', default => 0);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


Allows for an undefined `hdp_type` attribute in the `CXGN::Trial::Download` class.

Fixes #6161 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
