### PR TITLE
Add synonym and parent UI to cvterm detail page

### DIFF
--- a/lib/CXGN/Cvterm.pm
+++ b/lib/CXGN/Cvterm.pm
@@ -415,6 +415,43 @@ sub _store_cvtermprop {
 
 
 
+sub add_parent_terms {
+    my $self       = shift;
+    my $parent_ids = shift;
+
+    my $schema    = $self->schema();
+    my $cvterm_id = $self->cvterm_id();
+
+    my $relationship_cv = $schema->resultset("Cv::Cv")->find({ name => 'relationship' });
+    die "No 'relationship' CV found in the database.\n" unless $relationship_cv;
+    my $rel_cv_id = $relationship_cv->cv_id();
+
+    my $variable_of = $schema->resultset("Cv::Cvterm")->find({ name => 'VARIABLE_OF', cv_id => $rel_cv_id });
+    my $isa         = $schema->resultset("Cv::Cvterm")->find({ name => 'is_a',        cv_id => $rel_cv_id });
+    die "No 'is_a' relationship type found.\n" unless $isa;
+
+    my $type_id = $isa->cvterm_id();
+    if ($variable_of) {
+        my $has_variable_of = $schema->resultset("Cv::CvtermRelationship")->search({
+            subject_id => $cvterm_id,
+            type_id    => $variable_of->cvterm_id(),
+        })->count();
+        if ($has_variable_of > 0) {
+            $type_id = $variable_of->cvterm_id();
+        }
+    }
+
+    $schema->txn_do(sub {
+        for my $parent_id (@$parent_ids) {
+            $schema->resultset("Cv::CvtermRelationship")->find_or_create({
+                subject_id => $cvterm_id,
+                object_id  => $parent_id,
+                type_id    => $type_id,
+            });
+        }
+    });
+}
+
 __PACKAGE__->meta->make_immutable;
 
 ##########

--- a/lib/CXGN/Trait.pm
+++ b/lib/CXGN/Trait.pm
@@ -795,11 +795,11 @@ sub delete_existing_synonyms {
 
 sub interactive_store {
 	my $self = shift;
-    my $parent_term = shift;
+    my $parent_terms_json = shift;
 
     my $schema = $self->bcs_schema();
 
-	my $parent_id;
+	my @parent_ids;
 
     my $name = $self->name() || die "No name found.\n";
     my $definition = $self->definition() || die "No definition found.\n";
@@ -878,17 +878,20 @@ sub interactive_store {
 
 	my $db_name = $h->fetchrow_array();
 
-	if ($parent_term) {
-		my $lt = CXGN::List::Transform->new();
-    
-		my $transform = $lt->transform($schema, "traits_2_trait_ids", [$parent_term]);
+	my $parent_terms = [];
+	if ($parent_terms_json) {
+		$parent_terms = decode_json($parent_terms_json);
+	}
 
-		if (@{$transform->{missing}}>0) { 
-			die "Parent term $parent_term could not be found in the database.\n";
+	if (@$parent_terms) {
+		my $lt = CXGN::List::Transform->new();
+		my $transform = $lt->transform($schema, "traits_2_trait_ids", $parent_terms);
+
+		if (@{$transform->{missing}} > 0) {
+			die "Parent term(s) " . join(", ", @{$transform->{missing}}) . " could not be found in the database.\n";
 		}
 
-		my @parent_id_list = @{$transform->{transform}};
-		$parent_id = $parent_id_list[0];
+		@parent_ids = @{$transform->{transform}};
 	} else {
 		my $ontology_obj = CXGN::Onto->new({
 			schema => $schema
@@ -897,7 +900,7 @@ sub interactive_store {
 
 		my $root_term_name = $root_nodes[0]->[1] =~ s/\w+:\d+ //r;
 
-		$parent_id = $schema->resultset("Cv::Cvterm")->find({
+		push @parent_ids, $schema->resultset("Cv::Cvterm")->find({
 			name => $root_term_name,
 			cv_id => $root_nodes[0]->[0]
 		})->cvterm_id();
@@ -947,18 +950,20 @@ sub interactive_store {
 				dbxref => "$zeroes"."$accession_num"
 			})->cvterm_id();
 
-			if ($format eq "ontology") {
-				$schema->resultset("Cv::CvtermRelationship")->find_or_create({
-					object_id => $parent_id,
-					subject_id => $new_trait_id,
-					type_id => $isa_id
-				});
-			} else {
-				$schema->resultset("Cv::CvtermRelationship")->find_or_create({
-					object_id => $parent_id,
-					subject_id => $new_trait_id,
-					type_id => $variable_of_id
-				});
+			foreach my $pid (@parent_ids) {
+				if ($format eq "ontology") {
+					$schema->resultset("Cv::CvtermRelationship")->find_or_create({
+						object_id => $pid,
+						subject_id => $new_trait_id,
+						type_id => $isa_id
+					});
+				} else {
+					$schema->resultset("Cv::CvtermRelationship")->find_or_create({
+						object_id => $pid,
+						subject_id => $new_trait_id,
+						type_id => $variable_of_id
+					});
+				}
 			}
 
 			$new_trait = $schema->resultset("Cv::Cvterm")->find({

--- a/lib/CXGN/Trait/Treatment.pm
+++ b/lib/CXGN/Trait/Treatment.pm
@@ -42,20 +42,26 @@ sub BUILD {
 
 sub store {
     my $self = shift;
-    my $parent_term = shift;
+    my $parent_terms_json = shift;
 
     my $schema = $self->bcs_schema();
-    
-    my $lt = CXGN::List::Transform->new();
-    
-    my $transform = $lt->transform($schema, "traits_2_trait_ids", [$parent_term]);
 
-    if (@{$transform->{missing}}>0) { 
-	    die "Parent term $parent_term could not be found in the database.\n";
+    my $parent_terms = [];
+    if ($parent_terms_json) {
+        $parent_terms = decode_json($parent_terms_json);
+    }
+    if (!@$parent_terms) {
+        $parent_terms = ['Experimental treatment ontology|EXPERIMENT_TREATMENT:0000000'];
     }
 
-    my @parent_id_list = @{$transform->{transform}};
-    my $parent_id = $parent_id_list[0];
+    my $lt = CXGN::List::Transform->new();
+    my $transform = $lt->transform($schema, "traits_2_trait_ids", $parent_terms);
+
+    if (@{$transform->{missing}} > 0) {
+        die "Parent term(s) " . join(", ", @{$transform->{missing}}) . " could not be found in the database.\n";
+    }
+
+    my @parent_ids = @{$transform->{transform}};
 
     my $name = $self->name() || die "No name found.\n";
     my $definition = $self->definition() || die "No definition found.\n";
@@ -166,18 +172,20 @@ sub store {
                 dbxref => "$zeroes"."$accession_num"
             })->cvterm_id();
 
-            if ($format eq "ontology") {
-                $schema->resultset("Cv::CvtermRelationship")->find_or_create({
-                    object_id => $parent_id,
-                    subject_id => $new_treatment_id,
-                    type_id => $isa_id
-                });
-            } else {
-                $schema->resultset("Cv::CvtermRelationship")->find_or_create({
-                    object_id => $parent_id,
-                    subject_id => $new_treatment_id,
-                    type_id => $variable_of_id
-                });
+            foreach my $pid (@parent_ids) {
+                if ($format eq "ontology") {
+                    $schema->resultset("Cv::CvtermRelationship")->find_or_create({
+                        object_id => $pid,
+                        subject_id => $new_treatment_id,
+                        type_id => $isa_id
+                    });
+                } else {
+                    $schema->resultset("Cv::CvtermRelationship")->find_or_create({
+                        object_id => $pid,
+                        subject_id => $new_treatment_id,
+                        type_id => $variable_of_id
+                    });
+                }
             }
 
             $new_treatment = $schema->resultset("Cv::Cvterm")->find({

--- a/lib/SGN/Controller/AJAX/Cvterm.pm
+++ b/lib/SGN/Controller/AJAX/Cvterm.pm
@@ -22,6 +22,7 @@ use List::MoreUtils qw /any /;
 use Try::Tiny;
 use CXGN::Page::FormattingHelpers qw/ columnar_table_html commify_number /;
 use CXGN::Chado::Cvterm;
+use CXGN::Cvterm;
 use Data::Dumper;
 use JSON;
 
@@ -434,6 +435,210 @@ sub delete_cvtermprop_GET {
 	    return;
     }
     $c->stash->{rest} = { message => "The cvterm prop was removed from the database." };
+}
+
+sub add_synonym : Path('/ajax/cvterm/add_synonym') : ActionClass('REST') { }
+
+sub add_synonym_POST {
+    my ($self, $c) = @_;
+
+    if (!$c->user()) {
+        $c->stash->{rest} = { error => "You must be logged in to add synonyms." };
+        return;
+    }
+    if (!$c->user()->check_roles('curator')) {
+        $c->stash->{rest} = { error => "You must have curator privileges to add synonyms." };
+        return;
+    }
+
+    my $cvterm_id = $c->req->param('cvterm_id');
+    my $synonym   = $c->req->param('synonym');
+
+    $synonym =~ s/[^[:ascii:]]//g;
+    $synonym =~ s/\|//g;
+    $synonym =~ s/^\s+|\s+$//g;
+
+    if (!$synonym) {
+        $c->stash->{rest} = { error => "Synonym cannot be empty." };
+        return;
+    }
+
+    my $dbh = $c->dbc->dbh;
+
+    my $check_sth = $dbh->prepare("SELECT cvtermsynonym_id FROM cvtermsynonym WHERE synonym ilike ?");
+    $check_sth->execute($synonym);
+    my ($existing_id) = $check_sth->fetchrow_array();
+    if ($existing_id) {
+        $c->stash->{rest} = { error => "The synonym '$synonym' already exists in the database." };
+        return;
+    }
+
+    eval {
+        my $cvterm = CXGN::Chado::Cvterm->new($dbh, $cvterm_id);
+        $cvterm->add_synonym($synonym);
+    };
+    if ($@) {
+        $c->stash->{rest} = { error => "Error adding synonym: $@" };
+        return;
+    }
+
+    $c->stash->{rest} = { message => "Synonym '$synonym' added successfully." };
+}
+
+
+sub delete_synonym : Path('/ajax/cvterm/delete_synonym') : ActionClass('REST') { }
+
+sub delete_synonym_POST {
+    my ($self, $c) = @_;
+
+    if (!$c->user()) {
+        $c->stash->{rest} = { error => "You must be logged in to delete synonyms." };
+        return;
+    }
+    if (!$c->user()->check_roles('curator')) {
+        $c->stash->{rest} = { error => "You must have curator privileges to delete synonyms." };
+        return;
+    }
+
+    my $cvterm_id = $c->req->param('cvterm_id');
+    my $synonym   = $c->req->param('synonym');
+
+    if (!$synonym) {
+        $c->stash->{rest} = { error => "Synonym cannot be empty." };
+        return;
+    }
+
+    my $dbh = $c->dbc->dbh;
+
+    eval {
+        my $cvterm = CXGN::Chado::Cvterm->new($dbh, $cvterm_id);
+        $cvterm->delete_synonym($synonym);
+    };
+    if ($@) {
+        $c->stash->{rest} = { error => "Error deleting synonym: $@" };
+        return;
+    }
+
+    $c->stash->{rest} = { message => "Synonym '$synonym' deleted successfully." };
+}
+
+sub cvterm_relationships : Path('/ajax/cvterm/cvterm_relationships') : ActionClass('REST') { }
+
+sub cvterm_relationships_GET {
+    my ($self, $c) = @_;
+
+    my $cvterm_id = $c->req->param('cvterm_id');
+    if (!$cvterm_id) {
+        $c->stash->{rest} = { error => "cvterm_id is required." };
+        return;
+    }
+
+    my $sth = $c->dbc->dbh->prepare(
+        "SELECT type.name AS relationship_name,
+                object.cvterm_id AS object_cvterm_id,
+                object.name AS object_name
+         FROM cvterm_relationship
+         JOIN cvterm AS type   ON (type.cvterm_id   = cvterm_relationship.type_id)
+         JOIN cvterm AS object ON (object.cvterm_id = cvterm_relationship.object_id)
+         WHERE subject_id = ?"
+    );
+
+    my @relationships;
+    eval {
+        $sth->execute($cvterm_id);
+        while (my ($rel_name, $obj_id, $obj_name) = $sth->fetchrow_array()) {
+            push @relationships, {
+                relationship_name => $rel_name,
+                object_cvterm_id  => $obj_id,
+                object_name       => $obj_name,
+            };
+        }
+    };
+    if ($@) {
+        $c->stash->{rest} = { error => "Error retrieving relationships: $@" };
+        return;
+    }
+
+    $c->stash->{rest} = { relationships => \@relationships };
+}
+
+sub add_parent_terms : Path('/ajax/cvterm/add_parent_terms') : ActionClass('REST') { }
+
+sub add_parent_terms_POST {
+    my ($self, $c) = @_;
+
+    if (!$c->user()) {
+        $c->stash->{rest} = { error => "You must be logged in to add parent terms." };
+        return;
+    }
+    if (!$c->user()->check_roles('curator')) {
+        $c->stash->{rest} = { error => "You must have curator privileges to add parent terms." };
+        return;
+    }
+
+    my $cvterm_id         = $c->req->param('cvterm_id');
+    my $parent_terms_json = $c->req->param('parent_terms');
+
+    my $parent_terms;
+    eval { $parent_terms = decode_json($parent_terms_json); };
+    if ($@ || ref($parent_terms) ne 'ARRAY') {
+        $c->stash->{rest} = { error => "Invalid parent_terms parameter." };
+        return;
+    }
+
+    my $schema = $c->dbic_schema('Bio::Chado::Schema', 'sgn_chado');
+
+    my @parent_ids;
+    for my $term_str (@$parent_terms) {
+        my ($name, $accession_str) = split(/\|/, $term_str, 2);
+        unless (defined $accession_str) {
+            $c->stash->{rest} = { error => "Could not parse parent term '$term_str'. Expected format: name|DB:accession." };
+            return;
+        }
+        my ($db_name_part, $accession) = split(/:/, $accession_str, 2);
+        unless (defined $db_name_part && defined $accession) {
+            $c->stash->{rest} = { error => "Could not parse accession from '$accession_str'." };
+            return;
+        }
+
+        my $dbxref = $schema->resultset("General::Dbxref")->find(
+            {
+                'db.name'      => $db_name_part,
+                'me.accession' => $accession,
+            },
+            { join => 'db' }
+        );
+        unless ($dbxref && $dbxref->cvterm) {
+            $c->stash->{rest} = { error => "Parent term '$term_str' not found in the database." };
+            return;
+        }
+
+        my $parent_cvterm_id = $dbxref->cvterm->cvterm_id;
+
+        my $existing = $schema->resultset("Cv::CvtermRelationship")->find({
+            subject_id => $cvterm_id,
+            object_id  => $parent_cvterm_id,
+        });
+        next if $existing;
+
+        push @parent_ids, $parent_cvterm_id;
+    }
+
+    if (!@parent_ids) {
+        $c->stash->{rest} = { error => "All specified parent terms are already parents of this cvterm." };
+        return;
+    }
+
+    eval {
+        my $cvterm_obj = CXGN::Cvterm->new({ schema => $schema, cvterm_id => $cvterm_id });
+        $cvterm_obj->add_parent_terms(\@parent_ids);
+    };
+    if ($@) {
+        $c->stash->{rest} = { error => "Error adding parent terms: $@" };
+        return;
+    }
+
+    $c->stash->{rest} = { message => scalar(@parent_ids) . " parent term(s) added successfully." };
 }
 
 ####

--- a/lib/SGN/Controller/AJAX/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Trait.pm
@@ -40,11 +40,12 @@ sub create_trait :Path('/ajax/trait/create') {
     my $categories = $c->req->param('categories') ? $c->req->param('categories') : undef;
     my $category_details = $c->req->param('category_details') ? $c->req->param('category_details') : undef;
     my $repeat_type = $c->req->param('repeat_type') ? $c->req->param('repeat_type') : undef;
-    my $parent_term = $c->req->param('parent_term') ? $c->req->param('parent_term') : undef;
+    my $parent_terms = $c->req->param('parent_terms') ? $c->req->param('parent_terms') : undef;
 
     $name =~ s/^\s+//;
     $name =~ s/\s+$//;
     $name =~ s/[^[:ascii:]]//g;
+    $name =~ s/\|//g;
 
     $definition =~ s/^\s+//;
     $definition =~ s/\s+$//;
@@ -139,7 +140,7 @@ sub create_trait :Path('/ajax/trait/create') {
             $new_trait->default_value($default_value);
         }
 
-        $new_trait->interactive_store($parent_term);
+        $new_trait->interactive_store($parent_terms);
     };
 
     if ($@) {

--- a/lib/SGN/Controller/AJAX/Treatment.pm
+++ b/lib/SGN/Controller/AJAX/Treatment.pm
@@ -40,11 +40,12 @@ sub create_treatment :Path('/ajax/treatment/create') {
     my $categories = $c->req->param('categories') ? $c->req->param('categories') : undef;
     my $category_details = $c->req->param('category_details') ? $c->req->param('category_details') : undef;
     my $repeat_type = $c->req->param('repeat_type') ? $c->req->param('repeat_type') : undef;
-    my $parent_term = $c->req->param('parent_term') || 'Experimental treatment ontology|EXPERIMENT_TREATMENT:0000000';
+    my $parent_terms = $c->req->param('parent_terms') ? $c->req->param('parent_terms') : undef;
 
     $name =~ s/^\s+//;
     $name =~ s/\s+$//;
     $name =~ s/[^[:ascii:]]//g;
+    $name =~ s/\|//g;
 
     $definition =~ s/^\s+//;
     $definition =~ s/\s+$//;
@@ -138,7 +139,7 @@ sub create_treatment :Path('/ajax/treatment/create') {
             $new_treatment->default_value($default_value);
         }
 
-        $new_treatment->store($parent_term);
+        $new_treatment->store($parent_terms);
     };
 
     if ($@) {

--- a/mason/chado/cvterm.mas
+++ b/mason/chado/cvterm.mas
@@ -115,7 +115,7 @@ my $edit_privs = $curator ;
 </%perl>
 
 
-<& /util/import_javascript.mas, classes => [qw [CXGN.AJAX.Ontology  CXGN.Phenome.Qtl thickbox jquery  jquery.dataTables] ] &>
+<& /util/import_javascript.mas, classes => [qw [CXGN.AJAX.Ontology  CXGN.Phenome.Qtl thickbox jquery  jquery.dataTables jqueryui] ] &>
 
 
 <script language="javascript">
@@ -134,6 +134,17 @@ my $edit_privs = $curator ;
 
   function displayCvtermEditDialog() {
     jQuery('#edit_cvterm').modal('show');
+  }
+
+  function displaySynonymEditDialog() {
+    jQuery('#edit_synonym').modal('show');
+  }
+
+  function displayAddParentTermsDialog() {
+    jQuery('#new_parent_terms_list').empty();
+    jQuery('#new_parent_term_input').val('');
+    jQuery('#remove_parent_term_btn').hide();
+    jQuery('#edit_parents').modal('show');
   }
 
   function deleteCvterm() {
@@ -201,10 +212,214 @@ my $edit_privs = $curator ;
     </div>
 </div>
 
+<div class="modal fade" id="edit_synonym" name="edit_synonym" tabindex="-1" role="dialog" aria-labelledby="editSynonymDialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header" style="text-align: center">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="editSynonymDialog">Edit Synonyms</h4>
+            </div>
+            <div class="modal-body">
+                <div id="synonym_list">
+% foreach my $synonym (@synonyms) {
+                <div class="form-group">
+                    <span><% $synonym | h %></span>
+                    &nbsp;
+                    <button type="button" class="btn btn-danger btn-sm delete_synonym_btn" data-synonym="<% $synonym | h %>"><span class="glyphicon glyphicon-trash"></span></button>
+                </div>
+% }
+                </div>
+                <hr/>
+                <div class="form-inline">
+                    <input type="text" id="new_synonym_input" class="form-control" placeholder="New synonym"/>
+                    &nbsp;
+                    <button type="button" id="add_synonym_btn" class="btn btn-primary">Add Synonym</button>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="edit_parents" name="edit_parents" tabindex="-1" role="dialog" aria-labelledby="editParentsDialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header" style="text-align: center">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="editParentsDialog">Add Parent Terms</h4>
+            </div>
+            <div class="modal-body">
+                <div class="container-fluid">
+                    <div class="form-group">
+                        <label>Parent term:</label>
+                        <div class="input-group">
+                            <input class="form-control" id="new_parent_term_input" type="text" placeholder="Start typing a term name..."/>
+                            <span class="input-group-btn">
+                                <button id="add_parent_term_btn" class="btn btn-success">+</button>
+                            </span>
+                        </div>
+                        <ul id="new_parent_terms_list" style="text-align:left; padding-left:1em; list-style-type:disc; margin-top:0.5em;"></ul>
+                        <button id="remove_parent_term_btn" class="btn btn-sm btn-danger" style="display:none;"><span class="glyphicon glyphicon-trash"></span> Remove last</button>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" id="add_parent_terms_submit_btn">Submit</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+  jQuery(document).ready(function () {
+
+    jQuery('#edit_synonym').on('click', '.delete_synonym_btn', function() {
+      var synonym = jQuery(this).data('synonym');
+      jQuery('#working_modal').modal('show');
+      jQuery.ajax({
+        url: '/ajax/cvterm/delete_synonym',
+        method: 'POST',
+        data: {
+          cvterm_id : <% $cvterm_id %>,
+          synonym   : synonym
+        },
+        success: function(response) {
+          jQuery('#working_modal').modal('hide');
+          if (response.error) {
+            alert(response.error);
+          } else {
+            alert(response.message);
+            window.location.reload();
+          }
+        },
+        error: function() {
+          jQuery('#working_modal').modal('hide');
+          alert("An error occurred deleting the synonym.");
+        }
+      });
+    });
+
+    jQuery('#add_synonym_btn').click(function() {
+      var synonym = jQuery('#new_synonym_input').val();
+      if (!synonym) {
+        alert("Please enter a synonym.");
+        return;
+      }
+      jQuery('#working_modal').modal('show');
+      jQuery.ajax({
+        url: '/ajax/cvterm/add_synonym',
+        method: 'POST',
+        data: {
+          cvterm_id : <% $cvterm_id %>,
+          synonym   : synonym
+        },
+        success: function(response) {
+          jQuery('#working_modal').modal('hide');
+          if (response.error) {
+            alert(response.error);
+          } else {
+            alert(response.message);
+            window.location.reload();
+          }
+        },
+        error: function() {
+          jQuery('#working_modal').modal('hide');
+          alert("An error occurred adding the synonym.");
+        }
+      });
+    });
+
+    jQuery('#new_parent_term_input').autocomplete({
+      source: '/ajax/cvterm/autocompleteslim' + "?db_name=<% $db_name %>",
+      appendTo: 'body'
+    }).autocomplete('widget').css('z-index', 9999);
+
+    jQuery('#add_parent_term_btn').on('click', function(e) {
+      e.preventDefault();
+      var term = jQuery('#new_parent_term_input').val().trim();
+      if (term) {
+        jQuery('<li>').text(term).appendTo('#new_parent_terms_list');
+        jQuery('#remove_parent_term_btn').show();
+        jQuery('#new_parent_term_input').val('');
+      }
+    });
+
+    jQuery('#remove_parent_term_btn').on('click', function(e) {
+      e.preventDefault();
+      jQuery('#new_parent_terms_list li:last').remove();
+      if (jQuery('#new_parent_terms_list li').length === 0) {
+        jQuery('#remove_parent_term_btn').hide();
+      }
+    });
+
+    jQuery('#add_parent_terms_submit_btn').click(function() {
+      var parent_terms = [];
+      jQuery('#new_parent_terms_list li').each(function() {
+        parent_terms.push(jQuery(this).text());
+      });
+      if (parent_terms.length === 0) {
+        alert("Please add at least one parent term.");
+        return;
+      }
+      jQuery('#working_modal').modal('show');
+      jQuery.ajax({
+        url: '/ajax/cvterm/add_parent_terms',
+        method: 'POST',
+        data: {
+          cvterm_id: <% $cvterm_id %>,
+          parent_terms: JSON.stringify(parent_terms)
+        },
+        success: function(response) {
+          jQuery('#working_modal').modal('hide');
+          if (response.error) {
+            alert(response.error);
+          } else {
+            alert(response.message);
+            window.location.reload();
+          }
+        },
+        error: function() {
+          jQuery('#working_modal').modal('hide');
+          alert("An error occurred adding parent terms.");
+        }
+      });
+    });
+
+    jQuery.ajax({
+      url: '/ajax/cvterm/cvterm_relationships',
+      method: 'GET',
+      data: { cvterm_id: <% $cvterm_id %> },
+      success: function(response) {
+        if (response.error) {
+          jQuery('#relationships_div').html(response.error);
+          return;
+        }
+        var rels = response.relationships;
+        if (!rels || rels.length === 0) {
+          jQuery('#relationships_div').html('None');
+          return;
+        }
+        var html = '';
+        jQuery.each(rels, function(i, r) {
+          html += r.relationship_name + ' <a href="/cvterm/' + r.object_cvterm_id + '/view">' + r.object_name + '</a><br />';
+        });
+        jQuery('#relationships_div').html(html);
+      },
+      error: function() {
+        jQuery('#relationships_div').html('Error loading relationships.');
+      }
+    });
+
+  });
+</script>
+
 <&| /page/info_section.mas, title=>"Cvterm details" &>
 <table style="border-spacing:10px">
-% if ( $allow_edits ) {
-<tr><td colspan="2"><a href="javascript:displayCvtermEditDialog()" id="edit_cvterm_link">[Edit] <a href="javascript:deleteCvterm()" id="delete_cvterm_link" style="color:red;">[Delete]</a></td><td></td><td></td></tr>
+% if ( $allow_edits && $edit_privs ) {
+<tr><td colspan="2"><a href="javascript:displayCvtermEditDialog()" id="edit_cvterm_link">[Edit]</a> <a href="javascript:deleteCvterm()" id="delete_cvterm_link" style="color:red;">[Delete]</a></td><td></td><td></td></tr>
 % }
 <tr><td>Term id</td><td width="10px">&nbsp;</td><td><b><% $accession %></b></td></tr>
 <tr><td>Term name</td><td>&nbsp;</td><td><b><% $cvterm_name %></b></td></tr>
@@ -216,10 +431,23 @@ my $edit_privs = $curator ;
 <b>Obsolete:</b> TRUE <br />
 % }
 
-<br /><b>Synonyms</b><br />
+<br />
+% if ( $allow_edits && $edit_privs ) {
+<a href="javascript:displaySynonymEditDialog()" id="edit_synonym_link">[Edit]</a>
+<br>
+% }
+<b>Synonyms</b><br />
 % foreach my $synonym (@synonyms) {
 <% $synonym %> <br />
 % }
+
+<br />
+% if ( $allow_edits && $edit_privs ) {
+<a href="javascript:displayAddParentTermsDialog()" id="add_parent_terms_link">[Add parent terms]</a>
+<br>
+% }
+<b> Relationships</b><br />
+<div id="relationships_div"></div>
 
 <br /><b> Definition dbxrefs</b><br />
 % foreach my $da (@def_accessions) {

--- a/mason/tools/trait_designer.mas
+++ b/mason/tools/trait_designer.mas
@@ -15,7 +15,7 @@
         <div class="form-group">
                 <label class="col-sm-3 control-label"> New trait name: </label>
                 <div class="col-sm-9">
-                    <input style="width:70%;" class="form-control" id="new_trait_name" name="new_trait_name" type="text" placeholder="ASCII characters only. Non-ASCII characters will be removed."/>
+                    <input style="width:70%;" class="form-control" id="new_trait_name" name="new_trait_name" type="text" placeholder="ASCII characters only. Non-ASCII characters and pipes (|) will be removed."/>
                 </div>
             </div>
             <div class="form-group">
@@ -84,9 +84,16 @@
             </div>
             <div class="form-group" id="chain_parent_term_container">
                 <label class="col-sm-3 control-label" id="chain_parent_term"><span class="glyphicon glyphicon-question-sign" style="color:blue;font-size:18px" title="Should not be a variable term.
-Will be the trait root term by default."></span>&nbsp;Chain to an existing term:</label>
+Will be the trait root term by default if none are added."></span>&nbsp;Chain to existing term(s):</label>
                 <div class="col-sm-9">
-                    <input style="width:70%;" class="form-control" id="new_trait_parent_term" name="new_trait_parent_term" type="text" placeholder="Full name, as in 'CGIAR cassava trait ontology|CO_334:0000000'"/>
+                    <table style="width:70%;">
+                        <tr>
+                            <td><input class="form-control" id="new_trait_parent_term" name="new_trait_parent_term" type="text" placeholder="Full name, as in 'CGIAR cassava trait ontology|CO_334:0000000'"/></td>
+                            <td><button id="new_trait_add_parent_btn" class="btn btn-small btn-success">+</button></td>
+                        </tr>
+                    </table>
+                    <ul id="new_trait_parents" style="text-align:left;width:70%;padding-left:1em;list-style-type:disc;"></ul>
+                    <button id="new_trait_remove_parent_btn" class="btn btn-small btn-danger" style="display:none;float:left;"><span class="glyphicon glyphicon-trash"></span></button>
                 </div>
             </div>
         </form>
@@ -123,7 +130,11 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
             });
             categories = cat_list.join('/');
             let category_details = cat_details_list.join('/');
-            let parent_term = jQuery('#new_trait_parent_term').val();
+            let parent_terms = [];
+            jQuery('#new_trait_parents li').each(function() {
+                parent_terms.push(jQuery(this).text());
+            });
+            let parent_terms_json = JSON.stringify(parent_terms);
 
             jQuery.ajax({
                 url: '/ajax/trait/create',
@@ -136,7 +147,7 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
                     maximum : maximum,
                     categories : categories,
                     category_details : category_details,
-                    parent_term : parent_term,
+                    parent_terms : parent_terms_json,
                     repeat_type : repeat_type
                 },
                 success: function(response) {
@@ -158,6 +169,24 @@ Will be the trait root term by default."></span>&nbsp;Chain to an existing term:
 
         jQuery('#new_trait_parent_term').autocomplete({
             source : '/ajax/cvterm/autocompleteslim' + "?db_name=<% $db_name %>"
+        });
+
+        jQuery('#new_trait_add_parent_btn').on('click', function(e) {
+            e.preventDefault();
+            let parent_term = jQuery('#new_trait_parent_term').val().trim();
+            if (parent_term) {
+                jQuery('<li>').text(parent_term).appendTo('#new_trait_parents');
+                jQuery('#new_trait_remove_parent_btn').show();
+                jQuery('#new_trait_parent_term').val('');
+            }
+        });
+
+        jQuery('#new_trait_remove_parent_btn').on('click', function(e) {
+            e.preventDefault();
+            jQuery('#new_trait_parents li:last').remove();
+            if (jQuery('#new_trait_parents li').length === 0) {
+                jQuery('#new_trait_remove_parent_btn').hide();
+            }
         });
 
         jQuery('#new_trait_format_select').on('change', function () {

--- a/mason/tools/treatment_designer.mas
+++ b/mason/tools/treatment_designer.mas
@@ -16,7 +16,7 @@
         <div class="form-group">
                 <label class="col-sm-3 control-label"> New treatment name: </label>
                 <div class="col-sm-9">
-                    <input style="width:70%;" class="form-control" id="new_treatment_name" name="new_treatment_name" type="text" placeholder="ASCII characters only. Non-ASCII characters will be removed."/>
+                    <input style="width:70%;" class="form-control" id="new_treatment_name" name="new_treatment_name" type="text" placeholder="ASCII characters only. Non-ASCII characters and pipes (|)  will be removed."/>
                 </div>
             </div>
             <div class="form-group">
@@ -84,10 +84,17 @@
                 </div>
             </div>
             <div class="form-group" id="chain_parent_term_container">
-                <label class="col-sm-3 control-label" id="chain_parent_term"><span class="glyphicon glyphicon-question-sign" style="color:blue;font-size:18px" title="Should not be a variable term. 
-Will be the treatment root term by default."></span>&nbsp;Chain to an existing term:</label>
+                <label class="col-sm-3 control-label" id="chain_parent_term"><span class="glyphicon glyphicon-question-sign" style="color:blue;font-size:18px" title="Should not be a variable term.
+Will be the treatment root term by default if none are added."></span>&nbsp;Chain to existing term(s):</label>
                 <div class="col-sm-9">
-                    <input style="width:70%;" class="form-control" id="new_treatment_parent_term" name="new_treatment_parent_term" type="text" placeholder="Full name, as in 'Legacy experiment treatment|EXPERIMENT_TREATMENT:0000001'"/>
+                    <table style="width:70%;">
+                        <tr>
+                            <td><input class="form-control" id="new_treatment_parent_term" name="new_treatment_parent_term" type="text" placeholder="Full name, as in 'Legacy experiment treatment|EXPERIMENT_TREATMENT:0000001'"/></td>
+                            <td><button id="new_treatment_add_parent_btn" class="btn btn-small btn-success">+</button></td>
+                        </tr>
+                    </table>
+                    <ul id="new_treatment_parents" style="text-align:left;width:70%;padding-left:1em;list-style-type:disc;"></ul>
+                    <button id="new_treatment_remove_parent_btn" class="btn btn-small btn-danger" style="display:none;float:left;"><span class="glyphicon glyphicon-trash"></span></button>
                 </div>
             </div>
         </form>
@@ -123,7 +130,11 @@ Will be the treatment root term by default."></span>&nbsp;Chain to an existing t
             });
             categories = cat_list.join('/');
             let category_details = cat_details_list.join('/');
-            let parent_term = jQuery('#new_treatment_parent_term').val();
+            let parent_terms = [];
+            jQuery('#new_treatment_parents li').each(function() {
+                parent_terms.push(jQuery(this).text());
+            });
+            let parent_terms_json = JSON.stringify(parent_terms);
 
             jQuery.ajax({
                 url: '/ajax/treatment/create',
@@ -136,7 +147,7 @@ Will be the treatment root term by default."></span>&nbsp;Chain to an existing t
                     maximum : maximum,
                     categories : categories,
                     category_details : category_details,
-                    parent_term : parent_term,
+                    parent_terms : parent_terms_json,
                     repeat_type : repeat_type
                 },
                 success: function(response) { 
@@ -158,6 +169,24 @@ Will be the treatment root term by default."></span>&nbsp;Chain to an existing t
 
         jQuery('#new_treatment_parent_term').autocomplete({
             source : '/ajax/cvterm/autocompleteslim' + "?db_name=<% $db_name %>"
+        });
+
+        jQuery('#new_treatment_add_parent_btn').on('click', function(e) {
+            e.preventDefault();
+            let parent_term = jQuery('#new_treatment_parent_term').val().trim();
+            if (parent_term) {
+                jQuery('<li>').text(parent_term).appendTo('#new_treatment_parents');
+                jQuery('#new_treatment_remove_parent_btn').show();
+                jQuery('#new_treatment_parent_term').val('');
+            }
+        });
+
+        jQuery('#new_treatment_remove_parent_btn').on('click', function(e) {
+            e.preventDefault();
+            jQuery('#new_treatment_parents li:last').remove();
+            if (jQuery('#new_treatment_parents li').length === 0) {
+                jQuery('#new_treatment_remove_parent_btn').hide();
+            }
         });
 
         jQuery('#new_treatment_format_select').on('change', function () {

--- a/t/unit_fixture/CXGN/Trial/TrialCreate.t
+++ b/t/unit_fixture/CXGN/Trial/TrialCreate.t
@@ -603,7 +603,7 @@ ok(my $test_treatment = CXGN::Trait::Treatment->new({
     format => 'numeric'
 }), 'create a test treatment');
 
-my $exp_treatment_root_term = 'Experimental treatment ontology|EXPERIMENT_TREATMENT:0000000';
+my $exp_treatment_root_term = encode_json(['Experimental treatment ontology|EXPERIMENT_TREATMENT:0000000']);
 
 ok($test_treatment->store($exp_treatment_root_term), 'store test treatment');
 

--- a/t/unit_fixture/CXGN/Uploading/TrialUpload.t
+++ b/t/unit_fixture/CXGN/Uploading/TrialUpload.t
@@ -1248,7 +1248,7 @@ for my $extension ("xls", "xlsx", "csv") {
 		format => 'numeric'
 	}), 'create a test treatment');
 
-	my $exp_treatment_root_term = 'Experimental treatment ontology|EXPERIMENT_TREATMENT:0000000';
+	my $exp_treatment_root_term = encode_json(['Experimental treatment ontology|EXPERIMENT_TREATMENT:0000000']);
 
 	ok(my $test_treatment_row = $test_treatment->store($exp_treatment_root_term), 'store test treatment');
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Adds the ability to add or delete synonyms from the cvterm detail page. Also adds ability to see cvterm relationships and add parent terms from cvterm detail page. 

<!-- If there are relevant issues, link them here: -->
Closes #6159 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
