### PR TITLE
Label Designer: sort labels by trial layout from list of plots

### DIFF
--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -19,6 +19,7 @@ use CXGN::Trial::TrialLayoutDownload;
 use CXGN::Cross;
 use SGN::Model::Cvterm;
 use Sort::Naturally;
+use CXGN::BreederSearch;
 
 BEGIN { extends 'Catalyst::Controller::REST' }
 
@@ -457,11 +458,36 @@ __PACKAGE__->config(
             }
             elsif ( $data_type eq 'Lists' ) {
                 my $list = CXGN::List->new({ dbh => $schema->storage->dbh(), list_id => $source_id });
+                my $list_type = $list->type();
                 my $list_elements = $list->retrieve_elements_with_ids($source_id);
-                my @trial_names = map { $_->[1] } @$list_elements;
-                my $lt = CXGN::List::Transform->new();
-                my $tr = $lt->transform($schema, "projects_2_project_ids", \@trial_names);
-                @trial_ids = @{$tr->{transform}};
+
+                if ( $list_type eq 'trials' ) {
+                    my @trial_names = map { $_->[1] } @$list_elements;
+                    my $lt = CXGN::List::Transform->new();
+                    my $tr = $lt->transform($schema, "projects_2_project_ids", \@trial_names);
+                    @trial_ids = @{$tr->{transform}};
+                }
+                elsif ( $list_type eq 'plots' ) {
+                    my @plot_names = map { $_->[1] } @$list_elements;
+                    my $lt = CXGN::List::Transform->new();
+                    my $tr = $lt->transform($schema, "stocks_2_stock_ids", \@plot_names);
+                    my @plot_ids = @{$tr->{transform}};
+
+                    my $bs = CXGN::BreederSearch->new({ dbh => $schema->storage->dbh() });
+                    my $criteria_list = [ 'plots', 'trials' ];
+                    my $dataref = {
+                        'trials' => {
+                            'plots' => join(', ', map { qq\'$_'\ } @plot_ids)
+                        }
+                    };
+                    my $queryref = {
+                        'trials' => {
+                            'plots' => 0
+                        }
+                    };
+                    my $results_ref = $bs->metadata_query($criteria_list, $dataref, $queryref);
+                    @trial_ids = map { $_->[0] } @{$results_ref->{results}};
+                }
             }
 
             # Get the sorted plots, individually by trial

--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -456,7 +456,7 @@ __PACKAGE__->config(
             if ( $data_type eq 'Field Trials' ) {
                 push(@trial_ids, $source_id);
             }
-            elsif ( $data_type eq 'Lists' ) {
+            elsif ( $data_type eq 'Lists' || $data_type eq 'Public Lists' ) {
                 my $list = CXGN::List->new({ dbh => $schema->storage->dbh(), list_id => $source_id });
                 my $list_type = $list->type();
                 my $list_elements = $list->retrieve_elements_with_ids($source_id);


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This fixes a bug in the Label Designer for sorting a list of plots by the Trial Layout: Plot Order option.

It now handles the trials and plots list types separately.  If the the list is a list of plots, it finds the trials those plots are from.

Fixes #6173 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
