### PR TITLE
download: remove redundant branch and use intended value for genotyping project name

### DIFF
--- a/lib/CXGN/Trial/TrialLayoutDownload/GenotypingPlateLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/GenotypingPlateLayout.pm
@@ -102,11 +102,7 @@ sub retrieve {
                 } elsif ($_ eq 'pedigree'){
                     push @$line, $pedigree_strings->{$design_info->{"accession_name"}};
                 } elsif ($_ eq 'genotyping_project_name'){
-                    my $accession = CXGN::Stock->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-                    push @$line, $accession->get_pedigree_string('Parents');
-                } elsif ($_ eq 'pedigree'){
-                    my $accession = CXGN::Stock->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-                    push @$line, $accession->get_pedigree_string('Parents');
+                    push @$line, $genotyping_project_name;
                 }else {
                     push @$line, $design_info->{$_};
                 }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

There was a redundant, unreachable branch for the "pedigree" column in GenotypingPlateLayout.pm. Judging from the git history, the first reachable "pedigree" branch is the intended, faster method. I removed the older, unreachable branch.

Also updated the genotyping project name branch to use the $genotyping_project_name variable already defined further up in the function. This was unused and likely the intended value for this column.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [x] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
