### PR TITLE
Bot CAPTCHA

### DIFF
--- a/conf/captcha.docker-compose.yml
+++ b/conf/captcha.docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  cap:
+    depends_on:
+      valkey:
+        condition: service_healthy
+    image: tiago2/cap:3.1.5
+    container_name: cap
+    ports:
+      - "3000:3000"
+    environment:
+      ADMIN_KEY: change_admin_password
+      REDIS_URL: redis://valkey:6379
+    restart: unless-stopped
+
+  valkey:
+    image: valkey/valkey:9-alpine
+    container_name: cap-valkey
+    volumes:
+      - valkey-data:/data
+    command: valkey-server --save 60 1 --loglevel warning --maxmemory-policy noeviction
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  valkey-data:

--- a/lib/SGN.pm
+++ b/lib/SGN.pm
@@ -41,6 +41,7 @@ use Catalyst qw/
      SmartURI
      Authentication
      +SGN::Authentication::Store
+     +SGN::Authentication::Captcha
      Authorization::Roles
      +SGN::Role::Site::Config
      +SGN::Role::Site::DBConnector

--- a/lib/SGN/Authentication/Captcha.pm
+++ b/lib/SGN/Authentication/Captcha.pm
@@ -1,0 +1,75 @@
+package SGN::Authentication::Captcha;
+
+=head1 NAME
+
+SGN::Authentication::Captcha - when enabled in the configuration, check all requests to HTML pages for a proper verification token cookie
+
+=head1 DESCRIPTION
+
+To enable this feature, the captcha settings (server, client_id, client_secret, signing_key) must be defined in the sgn config.
+
+This Catalyst plugin will intercept all requests that return an HTML response and check for a valid signed captcha token in the request's cookies.
+
+If the token is not found or not valid, the request will be redirected to the /captcha page where a captcha routine will be initiated.  If the 
+captcha routine passes, the captcha token will be set and signed and the user will be redirected back to the originally requested page.
+
+This is designed to use the Cap self-hosted Captcha server (https://trycap.dev/).  An example docker-compose.yml file to run the server can be 
+found at ./conf/captcha.docker-compose.yml in this repo.
+
+Author: David Waring <djw64@cornell.edu>
+
+=cut
+
+use Moose::Role;
+use URI::FromHash 'uri';
+use Digest::SHA qw(hmac_sha256_base64);
+use Data::Dumper;
+
+around 'finalize' => sub {
+    my ($orig, $c, @args) = @_;
+    my $path = $c->req->path;
+    my $content_type = $c->res->content_type;
+
+    # Verify access to HTML pages (except the /captcha page itself)
+    if ( $content_type eq 'text/html' && $path ne 'captcha' ) {
+
+        # Get the captcha config
+        my $config = $c->config->{'captcha'};
+
+        # Check for captcha token, only if the settings are enabled
+        if ( defined $config && defined $config->{server} && defined $config->{client_id} && defined $config->{client_secret} && defined $config->{signing_key} ) {
+            my $cookies = $c->req->cookies;
+            my $cookie = $cookies->{'captcha-token'};
+            my $cookie_value = $cookie ? $cookie->value : undef;
+
+            # If cookie is not provided, redirect to captcha page
+            if ( !defined $cookie_value || $cookie_value eq '' ) {
+                $c->res->redirect( uri( path => '/captcha', query => { goto_url => $c->req->uri->path_query } ) );
+            }
+
+            # If the cookie is provided, verify its signature
+            else {
+
+                # Get the token and signature from the cookie
+                my @parts = split(':', $cookie_value);
+                my $c_token = join(':', @parts[0..2]);
+                my $c_signature = $parts[3];
+
+                # Get the true signature to comapre to the one in the cookie
+                my $t_signature = hmac_sha256_base64($c_token, $config->{signing_key});
+
+                # cookie signature check fails, redirect to captcha page
+                if ( !defined $c_signature || !defined $t_signature || $c_signature ne $t_signature ) {
+                    $c->res->redirect( uri( path => '/captcha', query => { goto_url => $c->req->uri->path_query } ) );
+                }
+
+            }
+        }
+
+    }
+
+    my $rtn = $orig->($c, @args);
+    return $rtn;
+};
+
+1;

--- a/lib/SGN/Authentication/Captcha.pm
+++ b/lib/SGN/Authentication/Captcha.pm
@@ -41,26 +41,33 @@ around 'finalize' => sub {
             my $cookies = $c->req->cookies;
             my $cookie = $cookies->{'captcha-token'};
             my $cookie_value = $cookie ? $cookie->value : undef;
+            my $query_value = $c->req->param('captcha-token');
+            my $check_value = $query_value || $cookie_value;
 
-            # If cookie is not provided, redirect to captcha page
-            if ( !defined $cookie_value || $cookie_value eq '' ) {
+            # If token is not provided, redirect to captcha page
+            if ( !defined $check_value || $check_value eq '' ) {
                 $c->res->redirect( uri( path => '/captcha', query => { goto_url => $c->req->uri->path_query } ) );
             }
 
-            # If the cookie is provided, verify its signature
+            # If the token is provided, verify its signature
             else {
 
-                # Get the token and signature from the cookie
-                my @parts = split(':', $cookie_value);
+                # Get the token and signature from the value
+                my @parts = split(':', $check_value);
                 my $c_token = join(':', @parts[0..2]);
                 my $c_signature = $parts[3];
 
-                # Get the true signature to comapre to the one in the cookie
+                # Get the true signature to compare to the one in the value
                 my $t_signature = hmac_sha256_base64($c_token, $config->{signing_key});
 
-                # cookie signature check fails, redirect to captcha page
+                # value signature check fails, redirect to captcha page
                 if ( !defined $c_signature || !defined $t_signature || $c_signature ne $t_signature ) {
                     $c->res->redirect( uri( path => '/captcha', query => { goto_url => $c->req->uri->path_query } ) );
+                }
+
+                # If the token is sent as a query param, save it as a cookie for future requests
+                if ( defined $query_value ) {
+                    CXGN::Cookie::set_cookie('captcha-token', $query_value);
                 }
 
             }

--- a/lib/SGN/Controller/AJAX/Captcha.pm
+++ b/lib/SGN/Controller/AJAX/Captcha.pm
@@ -1,0 +1,65 @@
+
+package SGN::Controller::AJAX::Captcha;
+
+use Data::Dumper;
+use Moose;
+use LWP::UserAgent;
+use HTTP::Request;
+use JSON;
+use Digest::SHA qw(hmac_sha256_base64);
+
+BEGIN { extends 'Catalyst::Controller::REST'; }
+
+__PACKAGE__->config(
+    default   => 'application/json',
+    stash_key => 'rest',
+    map       => { 'application/json' => 'JSON', 'text/html' => 'JSON' },
+);
+
+#
+# Verify a Captcha Token
+# - Check if the provided token is valid with the captcha server
+# - If the token is valid, sign it and return it in a cookie
+# The cookie will be used to verify future requests
+#
+sub captcha : Path("/ajax/captcha") Args(0) {
+    my $self = shift;
+    my $c = shift;
+    my $token = $c->req->param("token");
+    my $config = $c->config->{captcha};
+    my $ua = LWP::UserAgent->new;
+
+    # Reset the cookie
+    CXGN::Cookie::set_cookie('captcha-token', "");
+
+    # Check the captcha config
+    if ( !defined $config || !defined $config->{server} || !defined $config->{client_id} || !defined $config->{client_secret} || !defined $config->{signing_key} ) {
+        $c->stash->{rest} = { error => 'Missing server captcha config' };
+        return;
+    }
+
+    # Check the token with the server
+    my $data = encode_json({
+        secret => $config->{client_secret},
+        response => $token
+    });
+    my $req = HTTP::Request->new(POST => $config->{server} . "/siteverify");
+    $req->header('Content-Type' => 'application/json');
+    $req->content($data);
+    my $response = $ua->request($req);
+    my $response_data = decode_json($response->content);
+
+    # The server did not verify the token
+    if ( !$response->is_success || !$response_data->{success} ) {
+        $c->stash->{rest} = { error => $response_data->{error} || $response->status_line };
+        return;
+    }
+
+    # Sign the token with the signing key
+    my $signature = hmac_sha256_base64($token, $config->{signing_key});
+
+    # Save the token and its signature in a cookie
+    CXGN::Cookie::set_cookie('captcha-token', "$token:$signature");
+
+    $c->stash->{rest} = { success => 1 };
+}

--- a/lib/SGN/Controller/Captcha.pm
+++ b/lib/SGN/Controller/Captcha.pm
@@ -1,0 +1,16 @@
+package SGN::Controller::Captcha;
+
+use Moose;
+
+BEGIN { extends 'Catalyst::Controller'; }
+
+sub captcha :Path('/captcha') {
+    my $self = shift;
+    my $c = shift;
+
+    $c->stash->{config} = $c->config->{captcha};
+    $c->stash->{goto_url} = $c->req->param("goto_url");
+    $c->stash->{template} = '/captcha.mas';
+}
+
+1;

--- a/mason/captcha.mas
+++ b/mason/captcha.mas
@@ -1,0 +1,86 @@
+<%args>
+    $config
+    $goto_url => '/'
+</%args>
+
+<%perl>
+    if ( !defined $config ) {
+        $m->comp("/generic_message.mas", message => "Captcha has not been enabled on this server");
+        $m->abort();
+    }
+</%perl>
+
+<noscript>
+    <div id="sgn-captcha-nojs" style="max-width: 400px; margin: 15px auto; text-align: center;">
+        <p>
+            <strong>Verification Failed</strong>
+            <br />
+            Javascript is required for bot detection...
+        </p>
+    </div>
+</noscript>
+
+<div id="sgn-captcha" style="display: none; max-width: 400px; min-height: 250px; margin: 15px auto; text-align: center;">
+    <p id="sgn-captcha-status">Verifying your request...</p>
+    <progress id="sgn-captcha-loader" max="100" value="0"></progress>
+</div>
+
+
+<script type="module">
+    import "https://cdn.jsdelivr.net/npm/cap-widget@0.1.56";
+    const container = document.getElementById("sgn-captcha");
+    const status = document.getElementById("sgn-captcha-status");
+    const loader = document.getElementById("sgn-captcha-loader");
+
+    // reset the display
+    container.style.display = "block";
+    loader.style.display = "inline-block";
+    loader.setAttribute("value", 0);
+
+    // Initiate the captcha solve routine
+    const cap = new Cap({ apiEndpoint: "<% $config->{server} %>/<% $config->{client_id} %>" });
+    cap.solve();
+
+    // When the captcha has been solved...
+    // verify the token that has been returned
+    // if the token is valid, redirect to the original URL
+    cap.addEventListener("solve", (e) => {
+        jQuery.ajax({
+            url: '/ajax/captcha',
+            method: 'POST',
+            data: { token: e.detail.token },
+            dataType:'json',
+            beforeSend: function() {
+                status.innerHTML = "<strong>Saving verification token...</strong>";
+                loader.removeAttribute("value");
+            },
+            success: function(response) {
+                if ( response?.error || response?.success !== 1 ) {
+                    status.innerHTML = `<strong>Could not save verification token</strong><br />${response.error}`;
+                    loader.style.display = "none";
+                }
+                else {
+                    status.innerHTML = "<strong>Saved verification token!</strong><br />You should now be redirected to <a href='<% $goto_url %>'><% $goto_url %></a>";
+                    loader.style.display = "none";
+                    window.location = "<% $goto_url %>";
+                }
+            },
+            error: function() {
+                status.innerHTML = "<strong>Could not save verification token</strong>";
+                loader.style.display = "none";
+            }
+        });
+    });
+
+    // Update the progress of the captcha solve routine...
+    cap.addEventListener("progress", (e) => {
+        status.innerHTML = `<strong>Verifying your request...</strong>`;
+        loader.value = e.detail.progress;
+    });
+
+    // The captcha solve has failed...
+    cap.addEventListener("error", (e) => {
+        status.innerHTML = `<strong>Could not verify the token</strong><br />${e.detail.message}`;
+        loader.style.display = "none";
+    });
+</script>

--- a/mason/captcha.mas
+++ b/mason/captcha.mas
@@ -62,7 +62,11 @@
                 else {
                     status.innerHTML = "<strong>Saved verification token!</strong><br />You should now be redirected to <a href='<% $goto_url %>'><% $goto_url %></a>";
                     loader.style.display = "none";
-                    window.location = "<% $goto_url %>";
+                    const url = new URL("<% $goto_url %>", `${window.location.protocol}//${window.location.host}`);
+                    if ( !url.searchParams.has("captcha") ) {
+                        url.searchParams.append("captcha", "passed");
+                        window.location = url.pathname + url.search;
+                    }
                 }
             },
             error: function() {

--- a/mason/captcha.mas
+++ b/mason/captcha.mas
@@ -65,6 +65,7 @@
                     const url = new URL("<% $goto_url %>", `${window.location.protocol}//${window.location.host}`);
                     if ( !url.searchParams.has("captcha") ) {
                         url.searchParams.append("captcha", "passed");
+                        url.searchParams.delete("captcha-token");
                         window.location = url.pathname + url.search;
                     }
                 }

--- a/mason/site/toolbar/login.mas
+++ b/mason/site/toolbar/login.mas
@@ -6,7 +6,7 @@
 
   // Add URL paths to this array that should not have the login dialog shown
   // when the config `require_login` is set
-  const PATHS_TO_NOT_REQUIRE_LOGIN = ["/user/reset_password_form"];
+  const PATHS_TO_NOT_REQUIRE_LOGIN = ["/user/reset_password_form", "/captcha"];
 
   function update_login_button() { 
 

--- a/sgn.conf
+++ b/sgn.conf
@@ -549,3 +549,13 @@ version_updated 2021-12-23T19:04:41Z
 #         auto_provision         1                                                                               # [OPTIONAL] If email does not exist in database, do create new user
 #     </keycloak>
 # </oidc_client>
+
+# Use the CAP captcha to verify requests to HTML pages (https://trycap.dev/)
+# This requires the server to be running at the specified address
+# And a site key and secret to be generated for this breedbase instance
+# <captcha>
+#     server              https://cap.example.com             # the URL for the CAP server
+#     client_id           xxxx                                # the CAP site key
+#     client_secret       yyyyyyyy                            # the CAP secret key
+#     signing_key         a_randomly_generated_long_string    # a randomly generated string for signing the tokens in the cookie
+# </captcha>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This adds an optional bot captcha to breedbase to try to reduce bots and crawlers from accessing the site.

It requires a running CAPTCHA server (https://trycap.dev/) - there's a docker-compose file included in this PR that can be used to run the server.  Once the server is running, you'll need to create a new key for each instance of breedbase you want to add the captcha too.  Add the URL to the CAPTCHA server and the generated site id/key and secret to the `sgn_local.conf` along with a randomly generated string to enable the captcha:

```
<captcha>
    server             https://cap.example.com
    client_id          xxxx
    client_secret      yyyyyyy
    signing_key        a_randomly_generated_long_string
</captcha>
```

The way this works:

- Every request to the breedbase server that returns an HTML response will check if there is a valid token stored in the user's cookies
- If the token does not exist or is not valid, the request is redirected to the `/captcha` page
- The captcha page will automatically start the verification procedure, including a [proof-of-work stage](https://trycap.dev/guide/effectiveness.html) and an optional [instrumentation stage](https://trycap.dev/guide/instrumentation.html) that are supposed to be computationally expensive enough to deter bots and test the browser environment to check if the script is running in a real browser.  These verification steps don't require any user intervention (no deciphering squiggly letters or finding bicycles).
- The captcha page will generate a response and the breedbase server will check with the CAPTCHA server to verify if the response is correct
- If the response is correct, the breedbase server will sign the response (with the configured signing key) and save the signed response as a token in the user's cookies (`captcha-token`).
- The user will be redirected back to the original page they requested
- Every subsequent request for an HTML page will check if the token is there and the response is correctly signed.
- The verification step will only occur once (as long as the browser's cookies have not been cleared).

To see the verification in action, try going to any of the T3 sites (https://wheat.triticeaetoolbox.org). 

[Screencast from 2026-07-08 14-49-56.webm](https://github.com/user-attachments/assets/5136fcad-b1f5-423e-bd81-ae037537ed54)


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
