### PR TITLE
Fix duplicate synonyms in trait search

### DIFF
--- a/lib/SGN/Controller/AJAX/Search/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Search/Trait.pm
@@ -111,6 +111,7 @@ sub search : Path('/ajax/search/traits') Args(0) {
     my $bs = CXGN::BreederSearch->new( { dbh=>$dbh } );
 
     my %seen;
+    my %seen_synonym;
     my @ordered_ids;
 
     foreach my $trait (@$data) {
@@ -119,7 +120,10 @@ sub search : Path('/ajax/search/traits') Args(0) {
             $seen{$id} = {%$trait, synonyms => []};
             push @ordered_ids, $id;
         }
-        push @{$seen{$id}{synonyms}}, $trait->{synonym} if $trait->{synonym};
+        my $syn = $trait->{synonym};
+        if (defined $syn && length $syn && !$seen_synonym{$id}{$syn}++) {
+            push @{ $seen{$id}{synonyms} }, $syn;
+        }
     }
 
     foreach my $id (@ordered_ids) {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
De duplicates synonyms in trait search caused by composed traits

<!-- If there are relevant issues, link them here: -->
Fixes #6185 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
