### PR TITLE
Speed up label designer

### DIFF
--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -501,4 +501,37 @@ sub _add_exact_performance_to_line {
     return $line;
 }
 
+# returns a hash of accession_id => {variety => ... , synonyms => ... , ... }
+# more accessionprops can be added here in the future, but they need to be handled in each 
+# trial layout plugin
+sub _get_trial_accessionprops {
+    my $self = shift;
+    my $schema = $self->schema();
+    my %design = %{$self->design};
+    my @trial_design = values %design;
+    my @all_accession_ids = map {$_->{accession_id}} @trial_design;
+    my %accessionprops = ();
+
+    my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
+    my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
+
+    my $q = "SELECT stock_id,
+    string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
+    string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
+    FROM stockprop
+    WHERE stock_id IN (".join(",",@all_accession_ids).")
+    AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
+    GROUP BY stock_id";
+    my $h = $schema->storage->dbh->prepare($q);
+    $h->execute();
+    while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
+        $accessionprops{$accession_id} = {
+            variety => $variety_names,
+            synonyms => $synonyms,
+        };
+    }
+
+    return \%accessionprops;
+}
+
 1;

--- a/lib/CXGN/Trial/TrialLayoutDownload/PlantLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/PlantLayout.pm
@@ -96,24 +96,7 @@ sub retrieve {
     # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
     my %accessionprops = ();
     if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
-        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
-        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
-        my @all_accession_ids = map {$design{$_}->{accession_id}} keys %design;
-        my $q = "SELECT stock_id,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
-        FROM stockprop
-        WHERE stock_id IN (".join(",",@all_accession_ids).")
-        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
-        GROUP BY stock_id";
-        my $h = $schema->storage->dbh->prepare($q);
-        $h->execute();
-        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
-            $accessionprops{$accession_id} = {
-                variety => $variety_names,
-                synonyms => $synonyms,
-            };
-        }
+        %accessionprops = %{$self->_get_trial_accessionprops()};
     }
 
     #Turn plot level design into a plant level design that can be sorted on plot_number and then plant index number..

--- a/lib/CXGN/Trial/TrialLayoutDownload/PlantLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/PlantLayout.pm
@@ -92,26 +92,40 @@ sub retrieve {
         }
     }
 
+    # for accession stockprops like synonym and variety, it is way too slow to create a CXGN::Stock::Accession for each plot.
+    # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
+    my %accessionprops = ();
+    if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
+        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
+        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
+        my @all_accession_ids = map {$design{$_}->{accession_id}} keys %design;
+        my $q = "SELECT stock_id,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
+        FROM stockprop
+        WHERE stock_id IN (".join(",",@all_accession_ids).")
+        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
+        GROUP BY stock_id";
+        my $h = $schema->storage->dbh->prepare($q);
+        $h->execute();
+        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
+            $accessionprops{$accession_id} = {
+                variety => $variety_names,
+                synonyms => $synonyms,
+            };
+        }
+    }
+
     #Turn plot level design into a plant level design that can be sorted on plot_number and then plant index number..
     my @plant_design;
     while (my($plot_number, $design_info) = each %design){
-        my $acc_synonyms = '';
-        if (exists($selected_cols{'synonyms'})){
-            my $accession = CXGN::Stock::Accession->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-            $acc_synonyms = join ',', @{$accession->synonyms};
-        }
         my $acc_pedigree = '';
         if (exists($selected_cols{'pedigree'})){
             $acc_pedigree = $pedigree_strings->{$design_info->{"accession_name"}};
         }
-        my $acc_variety = '';
-        if (exists($selected_cols{'variety'})) {
-            my $accession = CXGN::Stock::Accession->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-            $acc_variety = $accession->variety;
-        }
-        $design_info->{synonyms} = $acc_synonyms;
+        $design_info->{synonyms} = $accessionprops{$design_info->{accession_id}}->{synonyms} // "";
         $design_info->{pedigree} = $acc_pedigree;
-        $design_info->{variety} = $acc_variety;
+        $design_info->{variety} = $accessionprops{$design_info->{accession_id}}->{variety} // "";
 
         my $subplot_plant_names = $design_info->{'subplots_plant_names'};
         my $subplot_names = $design_info->{'subplot_names'};

--- a/lib/CXGN/Trial/TrialLayoutDownload/PlotLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/PlotLayout.pm
@@ -100,6 +100,30 @@ sub retrieve {
     my @overall_trait_names = sort keys %$overall_performance_hash;
     my @exact_trait_names = sort keys %$exact_performance_hash;
 
+    # for accession stockprops like synonym and variety, it is way too slow to create a CXGN::Stock::Accession for each plot.
+    # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
+    my %accessionprops = ();
+    if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
+        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
+        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
+        my @all_accession_ids = map {$_->{accession_id}} @plot_design;
+        my $q = "SELECT stock_id,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
+        FROM stockprop
+        WHERE stock_id IN (".join(",",@all_accession_ids).")
+        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
+        GROUP BY stock_id";
+        my $h = $schema->storage->dbh->prepare($q);
+        $h->execute();
+        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
+            $accessionprops{$accession_id} = {
+                variety => $variety_names,
+                synonyms => $synonyms,
+            };
+        }
+    }
+
     foreach my $design_info (@plot_design) {
         my $line;
         foreach (@possible_cols){
@@ -120,11 +144,9 @@ sub retrieve {
                     my $col = $design_info->{"col_number"} ? $design_info->{"col_number"} : '';
                     push @$line, $row."/".$col;
                 } elsif ($_ eq 'synonyms'){
-                    my $accession = CXGN::Stock::Accession->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-                    push @$line, join ',', @{$accession->synonyms}
+                    push @$line, $accessionprops{$design_info->{accession_id}}->{synonyms} // "";
                 } elsif ($_ eq 'variety'){
-                    my $accession = CXGN::Stock::Accession->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-                    push @$line, $accession->variety;
+                    push @$line, $accessionprops{$design_info->{accession_id}}->{variety} // "";
                 } elsif ($_ eq 'pedigree'){
                     push @$line, $pedigree_strings->{$design_info->{"accession_name"}};
                 } else {

--- a/lib/CXGN/Trial/TrialLayoutDownload/PlotLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/PlotLayout.pm
@@ -104,24 +104,7 @@ sub retrieve {
     # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
     my %accessionprops = ();
     if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
-        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
-        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
-        my @all_accession_ids = map {$_->{accession_id}} @plot_design;
-        my $q = "SELECT stock_id,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
-        FROM stockprop
-        WHERE stock_id IN (".join(",",@all_accession_ids).")
-        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
-        GROUP BY stock_id";
-        my $h = $schema->storage->dbh->prepare($q);
-        $h->execute();
-        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
-            $accessionprops{$accession_id} = {
-                variety => $variety_names,
-                synonyms => $synonyms,
-            };
-        }
+        %accessionprops = %{$self->_get_trial_accessionprops()};
     }
 
     foreach my $design_info (@plot_design) {

--- a/lib/CXGN/Trial/TrialLayoutDownload/SamplingTrialLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/SamplingTrialLayout.pm
@@ -43,7 +43,7 @@ sub retrieve {
     my $trial = $self->trial;
     my @output;
 
-    my @possible_cols = ('trial_name', 'year', 'planting_date', 'location', 'sampling_facility', 'sampling_trial_sample_type', 'acquisition_date', 'tissue_sample_name', 'plot_number', 'rep_number', 'source_observation_unit_name', 'accession_name', 'synonyms', 'dna_person', 'notes', 'tissue_type', 'extraction', 'concentration', 'volume');
+    my @possible_cols = ('trial_name', 'year', 'planting_date', 'location', 'sampling_facility', 'sampling_trial_sample_type', 'acquisition_date', 'tissue_sample_name', 'plot_number', 'rep_number', 'source_observation_unit_name', 'accession_name', 'synonyms', 'dna_person', 'notes', 'tissue_type', 'extraction', 'concentration', 'volume', 'variety');
 
     my @header;
     foreach (@possible_cols){
@@ -63,6 +63,30 @@ sub retrieve {
     my $sampling_type = $schema->resultset("Project::Projectprop")->search({ project_id => $trial->get_trial_id(), type_id => $sampling_trial_sample_type_cvterm_id } )->first->value();
 
     my $pedigree_strings = $self->_get_all_pedigrees(\%design);
+
+    # for accession stockprops like synonym and variety, it is way too slow to create a CXGN::Stock::Accession for each plot.
+    # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
+    my %accessionprops = ();
+    if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
+        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
+        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
+        my @all_accession_ids = map {$design{$_}->{accession_id}} keys %design;
+        my $q = "SELECT stock_id,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
+        FROM stockprop
+        WHERE stock_id IN (".join(",",@all_accession_ids).")
+        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
+        GROUP BY stock_id";
+        my $h = $schema->storage->dbh->prepare($q);
+        $h->execute();
+        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
+            $accessionprops{$accession_id} = {
+                variety => $variety_names,
+                synonyms => $synonyms,
+            };
+        }
+    }
 
     foreach my $key (sort { $a cmp $b} keys %design) {
         my $design_info = $design{$key};
@@ -84,8 +108,9 @@ sub retrieve {
                 } elsif ($_ eq 'tissue_sample_name'){
                     push @$line, $design_info->{'plot_name'};
                 } elsif ($_ eq 'synonyms'){
-                    my $accession = CXGN::Stock::Accession->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-                    push @$line, join ',', @{$accession->synonyms}
+                    push @$line, $accessionprops{$design_info->{accession_id}}->{synonyms} // "";
+                } elsif ($_ eq 'variety'){
+                    push @$line, $accessionprops{$design_info->{accession_id}}->{variety} // "";
                 } elsif ($_ eq 'pedigree'){
                     push @$line, $pedigree_strings->{$design_info->{"accession_name"}};
                 } else {

--- a/lib/CXGN/Trial/TrialLayoutDownload/SamplingTrialLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/SamplingTrialLayout.pm
@@ -68,24 +68,7 @@ sub retrieve {
     # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
     my %accessionprops = ();
     if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
-        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
-        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
-        my @all_accession_ids = map {$design{$_}->{accession_id}} keys %design;
-        my $q = "SELECT stock_id,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
-        FROM stockprop
-        WHERE stock_id IN (".join(",",@all_accession_ids).")
-        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
-        GROUP BY stock_id";
-        my $h = $schema->storage->dbh->prepare($q);
-        $h->execute();
-        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
-            $accessionprops{$accession_id} = {
-                variety => $variety_names,
-                synonyms => $synonyms,
-            };
-        }
+        %accessionprops = %{$self->_get_trial_accessionprops()};
     }
 
     foreach my $key (sort { $a cmp $b} keys %design) {

--- a/lib/CXGN/Trial/TrialLayoutDownload/SubplotLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/SubplotLayout.pm
@@ -95,26 +95,40 @@ sub retrieve {
         }
     }
 
+    # for accession stockprops like synonym and variety, it is way too slow to create a CXGN::Stock::Accession for each plot.
+    # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
+    my %accessionprops = ();
+    if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
+        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
+        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
+        my @all_accession_ids = map {$design{$_}->{accession_id}} keys %design;
+        my $q = "SELECT stock_id,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
+        FROM stockprop
+        WHERE stock_id IN (".join(",",@all_accession_ids).")
+        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
+        GROUP BY stock_id";
+        my $h = $schema->storage->dbh->prepare($q);
+        $h->execute();
+        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
+            $accessionprops{$accession_id} = {
+                variety => $variety_names,
+                synonyms => $synonyms,
+            };
+        }
+    }
+
     #Turn plot level design into a subplot level design that can be sorted on plot_number and then subplot index number..
     my @subplot_design;
     while (my($plot_number, $design_info) = each %design){
-        my $acc_synonyms = '';
-        if (exists($selected_cols{'synonyms'})){
-            my $accession = CXGN::Stock::Accession->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-            $acc_synonyms = join ',', @{$accession->synonyms};
-        }
         my $acc_pedigree = '';
         if (exists($selected_cols{'pedigree'})){
             $acc_pedigree = $pedigree_strings->{$design_info->{"accession_name"}};
         }
-        my $acc_variety = '';
-        if (exists($selected_cols{'variety'})) {
-            my $accession = CXGN::Stock::Accession->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-            $acc_variety = $accession->variety;
-        }
-        $design_info->{synonyms} = $acc_synonyms;
+        $design_info->{synonyms} = $accessionprops{$design_info->{accession_id}}->{synonyms} // "";
         $design_info->{pedigree} = $acc_pedigree;
-        $design_info->{variety} = $acc_variety;
+        $design_info->{variety} = $accessionprops{$design_info->{accession_id}}->{variety} // "";
 
         my $subplot_names = $design_info->{'subplot_names'};
         my $subplot_ids = $design_info->{'subplot_ids'};

--- a/lib/CXGN/Trial/TrialLayoutDownload/SubplotLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/SubplotLayout.pm
@@ -99,24 +99,7 @@ sub retrieve {
     # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
     my %accessionprops = ();
     if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
-        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
-        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
-        my @all_accession_ids = map {$design{$_}->{accession_id}} keys %design;
-        my $q = "SELECT stock_id,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
-        FROM stockprop
-        WHERE stock_id IN (".join(",",@all_accession_ids).")
-        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
-        GROUP BY stock_id";
-        my $h = $schema->storage->dbh->prepare($q);
-        $h->execute();
-        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
-            $accessionprops{$accession_id} = {
-                variety => $variety_names,
-                synonyms => $synonyms,
-            };
-        }
+        %accessionprops = %{$self->_get_trial_accessionprops()};
     }
 
     #Turn plot level design into a subplot level design that can be sorted on plot_number and then subplot index number..

--- a/lib/CXGN/Trial/TrialLayoutDownload/TissueSampleLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/TissueSampleLayout.pm
@@ -97,26 +97,40 @@ sub retrieve {
         }
     }
 
+    # for accession stockprops like synonym and variety, it is way too slow to create a CXGN::Stock::Accession for each plot.
+    # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
+    my %accessionprops = ();
+    if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
+        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
+        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
+        my @all_accession_ids = map {$design{$_}->{accession_id}} keys %design;
+        my $q = "SELECT stock_id,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
+        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
+        FROM stockprop
+        WHERE stock_id IN (".join(",",@all_accession_ids).")
+        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
+        GROUP BY stock_id";
+        my $h = $schema->storage->dbh->prepare($q);
+        $h->execute();
+        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
+            $accessionprops{$accession_id} = {
+                variety => $variety_names,
+                synonyms => $synonyms,
+            };
+        }
+    }
+
     #Turn plot level design into a tissue sample level design that can be sorted on plot_number and then tissue sample index number..
     my @tissue_sample_design;
     while (my($plot_number, $design_info) = each %design){
-        my $acc_synonyms = '';
-        if (exists($selected_cols{'synonyms'})){
-            my $accession = CXGN::Stock::Accession->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-            $acc_synonyms = join ',', @{$accession->synonyms};
-        }
         my $acc_pedigree = '';
         if (exists($selected_cols{'pedigree'})){
             $acc_pedigree = $pedigree_strings->{$design_info->{"accession_name"}};
         }
-        my $acc_variety = '';
-        if (exists($selected_cols{'variety'})) {
-            my $accession = CXGN::Stock::Accession->new({schema=>$schema, stock_id=>$design_info->{"accession_id"}});
-            $acc_variety = $accession->variety;
-        }
-        $design_info->{synonyms} = $acc_synonyms;
+        $design_info->{synonyms} = $accessionprops{$design_info->{accession_id}}->{synonyms} // "";
         $design_info->{pedigree} = $acc_pedigree;
-        $design_info->{variety} = $acc_variety;
+        $design_info->{variety} = $accessionprops{$design_info->{accession_id}}->{variety} // "";
 
         my $subplot_tissue_names = $design_info->{'subplots_tissue_sample_names'};
         my $plant_tissue_names = $design_info->{'plants_tissue_sample_names'};

--- a/lib/CXGN/Trial/TrialLayoutDownload/TissueSampleLayout.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload/TissueSampleLayout.pm
@@ -101,24 +101,7 @@ sub retrieve {
     # Instead, there needs to be one big call at the start to retrieve these stockprops and index them for the next loop
     my %accessionprops = ();
     if ($selected_cols{"variety"} || $selected_cols{"synonyms"}) {
-        my $synonym_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_synonym', 'stock_property')->cvterm_id();
-        my $variety_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'variety', 'stock_property')->cvterm_id();
-        my @all_accession_ids = map {$design{$_}->{accession_id}} keys %design;
-        my $q = "SELECT stock_id,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $variety_cvterm_id) AS variety_names,
-        string_agg(value, ',' ORDER BY rank) FILTER (WHERE type_id = $synonym_cvterm_id) AS synonyms
-        FROM stockprop
-        WHERE stock_id IN (".join(",",@all_accession_ids).")
-        AND type_id IN ($synonym_cvterm_id, $variety_cvterm_id)
-        GROUP BY stock_id";
-        my $h = $schema->storage->dbh->prepare($q);
-        $h->execute();
-        while (my ($accession_id, $variety_names, $synonyms) = $h->fetchrow_array) {
-            $accessionprops{$accession_id} = {
-                variety => $variety_names,
-                synonyms => $synonyms,
-            };
-        }
+        %accessionprops = %{$self->_get_trial_accessionprops()};
     }
 
     #Turn plot level design into a tissue sample level design that can be sorted on plot_number and then tissue sample index number..

--- a/lib/SGN/Controller/AJAX/LabelDesigner.pm
+++ b/lib/SGN/Controller/AJAX/LabelDesigner.pm
@@ -799,10 +799,10 @@ sub get_trial_design {
     my $type = shift;
     my %selected_columns = (
         plate => {genotyping_project_name=>1,genotyping_facility=>1,trial_name=>1,acquisition_date=>1,exported_tissue_sample_name=>1,tissue_sample_name=>1,well_A01=>1,row_number=>1,col_number=>1,source_observation_unit_name=>1,accession_name=>1,synonyms=>0,accession_id=>1,pedigree=>1,dna_person=>1,notes=>1,tissue_type=>1,extraction=>1,concentration=>1,volume=>1,is_blank=>1,year=>1,location_name=>1},
-        plots => {plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>0,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,rep_number=>1,range_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1, planting_date=>1, variety=>1},
-        plants => {plant_name=>1,plant_id=>1,subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>0,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,range_number=>1,rep_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,plant_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1, planting_date=>1, variety=>1},
-        subplots => {subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>0,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,rep_number=>1,range_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1, planting_date=>1, variety=>1},
-        field_trial_tissue_samples => {tissue_sample_name=>1,tissue_sample_id=>1,plant_name=>1,plant_id=>1,subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>0,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,range_number=>1,rep_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,plant_number=>1,tissue_sample_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1, planting_date=>1, variety=>1}
+        plots => {plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,rep_number=>1,range_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1, planting_date=>1, variety=>1},
+        plants => {plant_name=>1,plant_id=>1,subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,range_number=>1,rep_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,plant_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1, planting_date=>1, variety=>1},
+        subplots => {subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,rep_number=>1,range_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1, planting_date=>1, variety=>1},
+        field_trial_tissue_samples => {tissue_sample_name=>1,tissue_sample_id=>1,plant_name=>1,plant_id=>1,subplot_name=>1,subplot_id=>1,plot_name=>1,plot_id=>1,accession_name=>1,synonyms=>1,accession_id=>1,plot_number=>1,block_number=>1,is_a_control=>1,range_number=>1,rep_number=>1,row_number=>1,col_number=>1,seedlot_name=>1,seed_transaction_operator=>1,num_seed_per_plot=>1,subplot_number=>1,plant_number=>1,tissue_sample_number=>1,pedigree=>1,location_name=>1,trial_name=>1,year=>1,tier=>1,plot_geo_json=>1, planting_date=>1, variety=>1}
     );
     my %unique_identifier = (
         plate => 'tissue_sample_name',
@@ -827,7 +827,7 @@ sub get_trial_design {
             include_treatments => 'true',
             selected_columns => $selected_columns{$type},
             selected_trait_ids => [],
-            use_synonyms => 'false',
+            use_synonyms => 'true',
             include_measured => 'true'
         });
         my $layout = $trial_layout_download->get_layout_output();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Combines variety and synonym retrieval into a single query for each trial design. Trial cache regeneration is still slow for very large trials, but should be an improvement

Needs to be tested on cassava-devel or cassava-test before acceptance

<!-- If there are relevant issues, link them here: -->
Fixes #6196 
Fixes #5976
Fixes #5148 
Fixes #4964

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
