### PR TITLE
Allow trial owners to edit phenotypes

### DIFF
--- a/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
+++ b/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
@@ -572,6 +572,7 @@ sub update_single_observation :Path('/ajax/phenotype/edit/') Args(1) {
     }
 
     my $user = $c->user();
+    my $sp_person_id = $user->get_object()->get_sp_person_id();
 
     my $user_type = $user->get_object->get_user_type();
     my $username = $user->get_username();
@@ -601,10 +602,10 @@ sub update_single_observation :Path('/ajax/phenotype/edit/') Args(1) {
         trial_id => $trial_id
     });
 
-    my $breeding_program = $this_trial->get_breeding_program();
+    my $owners = $this_trial->_get_trial_owners();
 
-    if ( ! $user->check_roles("curator")  ) {
-        $c->stash->{rest} = {error => "You do not have permission to make edits on this trial."};
+    if ( ! $user->check_roles("curator") && !defined($owners->{$sp_person_id}) ) {
+        $c->stash->{rest} = {error => "You do not have permission to make edits on this trial - only curators and trial owners can modify raw phenotype values."};
         return;
     }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Enables trial owners in addition to curators to edit single phenotype values

<!-- If there are relevant issues, link them here: -->
Closes #6210 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
