### PR TITLE
enforce use of dataset genotype protocol

### DIFF
--- a/js/source/legacy/solGS/cluster.js
+++ b/js/source/legacy/solGS/cluster.js
@@ -829,21 +829,32 @@ solGS.cluster = {
     var clusterArgs;
 
     var selectedPopDiv = document.getElementById(runClusterElemId);
+    
+
     if (selectedPopDiv) {
-      var selectedPopData = selectedPopDiv.dataset;
+        var protocolId;
+        var selectedPopData = selectedPopDiv.dataset;
 
-      clusterArgs = JSON.parse(selectedPopData.selectedPop);
-      var clusterPopId = clusterArgs.data_str + "_" + clusterArgs.id;
+        clusterArgs = JSON.parse(selectedPopData.selectedPop);
+        var clusterPopId = clusterArgs.data_str + "_" + clusterArgs.id;
 
-      var protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("cluster_div");
+        if (clusterArgs.data_str && clusterArgs.data_str.match(/dataset/)) {
+            var datasetId = clusterArgs.id;
+            protocolId = solGS.dataset.getDatasetGenoProtocolId(datasetId);
+        }
 
-      clusterArgs["analysis_type"] = "cluster analysis";
-      clusterArgs["genotyping_protocol_id"] = protocolId;
-      clusterArgs["cluster_pop_id"] = clusterPopId;
-      clusterArgs["data_structure"] = clusterArgs.data_str;
+        if (!protocolId) {
+            protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("cluster_div");
+        }
+
+        clusterArgs["analysis_type"] = "cluster analysis";
+        clusterArgs["genotyping_protocol_id"] = protocolId;
+        clusterArgs["cluster_pop_id"] = clusterPopId;
+        clusterArgs["data_structure"] = clusterArgs.data_str;
     }
 
     return clusterArgs;
+    
   },
 
   populateClusterMenu: function (newPop) {

--- a/js/source/legacy/solGS/heatMap.js
+++ b/js/source/legacy/solGS/heatMap.js
@@ -402,7 +402,7 @@ solGS.heatmap = {
       if (!heatmapPlotDivId.match("#")) {
         heatmapPlotDivId = "#" + heatmapPlotDivId;
       }
-      jQuery(heatmapPlotDivId).append('<p style="margin-left: 40px">' + downloadLinks + "</p>");
+      jQuery(heatmapPlotDivId).append('<p style="margin: 20px 0px 0px 40px">' + downloadLinks + "</p>");
     }
   },
 

--- a/js/source/legacy/solGS/kinship.js
+++ b/js/source/legacy/solGS/kinship.js
@@ -406,10 +406,10 @@ jQuery(document).ready(function () {
     var runKinshipBtnId = e.target.id;
     if (runKinshipBtnId.match(/run_kinship/)) {
     
-        jQuery(runKinshipBtnId).hide();
+        jQuery(`#${runKinshipBtnId}`).hide();
+        var kinshipMsgDiv = solGS.kinship.kinshipMsgDiv;
         jQuery(kinshipMsgDiv).text("Running kinship... please wait...it may take minutes.").show();
-
-         jQuery(`${canvas} .multi-spinner-container`).show();
+        jQuery(`${canvas} .multi-spinner-container`).show();
 
         var kinshipArgs = solGS.kinship.getKinshipArgs();
         var kinshipPopId = kinshipArgs.kinship_pop_id;
@@ -426,7 +426,6 @@ jQuery(document).ready(function () {
     
         var canvas = solGS.kinship.canvas;
         var kinshipPlotDivId = solGS.kinship.kinshipPlotDivPrefix;
-        var kinshipMsgDiv = solGS.kinship.kinshipMsgDiv;
         runKinshipBtnId = `#${runKinshipBtnId}`;
         var kinshipUrl = kinshipArgs.analysis_page;
     

--- a/js/source/legacy/solGS/kinship.js
+++ b/js/source/legacy/solGS/kinship.js
@@ -174,7 +174,6 @@ solGS.kinship = {
 
     if (!protocolId) {
       protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("kinship_div");
-      console.log(`createRowElements kinshipArgs.protocolId: ${protocolId}`);
     }
 
     var kinshipArgs = {
@@ -284,30 +283,29 @@ solGS.kinship = {
   },
 
   getSelectedPopKinshipArgs: function (runKinshipElemId) {
-    var kinshipArgs;
 
     var selectedPopDiv = document.getElementById(runKinshipElemId);
     if (selectedPopDiv) {
-      var selectedPopData = selectedPopDiv.dataset;
+        var selectedPopData = selectedPopDiv.dataset;
 
-      kinshipArgs = JSON.parse(selectedPopData.selectedPop);
-      var kinshipPopId = kinshipArgs.data_structure + "_" + kinshipArgs.id;
+        var kinshipArgs = JSON.parse(selectedPopData.selectedPop);
 
-      var protocolId;
-      if (kinshipArgs.data_structure == 'dataset') {
-        datasetId = kinshipArgs.dataset_id;
-        protocolId = solGS.dataset.getDatasetGenoProtocolId(datasetId);
-      }
+        var protocolId;
+        if (kinshipArgs.data_structure && kinshipArgs.data_structure.match(/dataset/)) {
+            datasetId = kinshipArgs.dataset_id;
+            protocolId = solGS.dataset.getDatasetGenoProtocolId(datasetId);
+        }
 
-      if (!protocolId) {
-        protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("kinship_div");
-      }
+        if (!protocolId) {
+            protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("kinship_div");
+        }
 
-      var page = `/kinship/analysis/${kinshipPopId}/gp/${protocolId}`;
+        var kinshipPopId = kinshipArgs.kinship_pop_id;
+        var page = `/kinship/analysis/${kinshipPopId}/gp/${protocolId}`;
 
-      kinshipArgs["analysis_type"] = "kinship analysis";
-      kinshipArgs["genotyping_protocol_id"] = protocolId;
-      kinshipArgs["analysis_page"] = page;
+        kinshipArgs["analysis_type"] = "kinship analysis";
+        kinshipArgs["genotyping_protocol_id"] = protocolId;
+        kinshipArgs["analysis_page"] = page;
     }
 
     return kinshipArgs;
@@ -407,158 +405,159 @@ jQuery(document).ready(function () {
   jQuery("#kinship_div").on("click", function (e) {
     var runKinshipBtnId = e.target.id;
     if (runKinshipBtnId.match(/run_kinship/)) {
-      var kinshipArgs = solGS.kinship.getKinshipArgs();
-      var kinshipPopId = kinshipArgs.kinship_pop_id;
-      if (!kinshipPopId) {
-        kinshipArgs = solGS.kinship.getSelectedPopKinshipArgs(runKinshipBtnId);
-      }
+    
+        jQuery(runKinshipBtnId).hide();
+        jQuery(kinshipMsgDiv).text("Running kinship... please wait...it may take minutes.").show();
 
-      kinshipPopId = kinshipArgs.kinship_pop_id;
-      var protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("kinship_div");
+         jQuery(`${canvas} .multi-spinner-container`).show();
 
-      var canvas = solGS.kinship.canvas;
-      var kinshipPlotDivId = solGS.kinship.kinshipPlotDivPrefix;
-      var kinshipMsgDiv = solGS.kinship.kinshipMsgDiv;
-      runKinshipBtnId = `#${runKinshipBtnId}`;
-      var kinshipUrl = `/kinship/analysis/${kinshipPopId}/gp/${protocolId}`;
-      //    solGS.kinship.generateKinshipUrl(kinshipPopId);
-      kinshipArgs["analysis_page"] = kinshipUrl;
+        var kinshipArgs = solGS.kinship.getKinshipArgs();
+        var kinshipPopId = kinshipArgs.kinship_pop_id;
 
-      jQuery(runKinshipBtnId).hide();
-      jQuery(`${canvas} .multi-spinner-container`).show();
+        if (!kinshipPopId) {
+            kinshipArgs = solGS.kinship.getSelectedPopKinshipArgs(runKinshipBtnId);
+        }
 
-      jQuery(runKinshipBtnId).hide();
-      jQuery(kinshipMsgDiv).text("Running kinship... please wait...it may take minutes.").show();
+        if (!kinshipArgs.analysis_page) {
+            kinshipPopId = kinshipArgs.kinship_pop_id;
+            var protocolId = kinshipArgs.genotyping_protocol_id;
+            kinshipArgs["analysis_page"] = `/kinship/analysis/${kinshipPopId}/gp/${protocolId}`;
+        }
+    
+        var canvas = solGS.kinship.canvas;
+        var kinshipPlotDivId = solGS.kinship.kinshipPlotDivPrefix;
+        var kinshipMsgDiv = solGS.kinship.kinshipMsgDiv;
+        runKinshipBtnId = `#${runKinshipBtnId}`;
+        var kinshipUrl = kinshipArgs.analysis_page;
+    
+        solGS.kinship
+            .checkCachedKinship(kinshipUrl, kinshipArgs)
+            .done(function (res) {
+            if (res.kinship_output_data) {
+                jQuery(kinshipMsgDiv).html("Generating heatmap... please wait...").show();
 
-      jQuery(`${canvas} .multi-spinner-container`).show();
-      solGS.kinship
-        .checkCachedKinship(kinshipUrl, kinshipArgs)
-        .done(function (res) {
-          if (res.kinship_output_data) {
-            jQuery(kinshipMsgDiv).html("Generating heatmap... please wait...").show();
+                kinshipPlotDivId = `${kinshipPlotDivId}_${res.kinship_file_id}`;
 
-            kinshipPlotDivId = `${kinshipPlotDivId}_${res.kinship_file_id}`;
+                var links = solGS.kinship.addDowloandLinks(res);
+                var heatmapArgs = {
+                heatmap_input_data: res.kinship_output_data,
+                canvas: canvas,
+                plot_div_id: kinshipPlotDivId,
+                download_links: links,
+                };
 
-            var links = solGS.kinship.addDowloandLinks(res);
-            var heatmapArgs = {
-              heatmap_input_data: res.kinship_output_data,
-              canvas: canvas,
-              plot_div_id: kinshipPlotDivId,
-              download_links: links,
-            };
+                solGS.heatmap.plot(heatmapArgs);
 
-            solGS.heatmap.plot(heatmapArgs);
+                jQuery(`${canvas} .multi-spinner-container`).hide();
+                jQuery(kinshipMsgDiv).empty();
+                jQuery(runKinshipBtnId).show();
+            } else {
 
-            jQuery(`${canvas} .multi-spinner-container`).hide();
-            jQuery(kinshipMsgDiv).empty();
-            jQuery(runKinshipBtnId).show();
-          } else {
+                jQuery(`${canvas} .multi-spinner-container`).hide();
+                jQuery(kinshipMsgDiv).empty();
 
-			jQuery(`${canvas} .multi-spinner-container`).hide();
-            jQuery(kinshipMsgDiv).empty();
+                var title =
+                "<p>This analysis may take a long time. " +
+                "Do you want to submit the analysis and get an email when it completes?</p>";
 
-            var title =
-              "<p>This analysis may take a long time. " +
-              "Do you want to submit the analysis and get an email when it completes?</p>";
+                var jobSubmit = '<div id= "kinship_submit">' + title + "</div>";
 
-            var jobSubmit = '<div id= "kinship_submit">' + title + "</div>";
+                jQuery(jobSubmit).appendTo("body");
 
-            jQuery(jobSubmit).appendTo("body");
+                jQuery("#kinship_submit").dialog({
+                height: "auto",
+                width: "auto",
+                modal: true,
+                title: "Kinship job submission",
+                buttons: {
+                    OK: {
+                    text: "Yes",
+                    class: "btn btn-success",
+                    id: "queue_job",
+                    click: function () {
+                        jQuery(this).dialog("close");
 
-            jQuery("#kinship_submit").dialog({
-              height: "auto",
-              width: "auto",
-              modal: true,
-              title: "Kinship job submission",
-              buttons: {
-                OK: {
-                  text: "Yes",
-                  class: "btn btn-success",
-                  id: "queue_job",
-                  click: function () {
-                    jQuery(this).dialog("close");
+                        solGS.submitJob.checkUserLogin(kinshipUrl, kinshipArgs);
+                    },
+                    },
 
-                    solGS.submitJob.checkUserLogin(kinshipUrl, kinshipArgs);
-                  },
-                },
+                    No: {
+                    text: "No, I will wait till it completes.",
+                    class: "btn btn-warning",
+                    id: "no_queue",
+                    click: function () {
+                        jQuery(this).dialog("close");
 
-                No: {
-                  text: "No, I will wait till it completes.",
-                  class: "btn btn-warning",
-                  id: "no_queue",
-                  click: function () {
-                    jQuery(this).dialog("close");
+                        jQuery(kinshipMsgDiv).text("Running kinship... please wait...it may take minutes.").show();
+                        jQuery(`${canvas} .multi-spinner-container`).show();
 
-					jQuery(kinshipMsgDiv).text("Running kinship... please wait...it may take minutes.").show();
-					jQuery(`${canvas} .multi-spinner-container`).show();
+                        solGS.kinship
+                        .runKinshipAnalysis(kinshipArgs)
+                        .done(function (res) {
+                            if (res.kinship_output_data) {
+                            jQuery(kinshipMsgDiv)
+                                .html("Generating heatmap... please wait...")
+                                .show();
 
-                    solGS.kinship
-                      .runKinshipAnalysis(kinshipArgs)
-                      .done(function (res) {
-                        if (res.kinship_output_data) {
-                          jQuery(kinshipMsgDiv)
-                            .html("Generating heatmap... please wait...")
-                            .show();
+                            kinshipPlotDivId = `${kinshipPlotDivId}_${res.kinship_file_id}`;
 
-                          kinshipPlotDivId = `${kinshipPlotDivId}_${res.kinship_file_id}`;
+                            var links = solGS.kinship.addDowloandLinks(res);
+                            var heatmapArgs = {
+                                heatmap_input_data: res.kinship_output_data,
+                                canvas: canvas,
+                                plot_div_id: kinshipPlotDivId,
+                                download_links: links,
+                            };
 
-                          var links = solGS.kinship.addDowloandLinks(res);
-                          var heatmapArgs = {
-                            heatmap_input_data: res.kinship_output_data,
-                            canvas: canvas,
-                            plot_div_id: kinshipPlotDivId,
-                            download_links: links,
-                          };
+                            solGS.heatmap.plot(heatmapArgs);
 
-                          solGS.heatmap.plot(heatmapArgs);
+                            jQuery(`${canvas} .multi-spinner-container`).hide();
+                            jQuery(kinshipMsgDiv).empty();
+                            jQuery(runKinshipBtnId).show();
+                            } else {
+                            jQuery(`${canvas} .multi-spinner-container`).hide();
+                            jQuery(kinshipMsgDiv)
+                                .css({
+                                "padding-left": "0px",
+                                })
+                                .html("This population has no kinship output data.")
+                                .fadeOut(8400);
 
-                          jQuery(`${canvas} .multi-spinner-container`).hide();
-                          jQuery(kinshipMsgDiv).empty();
-                          jQuery(runKinshipBtnId).show();
-                        } else {
-                          jQuery(`${canvas} .multi-spinner-container`).hide();
-                          jQuery(kinshipMsgDiv)
-                            .css({
-                              "padding-left": "0px",
-                            })
-                            .html("This population has no kinship output data.")
+                            jQuery(runKinshipBtnId).show();
+                            }
+                        })
+                        .fail(function () {
+                            jQuery(kinshipMsgDiv)
+                            .html("Error occured running the kinship.")
+                            .show()
                             .fadeOut(8400);
 
-                          jQuery(runKinshipBtnId).show();
-                        }
-                      })
-                      .fail(function () {
-                        jQuery(kinshipMsgDiv)
-                          .html("Error occured running the kinship.")
-                          .show()
-                          .fadeOut(8400);
+                            jQuery(`${canvas} .multi-spinner-container`).hide();
+                            jQuery(runKinshipBtnId).show();
+                        });
+                    },
+                    },
 
-                        jQuery(`${canvas} .multi-spinner-container`).hide();
+                    Cancel: {
+                    text: "Cancel",
+                    class: "btn btn-info",
+                    id: "cancel_queue_info",
+                    click: function () {
+                        jQuery(this).dialog("close");
                         jQuery(runKinshipBtnId).show();
-                      });
-                  },
+                    },
+                    },
                 },
-
-                Cancel: {
-                  text: "Cancel",
-                  class: "btn btn-info",
-                  id: "cancel_queue_info",
-                  click: function () {
-                    jQuery(this).dialog("close");
-                    jQuery(runKinshipBtnId).show();
-                  },
-                },
-              },
+                });
+            }
+            })
+            .fail(function () {
+            jQuery(kinshipMsgDiv).html("Error occured running the kinship.").show().fadeOut(8400);
+            jQuery(`${canvas} .multi-spinner-container`).hide();
+            jQuery(runKinshipBtnId).show();
             });
-          }
-        })
-        .fail(function () {
-          jQuery(kinshipMsgDiv).html("Error occured running the kinship.").show().fadeOut(8400);
-          jQuery(`${canvas} .multi-spinner-container`).hide();
-          jQuery(runKinshipBtnId).show();
-        });
-    }
-  });
+        }
+    });
 });
 
 jQuery(document).ready(function () {
@@ -570,6 +569,7 @@ jQuery(document).ready(function () {
       if (args.data_structure) {
         args["kinship_pop_id"] = args.data_structure + "_" + args.kinship_pop_id;
       }
+
       solGS.kinship.checkCachedKinship(url, args).done(function (res) {
         if (res.kinship_output_data) {
           var kinshipMsgDiv = solGS.kinship.kinshipMsgDiv;

--- a/js/source/legacy/solGS/kinship.js
+++ b/js/source/legacy/solGS/kinship.js
@@ -174,6 +174,7 @@ solGS.kinship = {
 
     if (!protocolId) {
       protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("kinship_div");
+      console.log(`createRowElements kinshipArgs.protocolId: ${protocolId}`);
     }
 
     var kinshipArgs = {
@@ -290,11 +291,11 @@ solGS.kinship = {
       var selectedPopData = selectedPopDiv.dataset;
 
       kinshipArgs = JSON.parse(selectedPopData.selectedPop);
-      var kinshipPopId = kinshipArgs.data_str + "_" + kinshipArgs.id;
+      var kinshipPopId = kinshipArgs.data_structure + "_" + kinshipArgs.id;
 
       var protocolId;
-      if (kinshipArgs.data_str == 'dataset') {
-        datasetId = kinshipArgs.id;
+      if (kinshipArgs.data_structure == 'dataset') {
+        datasetId = kinshipArgs.dataset_id;
         protocolId = solGS.dataset.getDatasetGenoProtocolId(datasetId);
       }
 

--- a/js/source/legacy/solGS/pca.js
+++ b/js/source/legacy/solGS/pca.js
@@ -207,14 +207,12 @@ solGS.pca = {
             var pcaArgs = selectedPopData.selectedPop;
             pcaArgs = JSON.parse(pcaArgs);
             if (pcaArgs.data_structure.match(/dataset/)) {
-                var datasetId = pcaPopId.replace(/dataset_/, "");
+                var datasetId = pcaArgs.dataset_id;
                 protocolId = solGS.dataset.getDatasetGenoProtocolId(datasetId);
             }
 
             if (!protocolId) {
-                console.log(`No protocolId found, using default`);
                 protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("pca_div");
-                console.log(`pca div protocolId: ${protocolId}`);
             }
 
             var page = `/pca/analysis/${pcaPopId}/gp/${protocolId}`;
@@ -231,9 +229,6 @@ solGS.pca = {
                 pcaArgs["analysis_page"] = this.generatePcaUrl(pcaPopId);
             }
         }
-
-
-        console.log(`getSelectedPopPcaArgs pcaArgs return : ${pcaArgs}`);
 
         return pcaArgs;
     },
@@ -629,8 +624,17 @@ solGS.pca = {
 
     generatePcaUrl: function (pcaPopId) {
         var traitId = jQuery("#trait_id").val();
-        var protocolId =
-            solGS.genotypingProtocol.getGenotypingProtocolId("pca_div");
+
+        var protocolId;
+        if (pcaPopId.match(/dataset/)) {
+            var datasetId = pcaPopId.replace(/dataset_/g, "");
+            protocolId = solGS.dataset.getDatasetGenoProtocolId(datasetId);
+
+        } 
+
+        if (!protocolId) {
+            protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("pca_div");
+        }
 
         var solgsPages =
             "solgs/population/" +
@@ -1119,8 +1123,15 @@ jQuery(document).ready(function () {
             var canvas = solGS.pca.canvas;
             var pcaMsgDiv = solGS.pca.pcaMsgDiv;
 
-            var pcaUrl = solGS.pca.generatePcaUrl(pcaPopId);
-            pcaArgs["analysis_page"] = pcaUrl;
+            if (!pcaArgs.analysis_page) {
+                pcaPopId = pcaArgs.pca_pop_id;
+                var protocolId = pcaArgs.genotyping_protocol_id;
+                var pcaUrl = `/pca/analysis/${pcaPopId}/gp/${protocolId}`;
+                //    solGS.kinship.generateKinshipUrl(kinshipPopId);
+                pcaArgs["analysis_page"] = pcaUrl;
+            }
+        
+    
 
             solGS.pca
                 .checkCachedPca(pcaArgs)
@@ -1141,9 +1152,7 @@ jQuery(document).ready(function () {
                         solGS.pca.cleanUpOnSuccess(pcaPopId);
                     } else {
                         var page = location.pathname;
-                        var pcaUrl = solGS.pca.generatePcaUrl(
-                            pcaArgs.pca_pop_id
-                        );
+                        var pcaUrl = solGS.pca.generatePcaUrl(pcaArgs.pca_pop_id);
                         pcaArgs["analysis_page"] = pcaUrl;
 
                         runPcaBtnId = `#${runPcaBtnId}`;

--- a/js/source/legacy/solGS/pca.js
+++ b/js/source/legacy/solGS/pca.js
@@ -198,6 +198,7 @@ solGS.pca = {
         var pcaArgs;
         var selectedPopDiv = document.getElementById(runPcaElemId);
 
+        var protocolId;
         if (selectedPopDiv) {
             var selectedPopData = selectedPopDiv.dataset;
             var selectedPop = JSON.parse(selectedPopData.selectedPop);
@@ -205,6 +206,23 @@ solGS.pca = {
 
             var pcaArgs = selectedPopData.selectedPop;
             pcaArgs = JSON.parse(pcaArgs);
+            if (pcaArgs.data_structure.match(/dataset/)) {
+                var datasetId = pcaPopId.replace(/dataset_/, "");
+                protocolId = solGS.dataset.getDatasetGenoProtocolId(datasetId);
+            }
+
+            if (!protocolId) {
+                console.log(`No protocolId found, using default`);
+                protocolId = solGS.genotypingProtocol.getGenotypingProtocolId("pca_div");
+                console.log(`pca div protocolId: ${protocolId}`);
+            }
+
+            var page = `/pca/analysis/${pcaPopId}/gp/${protocolId}`;
+            
+            pcaArgs["analysis_type"] = "pca analysis";
+            pcaArgs["genotyping_protocol_id"] = protocolId;
+            pcaArgs["analysis_page"] = page;
+
             if (!selectedPop.data_type) {
                 pcaArgs["data_type"] = this.getSelectedDataType(pcaPopId);
             }
@@ -213,6 +231,9 @@ solGS.pca = {
                 pcaArgs["analysis_page"] = this.generatePcaUrl(pcaPopId);
             }
         }
+
+
+        console.log(`getSelectedPopPcaArgs pcaArgs return : ${pcaArgs}`);
 
         return pcaArgs;
     },

--- a/lib/SGN/Controller/solGS/Files.pm
+++ b/lib/SGN/Controller/solGS/Files.pm
@@ -1027,7 +1027,7 @@ sub get_solgs_dirs {
     my $solgs_lists     = catdir($cluster_shared_dir, 'solgs', 'tempfiles', 'lists');
     my $solgs_datasets  = catdir($cluster_shared_dir, 'solgs', 'tempfiles', 'datasets');
 
-    make_path([$solgs_lists, $solgs_datasets, $analysis_log_dir], { mode => oct('0755') });
+    make_path(($solgs_lists, $solgs_datasets, $analysis_log_dir), { mode => oct('0755') });
     $c->stash->{solgs_lists_dir} = $solgs_lists;
     $c->stash->{solgs_datasets_dir} = $solgs_datasets;
     $c->stash->{analysis_log_dir} = $analysis_log_dir;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
-- ensure the genotyping protocol of a dataset is used in all analyses using genotype data. If a dataset does not have a genotyping protocol property, then use the default or whatever the user selects from the analysis interface. 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
