### PR TITLE
Allow unicode characters in trait names and trait compositions

### DIFF
--- a/lib/SGN/Controller/AJAX/Onto.pm
+++ b/lib/SGN/Controller/AJAX/Onto.pm
@@ -33,6 +33,7 @@ use CXGN::Onto;
 use Data::Dumper;
 use JSON;
 use CXGN::Job;
+use Encode;
 use Cwd;
 
 use namespace::autoclean;
@@ -126,7 +127,7 @@ sub compose_trait: Path('/ajax/onto/store_composed_term') Args(0) {
   #my @ids = $c->req->param("ids[]");
   #print STDERR "Ids array for composing in AJAX Onto = @ids\n";
 
-  my $new_trait_names = decode_json $c->req->param("new_trait_names");
+  my $new_trait_names = decode_json( encode("utf8", $c->req->param("new_trait_names")) );
   my $term_type = $c->req->param("type") ? $c->req->param("type") : 'trait';
   #print STDERR Dumper $new_trait_names;
   my $new_terms;

--- a/lib/SGN/Controller/AJAX/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Trait.pm
@@ -44,7 +44,6 @@ sub create_trait :Path('/ajax/trait/create') {
 
     $name =~ s/^\s+//;
     $name =~ s/\s+$//;
-    $name =~ s/[^[:ascii:]]//g;
     $name =~ s/\|//g;
 
     $definition =~ s/^\s+//;

--- a/lib/SGN/Controller/AJAX/Treatment.pm
+++ b/lib/SGN/Controller/AJAX/Treatment.pm
@@ -44,7 +44,6 @@ sub create_treatment :Path('/ajax/treatment/create') {
 
     $name =~ s/^\s+//;
     $name =~ s/\s+$//;
-    $name =~ s/[^[:ascii:]]//g;
     $name =~ s/\|//g;
 
     $definition =~ s/^\s+//;

--- a/mason/tools/trait_designer.mas
+++ b/mason/tools/trait_designer.mas
@@ -15,7 +15,7 @@
         <div class="form-group">
                 <label class="col-sm-3 control-label"> New trait name: </label>
                 <div class="col-sm-9">
-                    <input style="width:70%;" class="form-control" id="new_trait_name" name="new_trait_name" type="text" placeholder="ASCII characters only. Non-ASCII characters and pipes (|) will be removed."/>
+                    <input style="width:70%;" class="form-control" id="new_trait_name" name="new_trait_name" type="text" placeholder="Pipes (|)  will be removed from name."/>
                 </div>
             </div>
             <div class="form-group">

--- a/mason/tools/treatment_designer.mas
+++ b/mason/tools/treatment_designer.mas
@@ -5,7 +5,7 @@
 
 <div style="text-align: center; margin: 2em 0">
    <h2 style="margin-bottom: 1em">Design new experimental treatments</h2>
-   <h4>Experimental treatments are applied to the stocks of a trial. Subplots, plants, and tissue samples inherit their treatments from their parent stocks.</h4>
+   <h4>Experimental treatments are applied to the stocks of a trial. Subplots, plants, and tissue samples inherit treatments from their parent stocks.</h4>
 
    <h4> Check the <a href='/search/treatments'>treatment search page</a> to see if your treatment has already been made before designing new treatments.</h4>
 
@@ -16,7 +16,7 @@
         <div class="form-group">
                 <label class="col-sm-3 control-label"> New treatment name: </label>
                 <div class="col-sm-9">
-                    <input style="width:70%;" class="form-control" id="new_treatment_name" name="new_treatment_name" type="text" placeholder="ASCII characters only. Non-ASCII characters and pipes (|)  will be removed."/>
+                    <input style="width:70%;" class="form-control" id="new_treatment_name" name="new_treatment_name" type="text" placeholder="Pipes (|)  will be removed from name."/>
                 </div>
             </div>
             <div class="form-group">


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Removes the ASCII character restriction on new cvterms and encodes composed terms in utf8

<!-- If there are relevant issues, link them here: -->
Closes #6154 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
