### PR TITLE
Decision Meeting - fixes date format and utf8

### DIFF
--- a/js/source/entries/decision_meeting.js
+++ b/js/source/entries/decision_meeting.js
@@ -982,7 +982,9 @@
         if (!$sel.length) return;
         $sel.empty().append('<option value="">(choose a list)</option>');
         ((resp && resp.lists) || []).forEach(function(li){
-          $sel.append('<option value="' + (li.list_id || '') + '">' + (li.name || ('List ' + li.list_id)) + '</option>');
+          var id = li.list_id || '';
+          var name = li.name || ('List ' + id);
+          $sel.append($('<option></option>').val(String(id)).text(String(name)));
         });
       });
     }
@@ -1045,8 +1047,8 @@
       var cur = normDecision(current);
       return '' +
         '<select class="dm-decision-select form-control input-sm ' + colorClass(cur) + '" ' +
-                'data-acc="' + String(acc || '').replace(/"/g, '&quot;') + '" ' +
-                'data-bp="' + String(bp || '').replace(/"/g, '&quot;') + '">' +
+                'data-acc="' + escapeHtml(acc) + '" ' +
+                'data-bp="' + escapeHtml(bp) + '">' +
           '<option value="">(select)</option>' +
           '<option value="drop"' +    (cur === 'drop'    ? ' selected' : '') + '>Drop</option>' +
           '<option value="hold"' +    (cur === 'hold'    ? ' selected' : '') + '>Hold</option>' +
@@ -1226,6 +1228,12 @@
         scrollX:true,
         scrollCollapse:true,
         deferRender:true,
+        columnDefs: [{
+          targets: [0, 1, 2, 3, 5, 6, 7, 8],
+          render: function(data, type){
+            return type === 'display' ? escapeHtml(data) : data;
+          }
+        }],
         drawCallback: function () {
           var api = this.api();
           setTimeout(function () {
@@ -1611,6 +1619,10 @@
 
         var dlg = document.getElementById('dm_save_dialog');
         if (dlg) dlg.close('saved');
+
+        document.dispatchEvent(new CustomEvent('meeting:decisions-saved', {
+          detail: { meeting_id: payload.meeting_id }
+        }));
 
         alert((data && (data.message || data.detail)) || 'All decisions were saved successfully.');
       } catch (e) {
@@ -2029,6 +2041,15 @@
     $('#create-meeting-error').hide().text('');
   }
 
+  function dmEscapeHtml(value){
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
   function ensureMultiProgramControl() {
     const $sel = $('#mtg_program');
     if (!$sel.length) return;
@@ -2152,7 +2173,7 @@
   function validate(p){
     if (!p.meeting_name) return 'Please enter the Meeting name.';
     if (!p.location) return 'Please enter the Location.';
-    if (!p.year || isNaN(Number(p.year))) return 'Please enter a valid Year.';
+    if (!/^\d{4}$/.test(p.year)) return 'Please enter the Year in YYYY format.';
     if (!$.trim($('#mtg_date').val() || '')) return 'Please enter the Date in YYYY-MM-DD format.';
     if (!p.date) return 'Please enter a valid Date in YYYY-MM-DD format.';
     if (!p.breeding_programs || p.breeding_programs.length === 0) return 'Please select at least one Breeding Program.';
@@ -2176,7 +2197,9 @@
         (items || []).forEach(function(l){
           const id = l.location_id ?? '';
           const nm = l.name ?? String(id);
-          if (id !== '') $sel.append('<option value="' + id + '">' + nm + '</option>');
+          if (id !== '') {
+            $sel.append($('<option></option>').val(String(id)).text(String(nm)));
+          }
         });
       })
       .fail(function(){});
@@ -2194,10 +2217,11 @@
   }
 
   function normPerson(p){
+    p = p && typeof p === 'object' ? p : {};
     return {
-      first_name:    (p.first_name ?? p.first ?? p.given_name ?? '').trim(),
-      last_name:     (p.last_name  ?? p.last  ?? p.family_name ?? '').trim(),
-      contact_email: (p.contact_email ?? p.email ?? '').trim()
+      first_name:    String(p.first_name ?? p.first ?? p.given_name ?? '').trim(),
+      last_name:     String(p.last_name  ?? p.last  ?? p.family_name ?? '').trim(),
+      contact_email: String(p.contact_email ?? p.email ?? '').trim()
     };
   }
 
@@ -2261,15 +2285,19 @@
       const key = personKey(p);
       const em  = p.contact_email || '';
       const checked = PEOPLE_SELECTED.has(key) ? ' checked' : '';
+      const safeKey = dmEscapeHtml(key);
+      const safeEmail = dmEscapeHtml(em);
+      const safeFirst = dmEscapeHtml(p.first_name || '');
+      const safeLast = dmEscapeHtml(p.last_name || '');
       return (
         '<tr>'
           + '<td class="text-center">'
             + `<input type="checkbox" class="person-check attendee-check" id="${id}"`
-              + ` data-key="${key}" data-email="${em}" data-first="${p.first_name || ''}" data-last="${p.last_name || ''}"${checked}>`
+              + ` data-key="${safeKey}" data-email="${safeEmail}" data-first="${safeFirst}" data-last="${safeLast}"${checked}>`
           + '</td>'
-          + `<td><label for="${id}" class="sr-only">Select ${p.first_name || 'person'}</label>${p.first_name || ''}</td>`
-          + `<td>${p.last_name || ''}</td>`
-          + `<td>${em}</td>`
+          + `<td><label for="${id}" class="sr-only">Select ${safeFirst || 'person'}</label>${safeFirst}</td>`
+          + `<td>${safeLast}</td>`
+          + `<td>${safeEmail}</td>`
         + '</tr>'
       );
     }).join('');
@@ -2405,7 +2433,7 @@
           (items || []).forEach(function(p){
             const id = (p.program_id ?? p.name ?? '');
             const nm = (p.name ?? String(p.program_id));
-            $sel.append('<option value="' + id + '">' + nm + '</option>');
+            $sel.append($('<option></option>').val(String(id)).text(String(nm)));
           });
           upgradeMultiProgramUI(items);
           $sel.trigger('change');
@@ -2485,12 +2513,12 @@
           $('#createMeetingModal').modal('hide');
           document.dispatchEvent(new CustomEvent('meeting:created', { detail: Object.assign({}, p, r) }));
         } else {
-          showErr((r && (r.message || r.detail)) || 'Unexpected server response.');
+          showErr((r && (r.message || r.msg || r.detail)) || 'Unexpected server response.');
         }
       })
       .fail(function (xhr) {
         const serverMsg =
-          (xhr.responseJSON && (xhr.responseJSON.message || xhr.responseJSON.detail)) ||
+          (xhr.responseJSON && (xhr.responseJSON.message || xhr.responseJSON.msg || xhr.responseJSON.detail)) ||
           xhr.responseText ||
           '';
 
@@ -2585,6 +2613,7 @@
     if (j.decisions_saved === true) return true;
     if (String(j.status || '').toLowerCase() === 'saved') return true;
     if (String(j.save_status || '').toLowerCase() === 'saved') return true;
+    if (String(j.saved_status || '').toLowerCase() === 'successfully') return true;
     if (j.saved_at) return true;
     if (j.date_saved) return true;
     return false;
@@ -2770,9 +2799,16 @@
   async function downloadMeetingReport(meetingId){
     var base = (window.DM_API_BASE || '/ajax/decisionmeeting');
     var url = base + '/meeting_report_html?meeting_id=' + encodeURIComponent(meetingId);
+    var reportWindow = window.open('', '_blank');
+
+    if (!reportWindow) {
+      throw new Error('Your browser blocked the report window. Allow pop-ups for this site and try again.');
+    }
+    reportWindow.opener = null;
 
     try {
       var resp = await fetch(url, {
+        cache: 'no-store',
         headers: { 'Accept': 'text/html,application/json' }
       });
 
@@ -2788,16 +2824,19 @@
         }
       }
 
-      window.open(url, '_blank');
+      reportWindow.location.href = url;
     } catch (err) {
-      alert(err && err.message ? err.message : 'Could not open meeting report.');
+      reportWindow.close();
       throw err;
     }
   }
 
-  document.addEventListener('meeting:created', function(){
+  function refreshMeetingTracker(){
     setTimeout(loadMeetingTracker, 200);
-  });
+  }
+
+  document.addEventListener('meeting:created', refreshMeetingTracker);
+  document.addEventListener('meeting:decisions-saved', refreshMeetingTracker);
 
   var dmMeetingResizeTimer = null;
 
@@ -2843,7 +2882,7 @@
       try {
         await downloadMeetingReport(meetingId);
       } catch (e) {
-        alert('Could not open the meeting report.');
+        alert(e && e.message ? e.message : 'Could not open the meeting report.');
       } finally {
         $btn.prop('disabled', false).text(original);
       }

--- a/js/source/entries/decision_meeting.js
+++ b/js/source/entries/decision_meeting.js
@@ -2076,6 +2076,61 @@
     $sel.attr('size', n);
   }
 
+  function twoDigit(value) {
+    return value < 10 ? '0' + value : String(value);
+  }
+
+  function formatMeetingDateForDisplay(date) {
+    return twoDigit(date.getDate()) + '/' +
+      twoDigit(date.getMonth() + 1) + '/' +
+      date.getFullYear();
+  }
+
+  function meetingDateForServer(value) {
+    const match = $.trim(value || '').match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    if (!match) return '';
+
+    const day = Number(match[1]);
+    const month = Number(match[2]);
+    const year = Number(match[3]);
+    const parsed = new Date(year, month - 1, day);
+
+    if (parsed.getFullYear() !== year ||
+        parsed.getMonth() !== month - 1 ||
+        parsed.getDate() !== day) {
+      return '';
+    }
+
+    return String(year) + '-' + twoDigit(month) + '-' + twoDigit(day);
+  }
+
+  function ensureMeetingDatePicker() {
+    const $date = $('#mtg_date');
+    if (!$date.length || !$.fn.datepicker) return;
+    if ($date.data('dmDatePickerInitialized')) return;
+
+    $date
+      .off('changeDate.dmMeetingDate')
+      .on('changeDate.dmMeetingDate', function(event) {
+        if (event && event.date instanceof Date && !isNaN(event.date.getTime())) {
+          $(this).val(formatMeetingDateForDisplay(event.date));
+        }
+      });
+
+    $date.datepicker({
+      // jQuery UI uses dateFormat; Bootstrap Datepicker uses format.
+      dateFormat: 'dd/mm/yy',
+      format: 'dd/mm/yyyy',
+      changeMonth: true,
+      changeYear: true,
+      autoclose: true,
+      onSelect: function(dateText) {
+        $(this).val(dateText);
+      }
+    });
+    $date.data('dmDatePickerInitialized', true);
+  }
+
   function buildPayload(){
     const progVals = $('#mtg_program').val();
     const programs = Array.isArray(progVals)
@@ -2088,7 +2143,7 @@
       breeding_programs:  programs,
       location:           $.trim($('#mtg_location').val() || ''),
       year:               String($('#mtg_year').val() || ''),
-      date:               $('#mtg_date').val() || '',
+      date:               meetingDateForServer($('#mtg_date').val()),
       data:               $.trim($('#mtg_data').val() || ''),
       attendees:          parseAttendees($('#mtg_attendees').val()).join(',')
     };
@@ -2098,7 +2153,8 @@
     if (!p.meeting_name) return 'Please enter the Meeting name.';
     if (!p.location) return 'Please enter the Location.';
     if (!p.year || isNaN(Number(p.year))) return 'Please enter a valid Year.';
-    if (!p.date) return 'Please choose a Date.';
+    if (!$.trim($('#mtg_date').val() || '')) return 'Please enter the Date in DD/MM/YYYY format.';
+    if (!p.date) return 'Please enter a valid Date in DD/MM/YYYY format.';
     if (!p.breeding_programs || p.breeding_programs.length === 0) return 'Please select at least one Breeding Program.';
     return '';
   }
@@ -2108,7 +2164,11 @@
     if (!$sel.length) return;
     if (!API_BASE) return;
     $sel.find('option:not([value=""])').remove();
-    $.ajax({ url: API_BASE + '/locations', dataType: 'json' })
+    $.ajax({
+      url: API_BASE + '/locations',
+      dataType: 'json',
+      cache: false
+    })
       .done(function(items){
         if (!items || !items.length) {
           return;
@@ -2127,6 +2187,11 @@
   let PEOPLE_FILTERED = [];
   let PEOPLE_PAGE = 1;
   let PEOPLE_SELECTED = new Set();
+
+  function dm_updateSelectedAttendeeCount() {
+    const count = PEOPLE_SELECTED.size;
+    $('#people_selected_count').text(count + ' selected');
+  }
 
   function normPerson(p){
     return {
@@ -2184,6 +2249,7 @@
       $tbody.html('<tr><td colspan="4">No people found.</td></tr>');
       $('#people_pager').remove();
       dm_syncSelectAllState();
+      dm_updateSelectedAttendeeCount();
       return;
     }
 
@@ -2216,6 +2282,7 @@
       $('#people_table').closest('.table-responsive').after(pagerHtml);
     }
     dm_syncSelectAllState();
+    dm_updateSelectedAttendeeCount();
   }
 
   function applyPeopleSearch(){
@@ -2283,6 +2350,7 @@
       else PEOPLE_SELECTED.delete(key);
       $row.toggleClass('selected', on);
       dm_syncSelectAllState();
+      dm_updateSelectedAttendeeCount();
     });
 
   $(document)
@@ -2298,24 +2366,22 @@
     });
 
   function dm_collectSelectedNames() {
-    const out = [];
-    $('#people_table tbody input.person-check:checked, #people_table tbody input.attendee-check:checked').each(function(){
-      const $cb   = $(this);
-      const first = String($cb.data('first') || '').trim();
-      const last  = String($cb.data('last') || '').trim();
-      let name    = [first, last].filter(Boolean).join(' ').trim();
-      if (!name) {
-        const $tr   = $cb.closest('tr');
-        const tds   = $tr.children('td');
-        const alt   = [tds.eq(1).text(), tds.eq(2).text()].map(function(s){ return (s || '').trim(); }).filter(Boolean).join(' ');
-        name = alt || String($cb.data('email') || '').trim();
-      }
-      if (name) out.push(name);
-    });
+    const out = PEOPLE_ALL
+      .filter(function(person) {
+        return PEOPLE_SELECTED.has(personKey(person));
+      })
+      .map(function(person) {
+        const name = [person.first_name, person.last_name]
+          .filter(Boolean)
+          .join(' ')
+          .trim();
+        return name || person.contact_email || '';
+      })
+      .filter(Boolean);
     const seen = new Set();
-    return out.filter(function(n){
-      n = n.trim();
-      return n && !seen.has(n) && seen.add(n);
+    return out.filter(function(name){
+      const normalized = name.trim();
+      return normalized && !seen.has(normalized) && seen.add(normalized);
     });
   }
 
@@ -2327,7 +2393,8 @@
       if ($form.length) $form[0].reset();
       const now = new Date();
       $('#mtg_year').val(now.getFullYear());
-      $('#mtg_date').val(now.toISOString().slice(0,10));
+      ensureMeetingDatePicker();
+      $('#mtg_date').val(formatMeetingDateForDisplay(now));
       hideErr();
       ensureMultiProgramControl();
       $.ajax({ url: API_BASE + '/programs', dataType: 'json' })
@@ -2347,6 +2414,7 @@
       $('#people_search').val('');
       PEOPLE_PAGE = 1;
       PEOPLE_SELECTED = new Set();
+      dm_updateSelectedAttendeeCount();
       $('#mtg_attendees').val('');
       dm_loadPeople();
       const $modal = $('#createMeetingModal');
@@ -2504,6 +2572,7 @@
   }
 
   function parseJSON(s){
+    if (s && typeof s === 'object') return s;
     try { return JSON.parse(s || '{}') || {}; }
     catch (e) { return {}; }
   }
@@ -2522,15 +2591,19 @@
   }
 
   function getMeetingProgramsText(j){
+    if (Array.isArray(j.breeding_program_names) && j.breeding_program_names.length) {
+      return j.breeding_program_names.join(', ');
+    }
+    if (j.breeding_program_name) return j.breeding_program_name;
     return Array.isArray(j.breeding_programs)
       ? j.breeding_programs.join(', ')
       : (j.breeding_programs || j.breeding_program || '');
   }
 
   function getMeetingAttendeesText(j){
-    return Array.isArray(j.attendees_list)
-      ? j.attendees_list.join(', ')
-      : (j.attendees || '');
+    if (Array.isArray(j.attendees_list)) return j.attendees_list.join(', ');
+    if (Array.isArray(j.attendees)) return j.attendees.join(', ');
+    return j.attendees || '';
   }
 
   function getMeetingNotesText(j){
@@ -2612,13 +2685,13 @@
 
   function rowsToArrays(rows){
     return (rows || []).map(function(r){
-      var j = parseJSON(r.meeting_json);
+      var j = parseJSON(r.meeting_data || r.meeting_json);
       var id    = r.project_id;
-      var name  = j.meeting_name || r.project_name || '';
-      var date  = j.date || '';
-      var loc   = j.location_name || j.location || '';
-      var progs = getMeetingProgramsText(j);
-      var atts  = getMeetingAttendeesText(j);
+      var name  = r.meeting_name || j.meeting_name || r.project_name || '';
+      var date  = r.meeting_date || j.date || j.meeting_date || '';
+      var loc   = r.meeting_location || j.location_name || j.location || j.location_raw || '';
+      var progs = r.meeting_programs || getMeetingProgramsText(j);
+      var atts  = r.meeting_attendees || getMeetingAttendeesText(j);
       var notes = getMeetingNotesText(j);
       var saved = isMeetingSaved(j);
 
@@ -2656,7 +2729,10 @@
     $tbl.addClass('dm-loading');
 
     try {
-      var r = await fetch(url, { headers:{ 'Accept':'application/json' } });
+      var r = await fetch(url, {
+        cache: 'no-store',
+        headers:{ 'Accept':'application/json' }
+      });
       if (!r.ok) throw new Error('HTTP ' + r.status + ' ' + r.statusText);
       var j = await r.json();
       var rows = j.rows || [];

--- a/js/source/entries/decision_meeting.js
+++ b/js/source/entries/decision_meeting.js
@@ -1074,23 +1074,6 @@
       };
     }
 
-    function extractYearFromStage(stageValue){
-      var stage = String(stageValue || '').trim();
-      if (!stage) return '';
-
-      var parts = stage.split('-').map(function(part){
-        return String(part || '').trim();
-      }).filter(Boolean);
-
-      for (var i = 0; i < parts.length; i++) {
-        if (/^\d{2}$/.test(parts[i]) || /^\d{4}$/.test(parts[i])) {
-          return parts[i];
-        }
-      }
-
-      return '';
-    }
-
     function normalizeStageList(raw){
       var flat = [];
 
@@ -1822,7 +1805,6 @@
         }
 
         var stageText = rowObj ? (rowObj.stage || '') : '';
-        var originalYear = rowObj ? (rowObj.year || '') : '';
         var previousNewStage = rowObj ? (rowObj.new_stage || '') : '';
         var stockId = rowObj ? (rowObj.stock_id || '') : '';
 
@@ -1883,7 +1865,7 @@
         }
 
         var selectedStage = '';
-        var stageYear = v === 'drop' ? (extractYearFromStage(stageText) || originalYear) : meetingYearFull;
+        var stageYear = meetingYearFull;
         if (v === 'advance' || v === 'jump') {
           $.ajax({
             url: (window.DM_API_BASE || '/ajax/decisionmeeting') + '/compute_new_stage',
@@ -2094,61 +2076,6 @@
     $sel.attr('size', n);
   }
 
-  function twoDigit(value) {
-    return value < 10 ? '0' + value : String(value);
-  }
-
-  function formatMeetingDateForDisplay(date) {
-    return twoDigit(date.getDate()) + '/' +
-      twoDigit(date.getMonth() + 1) + '/' +
-      date.getFullYear();
-  }
-
-  function meetingDateForServer(value) {
-    const match = $.trim(value || '').match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
-    if (!match) return '';
-
-    const day = Number(match[1]);
-    const month = Number(match[2]);
-    const year = Number(match[3]);
-    const parsed = new Date(year, month - 1, day);
-
-    if (parsed.getFullYear() !== year ||
-        parsed.getMonth() !== month - 1 ||
-        parsed.getDate() !== day) {
-      return '';
-    }
-
-    return String(year) + '-' + twoDigit(month) + '-' + twoDigit(day);
-  }
-
-  function ensureMeetingDatePicker() {
-    const $date = $('#mtg_date');
-    if (!$date.length || !$.fn.datepicker) return;
-    if ($date.data('dmDatePickerInitialized')) return;
-
-    $date
-      .off('changeDate.dmMeetingDate')
-      .on('changeDate.dmMeetingDate', function(event) {
-        if (event && event.date instanceof Date && !isNaN(event.date.getTime())) {
-          $(this).val(formatMeetingDateForDisplay(event.date));
-        }
-      });
-
-    $date.datepicker({
-      // jQuery UI uses dateFormat; Bootstrap Datepicker uses format.
-      dateFormat: 'dd/mm/yy',
-      format: 'dd/mm/yyyy',
-      changeMonth: true,
-      changeYear: true,
-      autoclose: true,
-      onSelect: function(dateText) {
-        $(this).val(dateText);
-      }
-    });
-    $date.data('dmDatePickerInitialized', true);
-  }
-
   function buildPayload(){
     const progVals = $('#mtg_program').val();
     const programs = Array.isArray(progVals)
@@ -2161,7 +2088,7 @@
       breeding_programs:  programs,
       location:           $.trim($('#mtg_location').val() || ''),
       year:               String($('#mtg_year').val() || ''),
-      date:               meetingDateForServer($('#mtg_date').val()),
+      date:               $('#mtg_date').val() || '',
       data:               $.trim($('#mtg_data').val() || ''),
       attendees:          parseAttendees($('#mtg_attendees').val()).join(',')
     };
@@ -2171,8 +2098,7 @@
     if (!p.meeting_name) return 'Please enter the Meeting name.';
     if (!p.location) return 'Please enter the Location.';
     if (!p.year || isNaN(Number(p.year))) return 'Please enter a valid Year.';
-    if (!$.trim($('#mtg_date').val() || '')) return 'Please enter the Date in DD/MM/YYYY format.';
-    if (!p.date) return 'Please enter a valid Date in DD/MM/YYYY format.';
+    if (!p.date) return 'Please choose a Date.';
     if (!p.breeding_programs || p.breeding_programs.length === 0) return 'Please select at least one Breeding Program.';
     return '';
   }
@@ -2182,11 +2108,7 @@
     if (!$sel.length) return;
     if (!API_BASE) return;
     $sel.find('option:not([value=""])').remove();
-    $.ajax({
-      url: API_BASE + '/locations',
-      dataType: 'json',
-      cache: false
-    })
+    $.ajax({ url: API_BASE + '/locations', dataType: 'json' })
       .done(function(items){
         if (!items || !items.length) {
           return;
@@ -2205,11 +2127,6 @@
   let PEOPLE_FILTERED = [];
   let PEOPLE_PAGE = 1;
   let PEOPLE_SELECTED = new Set();
-
-  function dm_updateSelectedAttendeeCount() {
-    const count = PEOPLE_SELECTED.size;
-    $('#people_selected_count').text(count + ' selected');
-  }
 
   function normPerson(p){
     return {
@@ -2267,7 +2184,6 @@
       $tbody.html('<tr><td colspan="4">No people found.</td></tr>');
       $('#people_pager').remove();
       dm_syncSelectAllState();
-      dm_updateSelectedAttendeeCount();
       return;
     }
 
@@ -2300,7 +2216,6 @@
       $('#people_table').closest('.table-responsive').after(pagerHtml);
     }
     dm_syncSelectAllState();
-    dm_updateSelectedAttendeeCount();
   }
 
   function applyPeopleSearch(){
@@ -2368,7 +2283,6 @@
       else PEOPLE_SELECTED.delete(key);
       $row.toggleClass('selected', on);
       dm_syncSelectAllState();
-      dm_updateSelectedAttendeeCount();
     });
 
   $(document)
@@ -2384,23 +2298,24 @@
     });
 
   function dm_collectSelectedNames() {
-    const out = PEOPLE_ALL
-      .filter(function(person) {
-        return PEOPLE_SELECTED.has(personKey(person));
-      })
-      .map(function(person) {
-        const name = [person.first_name, person.last_name]
-          .filter(Boolean)
-          .join(' ')
-          .trim();
-        return name || person.contact_email || '';
-      })
-      .filter(Boolean);
-
+    const out = [];
+    $('#people_table tbody input.person-check:checked, #people_table tbody input.attendee-check:checked').each(function(){
+      const $cb   = $(this);
+      const first = String($cb.data('first') || '').trim();
+      const last  = String($cb.data('last') || '').trim();
+      let name    = [first, last].filter(Boolean).join(' ').trim();
+      if (!name) {
+        const $tr   = $cb.closest('tr');
+        const tds   = $tr.children('td');
+        const alt   = [tds.eq(1).text(), tds.eq(2).text()].map(function(s){ return (s || '').trim(); }).filter(Boolean).join(' ');
+        name = alt || String($cb.data('email') || '').trim();
+      }
+      if (name) out.push(name);
+    });
     const seen = new Set();
-    return out.filter(function(name){
-      const normalized = name.trim();
-      return normalized && !seen.has(normalized) && seen.add(normalized);
+    return out.filter(function(n){
+      n = n.trim();
+      return n && !seen.has(n) && seen.add(n);
     });
   }
 
@@ -2412,8 +2327,7 @@
       if ($form.length) $form[0].reset();
       const now = new Date();
       $('#mtg_year').val(now.getFullYear());
-      ensureMeetingDatePicker();
-      $('#mtg_date').val(formatMeetingDateForDisplay(now));
+      $('#mtg_date').val(now.toISOString().slice(0,10));
       hideErr();
       ensureMultiProgramControl();
       $.ajax({ url: API_BASE + '/programs', dataType: 'json' })
@@ -2433,7 +2347,6 @@
       $('#people_search').val('');
       PEOPLE_PAGE = 1;
       PEOPLE_SELECTED = new Set();
-      dm_updateSelectedAttendeeCount();
       $('#mtg_attendees').val('');
       dm_loadPeople();
       const $modal = $('#createMeetingModal');
@@ -2591,7 +2504,6 @@
   }
 
   function parseJSON(s){
-    if (s && typeof s === 'object') return s;
     try { return JSON.parse(s || '{}') || {}; }
     catch (e) { return {}; }
   }
@@ -2610,19 +2522,15 @@
   }
 
   function getMeetingProgramsText(j){
-    if (Array.isArray(j.breeding_program_names) && j.breeding_program_names.length) {
-      return j.breeding_program_names.join(', ');
-    }
-    if (j.breeding_program_name) return j.breeding_program_name;
     return Array.isArray(j.breeding_programs)
       ? j.breeding_programs.join(', ')
       : (j.breeding_programs || j.breeding_program || '');
   }
 
   function getMeetingAttendeesText(j){
-    if (Array.isArray(j.attendees_list)) return j.attendees_list.join(', ');
-    if (Array.isArray(j.attendees)) return j.attendees.join(', ');
-    return j.attendees || '';
+    return Array.isArray(j.attendees_list)
+      ? j.attendees_list.join(', ')
+      : (j.attendees || '');
   }
 
   function getMeetingNotesText(j){
@@ -2704,13 +2612,13 @@
 
   function rowsToArrays(rows){
     return (rows || []).map(function(r){
-      var j = parseJSON(r.meeting_data || r.meeting_json);
+      var j = parseJSON(r.meeting_json);
       var id    = r.project_id;
-      var name  = r.meeting_name || j.meeting_name || r.project_name || '';
-      var date  = r.meeting_date || j.date || j.meeting_date || '';
-      var loc   = r.meeting_location || j.location_name || j.location || j.location_raw || '';
-      var progs = r.meeting_programs || getMeetingProgramsText(j);
-      var atts  = r.meeting_attendees || getMeetingAttendeesText(j);
+      var name  = j.meeting_name || r.project_name || '';
+      var date  = j.date || '';
+      var loc   = j.location_name || j.location || '';
+      var progs = getMeetingProgramsText(j);
+      var atts  = getMeetingAttendeesText(j);
       var notes = getMeetingNotesText(j);
       var saved = isMeetingSaved(j);
 
@@ -2748,10 +2656,7 @@
     $tbl.addClass('dm-loading');
 
     try {
-      var r = await fetch(url, {
-        cache: 'no-store',
-        headers:{ 'Accept':'application/json' }
-      });
+      var r = await fetch(url, { headers:{ 'Accept':'application/json' } });
       if (!r.ok) throw new Error('HTTP ' + r.status + ' ' + r.statusText);
       var j = await r.json();
       var rows = j.rows || [];

--- a/js/source/entries/decision_meeting.js
+++ b/js/source/entries/decision_meeting.js
@@ -1810,7 +1810,7 @@
 
         var meetingYearFull = '';
         if (meetingDate) {
-          var m = String(meetingDate).match(/^(\d{4})-/);
+          var m = String(meetingDate).match(/^(\d{4})[\/-]/);
           if (m) {
             meetingYearFull = m[1];
           } else {
@@ -2081,18 +2081,18 @@
   }
 
   function formatMeetingDateForDisplay(date) {
-    return twoDigit(date.getDate()) + '/' +
-      twoDigit(date.getMonth() + 1) + '/' +
-      date.getFullYear();
+    return date.getFullYear() + '-' +
+      twoDigit(date.getMonth() + 1) + '-' +
+      twoDigit(date.getDate());
   }
 
   function meetingDateForServer(value) {
-    const match = $.trim(value || '').match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    const match = $.trim(value || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
     if (!match) return '';
 
-    const day = Number(match[1]);
+    const year = Number(match[1]);
     const month = Number(match[2]);
-    const year = Number(match[3]);
+    const day = Number(match[3]);
     const parsed = new Date(year, month - 1, day);
 
     if (parsed.getFullYear() !== year ||
@@ -2119,8 +2119,8 @@
 
     $date.datepicker({
       // jQuery UI uses dateFormat; Bootstrap Datepicker uses format.
-      dateFormat: 'dd/mm/yy',
-      format: 'dd/mm/yyyy',
+      dateFormat: 'yy-mm-dd',
+      format: 'yyyy-mm-dd',
       changeMonth: true,
       changeYear: true,
       autoclose: true,
@@ -2153,8 +2153,8 @@
     if (!p.meeting_name) return 'Please enter the Meeting name.';
     if (!p.location) return 'Please enter the Location.';
     if (!p.year || isNaN(Number(p.year))) return 'Please enter a valid Year.';
-    if (!$.trim($('#mtg_date').val() || '')) return 'Please enter the Date in DD/MM/YYYY format.';
-    if (!p.date) return 'Please enter a valid Date in DD/MM/YYYY format.';
+    if (!$.trim($('#mtg_date').val() || '')) return 'Please enter the Date in YYYY-MM-DD format.';
+    if (!p.date) return 'Please enter a valid Date in YYYY-MM-DD format.';
     if (!p.breeding_programs || p.breeding_programs.length === 0) return 'Please select at least one Breeding Program.';
     return '';
   }
@@ -2610,6 +2610,23 @@
     return j.notes || j.meeting_notes || j.data || '';
   }
 
+  function normalizeMeetingDateForDisplay(value){
+    var match = String(value || '').trim().match(/^(\d{4})[\/-](\d{2})[\/-](\d{2})$/);
+    if (!match) return '';
+
+    var year = Number(match[1]);
+    var month = Number(match[2]);
+    var day = Number(match[3]);
+    var parsed = new Date(year, month - 1, day);
+    if (parsed.getFullYear() !== year ||
+        parsed.getMonth() !== month - 1 ||
+        parsed.getDate() !== day) {
+      return '';
+    }
+
+    return match[1] + '-' + match[2] + '-' + match[3];
+  }
+
   function meetingCheckboxHtml(id, name, date, saved){
     if (saved) {
       return '<span class="dm-meeting-select-disabled" title="This meeting has already been saved.">Saved</span>';
@@ -2688,7 +2705,7 @@
       var j = parseJSON(r.meeting_data || r.meeting_json);
       var id    = r.project_id;
       var name  = r.meeting_name || j.meeting_name || r.project_name || '';
-      var date  = r.meeting_date || j.date || j.meeting_date || '';
+      var date  = normalizeMeetingDateForDisplay(r.meeting_date || j.date || j.meeting_date || '');
       var loc   = r.meeting_location || j.location_name || j.location || j.location_raw || '';
       var progs = r.meeting_programs || getMeetingProgramsText(j);
       var atts  = r.meeting_attendees || getMeetingAttendeesText(j);

--- a/js/source/entries/decision_meeting.js
+++ b/js/source/entries/decision_meeting.js
@@ -2182,7 +2182,11 @@
     if (!$sel.length) return;
     if (!API_BASE) return;
     $sel.find('option:not([value=""])').remove();
-    $.ajax({ url: API_BASE + '/locations', dataType: 'json' })
+    $.ajax({
+      url: API_BASE + '/locations',
+      dataType: 'json',
+      cache: false
+    })
       .done(function(items){
         if (!items || !items.length) {
           return;

--- a/js/source/entries/decision_meeting.js
+++ b/js/source/entries/decision_meeting.js
@@ -2094,6 +2094,61 @@
     $sel.attr('size', n);
   }
 
+  function twoDigit(value) {
+    return value < 10 ? '0' + value : String(value);
+  }
+
+  function formatMeetingDateForDisplay(date) {
+    return twoDigit(date.getDate()) + '/' +
+      twoDigit(date.getMonth() + 1) + '/' +
+      date.getFullYear();
+  }
+
+  function meetingDateForServer(value) {
+    const match = $.trim(value || '').match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    if (!match) return '';
+
+    const day = Number(match[1]);
+    const month = Number(match[2]);
+    const year = Number(match[3]);
+    const parsed = new Date(year, month - 1, day);
+
+    if (parsed.getFullYear() !== year ||
+        parsed.getMonth() !== month - 1 ||
+        parsed.getDate() !== day) {
+      return '';
+    }
+
+    return String(year) + '-' + twoDigit(month) + '-' + twoDigit(day);
+  }
+
+  function ensureMeetingDatePicker() {
+    const $date = $('#mtg_date');
+    if (!$date.length || !$.fn.datepicker) return;
+    if ($date.data('dmDatePickerInitialized')) return;
+
+    $date
+      .off('changeDate.dmMeetingDate')
+      .on('changeDate.dmMeetingDate', function(event) {
+        if (event && event.date instanceof Date && !isNaN(event.date.getTime())) {
+          $(this).val(formatMeetingDateForDisplay(event.date));
+        }
+      });
+
+    $date.datepicker({
+      // jQuery UI uses dateFormat; Bootstrap Datepicker uses format.
+      dateFormat: 'dd/mm/yy',
+      format: 'dd/mm/yyyy',
+      changeMonth: true,
+      changeYear: true,
+      autoclose: true,
+      onSelect: function(dateText) {
+        $(this).val(dateText);
+      }
+    });
+    $date.data('dmDatePickerInitialized', true);
+  }
+
   function buildPayload(){
     const progVals = $('#mtg_program').val();
     const programs = Array.isArray(progVals)
@@ -2106,7 +2161,7 @@
       breeding_programs:  programs,
       location:           $.trim($('#mtg_location').val() || ''),
       year:               String($('#mtg_year').val() || ''),
-      date:               $('#mtg_date').val() || '',
+      date:               meetingDateForServer($('#mtg_date').val()),
       data:               $.trim($('#mtg_data').val() || ''),
       attendees:          parseAttendees($('#mtg_attendees').val()).join(',')
     };
@@ -2116,7 +2171,8 @@
     if (!p.meeting_name) return 'Please enter the Meeting name.';
     if (!p.location) return 'Please enter the Location.';
     if (!p.year || isNaN(Number(p.year))) return 'Please enter a valid Year.';
-    if (!p.date) return 'Please choose a Date.';
+    if (!$.trim($('#mtg_date').val() || '')) return 'Please enter the Date in DD/MM/YYYY format.';
+    if (!p.date) return 'Please enter a valid Date in DD/MM/YYYY format.';
     if (!p.breeding_programs || p.breeding_programs.length === 0) return 'Please select at least one Breeding Program.';
     return '';
   }
@@ -2345,7 +2401,8 @@
       if ($form.length) $form[0].reset();
       const now = new Date();
       $('#mtg_year').val(now.getFullYear());
-      $('#mtg_date').val(now.toISOString().slice(0,10));
+      ensureMeetingDatePicker();
+      $('#mtg_date').val(formatMeetingDateForDisplay(now));
       hideErr();
       ensureMultiProgramControl();
       $.ajax({ url: API_BASE + '/programs', dataType: 'json' })
@@ -2522,6 +2579,7 @@
   }
 
   function parseJSON(s){
+    if (s && typeof s === 'object') return s;
     try { return JSON.parse(s || '{}') || {}; }
     catch (e) { return {}; }
   }
@@ -2540,15 +2598,19 @@
   }
 
   function getMeetingProgramsText(j){
+    if (Array.isArray(j.breeding_program_names) && j.breeding_program_names.length) {
+      return j.breeding_program_names.join(', ');
+    }
+    if (j.breeding_program_name) return j.breeding_program_name;
     return Array.isArray(j.breeding_programs)
       ? j.breeding_programs.join(', ')
       : (j.breeding_programs || j.breeding_program || '');
   }
 
   function getMeetingAttendeesText(j){
-    return Array.isArray(j.attendees_list)
-      ? j.attendees_list.join(', ')
-      : (j.attendees || '');
+    if (Array.isArray(j.attendees_list)) return j.attendees_list.join(', ');
+    if (Array.isArray(j.attendees)) return j.attendees.join(', ');
+    return j.attendees || '';
   }
 
   function getMeetingNotesText(j){
@@ -2630,13 +2692,13 @@
 
   function rowsToArrays(rows){
     return (rows || []).map(function(r){
-      var j = parseJSON(r.meeting_json);
+      var j = parseJSON(r.meeting_data || r.meeting_json);
       var id    = r.project_id;
-      var name  = j.meeting_name || r.project_name || '';
-      var date  = j.date || '';
-      var loc   = j.location_name || j.location || '';
-      var progs = getMeetingProgramsText(j);
-      var atts  = getMeetingAttendeesText(j);
+      var name  = r.meeting_name || j.meeting_name || r.project_name || '';
+      var date  = r.meeting_date || j.date || j.meeting_date || '';
+      var loc   = r.meeting_location || j.location_name || j.location || j.location_raw || '';
+      var progs = r.meeting_programs || getMeetingProgramsText(j);
+      var atts  = r.meeting_attendees || getMeetingAttendeesText(j);
       var notes = getMeetingNotesText(j);
       var saved = isMeetingSaved(j);
 
@@ -2674,7 +2736,10 @@
     $tbl.addClass('dm-loading');
 
     try {
-      var r = await fetch(url, { headers:{ 'Accept':'application/json' } });
+      var r = await fetch(url, {
+        cache: 'no-store',
+        headers:{ 'Accept':'application/json' }
+      });
       if (!r.ok) throw new Error('HTTP ' + r.status + ' ' + r.statusText);
       var j = await r.json();
       var rows = j.rows || [];

--- a/js/source/entries/decision_meeting.js
+++ b/js/source/entries/decision_meeting.js
@@ -2206,6 +2206,11 @@
   let PEOPLE_PAGE = 1;
   let PEOPLE_SELECTED = new Set();
 
+  function dm_updateSelectedAttendeeCount() {
+    const count = PEOPLE_SELECTED.size;
+    $('#people_selected_count').text(count + ' selected');
+  }
+
   function normPerson(p){
     return {
       first_name:    (p.first_name ?? p.first ?? p.given_name ?? '').trim(),
@@ -2262,6 +2267,7 @@
       $tbody.html('<tr><td colspan="4">No people found.</td></tr>');
       $('#people_pager').remove();
       dm_syncSelectAllState();
+      dm_updateSelectedAttendeeCount();
       return;
     }
 
@@ -2294,6 +2300,7 @@
       $('#people_table').closest('.table-responsive').after(pagerHtml);
     }
     dm_syncSelectAllState();
+    dm_updateSelectedAttendeeCount();
   }
 
   function applyPeopleSearch(){
@@ -2361,6 +2368,7 @@
       else PEOPLE_SELECTED.delete(key);
       $row.toggleClass('selected', on);
       dm_syncSelectAllState();
+      dm_updateSelectedAttendeeCount();
     });
 
   $(document)
@@ -2376,24 +2384,23 @@
     });
 
   function dm_collectSelectedNames() {
-    const out = [];
-    $('#people_table tbody input.person-check:checked, #people_table tbody input.attendee-check:checked').each(function(){
-      const $cb   = $(this);
-      const first = String($cb.data('first') || '').trim();
-      const last  = String($cb.data('last') || '').trim();
-      let name    = [first, last].filter(Boolean).join(' ').trim();
-      if (!name) {
-        const $tr   = $cb.closest('tr');
-        const tds   = $tr.children('td');
-        const alt   = [tds.eq(1).text(), tds.eq(2).text()].map(function(s){ return (s || '').trim(); }).filter(Boolean).join(' ');
-        name = alt || String($cb.data('email') || '').trim();
-      }
-      if (name) out.push(name);
-    });
+    const out = PEOPLE_ALL
+      .filter(function(person) {
+        return PEOPLE_SELECTED.has(personKey(person));
+      })
+      .map(function(person) {
+        const name = [person.first_name, person.last_name]
+          .filter(Boolean)
+          .join(' ')
+          .trim();
+        return name || person.contact_email || '';
+      })
+      .filter(Boolean);
+
     const seen = new Set();
-    return out.filter(function(n){
-      n = n.trim();
-      return n && !seen.has(n) && seen.add(n);
+    return out.filter(function(name){
+      const normalized = name.trim();
+      return normalized && !seen.has(normalized) && seen.add(normalized);
     });
   }
 
@@ -2426,6 +2433,7 @@
       $('#people_search').val('');
       PEOPLE_PAGE = 1;
       PEOPLE_SELECTED = new Set();
+      dm_updateSelectedAttendeeCount();
       $('#mtg_attendees').val('');
       dm_loadPeople();
       const $modal = $('#createMeetingModal');

--- a/lib/CXGN/Trial/TrialCreate.pm
+++ b/lib/CXGN/Trial/TrialCreate.pm
@@ -153,6 +153,7 @@ has 'trial_description' => (isa => 'Maybe[Str]', is => 'rw', predicate => 'has_t
 has 'trial_location' => (isa => 'Maybe[Str]', is => 'rw', predicate => 'has_trial_location', required => 0,);
 has 'design_type' => (isa => 'Maybe[Str]', is => 'rw', predicate => 'has_design_type', required => 0);
 has 'design' => (isa => 'HashRef[HashRef]|Undef', is => 'rw', predicate => 'has_design', required => 0);
+has 'skip_design_store' => (isa => 'Bool', is => 'rw', required => 0, default => 0);
 has 'trial_name' => (isa => 'Str', is => 'rw', predicate => 'has_trial_name', required => 1);
 has 'trial_type' => (isa => 'Str', is => 'rw', predicate => 'has_trial_type', required => 0);
 has 'trial_type_value' => (isa => 'Str', is => 'rw', predicate => 'has_trial_type_value', required => 0);
@@ -467,6 +468,13 @@ sub save_trial {
     if ($design_type eq 'greenhouse') {
         my $has_plants_cvterm = SGN::Model::Cvterm->get_cvterm_row($chado_schema, 'project_has_plant_entries', 'project_property');
         $project->create_projectprops({ $has_plants_cvterm->name() => 'varies' });
+    }
+
+    # Some project types, such as decision meetings, deliberately have no
+    # observation-unit layout. Their project and metadata records above are
+    # complete without running the plot/accession design validator or store.
+    if ($self->get_skip_design_store()) {
+        return { trial_id => $project->project_id };
     }
 
     print STDERR "NOW CALLING TRIAl DESIGN STORE...\n";

--- a/lib/SGN/Controller/AJAX/DecisionMeeting.pm
+++ b/lib/SGN/Controller/AJAX/DecisionMeeting.pm
@@ -79,6 +79,75 @@ sub _normalize_meeting_date {
     return $canonical;
 }
 
+sub _meeting_program_names {
+    my ($self, $meeting_data, $program_id_to_name) = @_;
+
+    return [] unless ref($meeting_data) eq 'HASH';
+    $program_id_to_name = {} unless ref($program_id_to_name) eq 'HASH';
+
+    my @raw_programs;
+    if (ref($meeting_data->{breeding_program_names}) eq 'ARRAY'
+        && @{$meeting_data->{breeding_program_names}}) {
+        @raw_programs = @{$meeting_data->{breeding_program_names}};
+    }
+    elsif (defined($meeting_data->{breeding_program_name})
+        && !ref($meeting_data->{breeding_program_name})
+        && $meeting_data->{breeding_program_name} ne '') {
+        @raw_programs = ($meeting_data->{breeding_program_name});
+    }
+    elsif (ref($meeting_data->{breeding_programs}) eq 'ARRAY'
+        && @{$meeting_data->{breeding_programs}}) {
+        @raw_programs = @{$meeting_data->{breeding_programs}};
+    }
+    elsif (defined($meeting_data->{breeding_program})
+        && !ref($meeting_data->{breeding_program})
+        && $meeting_data->{breeding_program} ne '') {
+        @raw_programs = split(/\s*,\s*/, $meeting_data->{breeding_program});
+    }
+    elsif (defined($meeting_data->{breeding_program_choice})
+        && !ref($meeting_data->{breeding_program_choice})
+        && $meeting_data->{breeding_program_choice} ne '') {
+        @raw_programs = ($meeting_data->{breeding_program_choice});
+    }
+
+    my (@programs, %seen);
+    foreach my $raw_program (@raw_programs) {
+        next if !defined($raw_program) || ref($raw_program);
+
+        my $program = $self->_trim($raw_program);
+        next if $program eq '';
+        $program = $program_id_to_name->{$program}
+            if exists $program_id_to_name->{$program};
+
+        my $key = lc($program);
+        next if $seen{$key}++;
+        push @programs, $program;
+    }
+
+    return \@programs;
+}
+
+sub _is_meeting_saved {
+    my ($self, $meeting_data) = @_;
+    return 0 unless ref($meeting_data) eq 'HASH';
+
+    foreach my $key (qw(saved is_saved meeting_saved decisions_saved)) {
+        next unless exists $meeting_data->{$key};
+        my $value = $meeting_data->{$key};
+        return 1 if ref($value) && eval { $value ? 1 : 0 };
+        return 1 if !ref($value)
+            && ("$value" eq '1' || lc("$value") eq 'true');
+    }
+    return 1 if defined($meeting_data->{saved_at}) && $meeting_data->{saved_at} ne '';
+    return 1 if defined($meeting_data->{date_saved}) && $meeting_data->{date_saved} ne '';
+
+    my $status = lc($meeting_data->{saved_status}
+        // $meeting_data->{save_status}
+        // $meeting_data->{status}
+        // '');
+    return $status eq 'successfully' || $status eq 'saved';
+}
+
 sub lists : Path('lists') : Args(0) : ActionClass('REST') {}
 sub lists_GET {
     my ($self, $c) = @_;
@@ -245,6 +314,14 @@ sub _decision_rows_entity {
     my $year_prop_name  = 'acquisition date';
 
     my $list = CXGN::List->new({ dbh => $dbh, list_id => $list_id });
+    my $current_owner_id = eval {
+        $c->user->get_object->get_sp_person_id;
+    };
+    return { rows => [] }
+        unless defined($current_owner_id)
+            && defined($list->owner)
+            && $list->owner == $current_owner_id;
+
     my $els  = $list->elements || [];
     my @accessions = grep { defined $_ && $_ ne '' } @$els;
 
@@ -277,6 +354,8 @@ sub _decision_rows_entity {
         push @program_names, $nm;
     }
 
+    my @meeting_programs;
+    my $meeting_program_metadata_present = 0;
     if (!$selected_program && $meeting_id) {
         my $sth = $dbh->prepare(q{
             SELECT pp.value
@@ -300,21 +379,12 @@ sub _decision_rows_entity {
             my ($decoded) = $self->_decode_meeting_json($meeting_json);
             $decoded = {} unless ref($decoded) eq 'HASH';
 
-            if ($decoded->{breeding_program_name}) {
-                $selected_program = $decoded->{breeding_program_name};
-            }
-            elsif ($decoded->{breeding_program_choice}) {
-                my $bp = $decoded->{breeding_program_choice};
-                $selected_program = exists $program_id_to_name{$bp}
-                    ? $program_id_to_name{$bp}
-                    : $bp;
-            }
-            elsif ($decoded->{breeding_program}) {
-                my $bp = $decoded->{breeding_program};
-                $selected_program = exists $program_id_to_name{$bp}
-                    ? $program_id_to_name{$bp}
-                    : $bp;
-            }
+            my $program_names = $self->_meeting_program_names(
+                $decoded,
+                \%program_id_to_name,
+            );
+            @meeting_programs = @$program_names;
+            $meeting_program_metadata_present = @meeting_programs ? 1 : 0;
         }
     }
 
@@ -322,7 +392,19 @@ sub _decision_rows_entity {
         $selected_program = $program_id_to_name{$selected_program};
     }
 
-    my @programs_to_use = $selected_program ? ($selected_program) : @program_names;
+    my %known_program_name = map { $_ => 1 } @program_names;
+    my @programs_to_use;
+    if ($selected_program) {
+        @programs_to_use = $known_program_name{$selected_program}
+            ? ($selected_program)
+            : ();
+    }
+    elsif ($meeting_program_metadata_present) {
+        @programs_to_use = grep { $known_program_name{$_} } @meeting_programs;
+    }
+    else {
+        @programs_to_use = @program_names;
+    }
 
     my %pedigree_by_acc;
     if (@accessions) {
@@ -1753,6 +1835,154 @@ sub _merge_decisions_into_meeting {
     return \%merged;
 }
 
+sub _validated_decisions_for_save {
+    my ($self, %args) = @_;
+
+    my $c            = $args{c};
+    my $schema       = $args{schema};
+    my $meeting_data = $args{meeting_data};
+    my $payload      = $args{payload};
+
+    return (undef, ['Missing request context']) unless $c;
+    return (undef, ['Missing database schema']) unless $schema;
+    return (undef, ['Stored meeting metadata is invalid'])
+        unless ref($meeting_data) eq 'HASH';
+    return (undef, ['Missing or invalid JSON payload'])
+        unless ref($payload) eq 'HASH';
+
+    my $list_id = $payload->{list_id};
+    return (undef, ['Missing list_id in payload'])
+        unless defined($list_id) && !ref($list_id) && $list_id =~ /^\d+$/;
+
+    my $submitted_rows = $payload->{accessions};
+    return (undef, ['The accessions field must be an array'])
+        unless ref($submitted_rows) eq 'ARRAY';
+    return (undef, ['There are no accession decisions to save'])
+        unless @$submitted_rows;
+
+    my $meeting_date = $self->_normalize_meeting_date(
+        $meeting_data->{date} // $meeting_data->{meeting_date} // ''
+    );
+    return (undef, ['The selected meeting does not have a valid date'])
+        unless $meeting_date;
+    my ($meeting_year) = $meeting_date =~ /^(\d{4})-/;
+
+    my $entity = eval {
+        $self->_decision_rows_entity(
+            $c,
+            list_id    => $list_id,
+            meeting_id => $payload->{meeting_id},
+        );
+    };
+    return (undef, ['Could not load the current accession decisions'])
+        if $@ || ref($entity) ne 'HASH';
+
+    my $current_rows = $entity->{rows};
+    return (undef, ['Could not load the current accession decisions'])
+        unless ref($current_rows) eq 'ARRAY';
+
+    my %current_lookup;
+    foreach my $row (@$current_rows) {
+        next unless ref($row) eq 'HASH';
+        my $key = join("\t", lc($row->{accession} || ''), lc($row->{breeding_program} || ''));
+        $current_lookup{$key} = $row if $key ne "\t";
+    }
+
+    my (@candidate_rows, @errors, %seen);
+    foreach my $submitted (@$submitted_rows) {
+        unless (ref($submitted) eq 'HASH') {
+            push @errors, 'Each accession decision must be an object.';
+            next;
+        }
+
+        my $accession = $self->_trim($submitted->{accession});
+        my $program   = $self->_trim($submitted->{breeding_program});
+        my $key       = join("\t", lc($accession), lc($program));
+
+        if ($accession eq '' || $program eq '') {
+            push @errors, 'Each decision must include an accession and breeding program.';
+            next;
+        }
+        if ($seen{$key}++) {
+            push @errors, "Duplicate decision for accession '$accession' and breeding program '$program'.";
+            next;
+        }
+
+        my $target = $current_lookup{$key};
+        unless ($target) {
+            push @errors, "Accession '$accession' and breeding program '$program' are not in the selected list and meeting.";
+            next;
+        }
+
+        my $decision = lc($self->_trim($submitted->{decision}));
+        my $new_stage = $self->_trim($submitted->{new_stage});
+        my $notes = defined($submitted->{notes}) && !ref($submitted->{notes})
+            ? "$submitted->{notes}"
+            : '';
+        my $save_comment = defined($submitted->{save_comment}) && !ref($submitted->{save_comment})
+            ? "$submitted->{save_comment}"
+            : '';
+
+        push @candidate_rows, {
+            stock_id         => $target->{stock_id},
+            accession        => $target->{accession},
+            breeding_program => $target->{breeding_program},
+            previous_stage   => $target->{stage} || '',
+            decision         => $decision,
+            new_stage        => $new_stage,
+            notes            => $notes,
+            save_comment     => $save_comment,
+        };
+    }
+
+    return (undef, \@errors) if @errors;
+
+    my ($validation_errors, $unmatched_rows) = $self->_validate_uploaded_decision_rows(
+        c            => $c,
+        schema       => $schema,
+        meeting_year => $meeting_year,
+        current_rows => $current_rows,
+        parsed_rows  => \@candidate_rows,
+    );
+    push @errors, @$validation_errors if $validation_errors;
+    if ($unmatched_rows && @$unmatched_rows) {
+        push @errors, map {
+            "Accession '" . ($_->{accession} || '') . "' and breeding program '"
+                . ($_->{breeding_program} || '') . "' are not in the selected list and meeting."
+        } @$unmatched_rows;
+    }
+    return (undef, \@errors) if @errors;
+
+    my $decision_format = $self->_decision_format_config($c);
+    my $breeding_stages = $self->_breeding_stages_config($c);
+    foreach my $row (@candidate_rows) {
+        next if $row->{decision} eq '';
+
+        my $selected_stage = '';
+        if ($row->{decision} eq 'advance' || $row->{decision} eq 'jump') {
+            $selected_stage = $self->_normalize_stage_token(
+                $row->{new_stage},
+                $breeding_stages,
+            );
+        }
+
+        my $transition = $self->_compute_stage_transition_data(
+            current_stage   => $row->{previous_stage},
+            decision        => $row->{decision},
+            year            => $meeting_year,
+            meeting_date    => $meeting_date,
+            stock_id        => $row->{stock_id},
+            selected_stage  => $selected_stage,
+            decision_format => $decision_format,
+            breeding_stages => $breeding_stages,
+            schema          => $schema,
+        );
+        $row->{new_stage} = $transition->{new_stage} || '';
+    }
+
+    return (\@candidate_rows, []);
+}
+
 sub save_all_decisions_POST {
     my ($self, $c) = @_;
 
@@ -1766,7 +1996,7 @@ sub save_all_decisions_POST {
     }
 
     my $meeting_id = $payload->{meeting_id};
-    unless ($meeting_id) {
+    unless (defined($meeting_id) && !ref($meeting_id) && $meeting_id =~ /^\d+$/) {
         return $self->status_bad_request($c, message => 'Missing meeting_id in payload');
     }
 
@@ -1774,29 +2004,15 @@ sub save_all_decisions_POST {
     my $schema = $c->dbic_schema("Bio::Chado::Schema", undef, $sp_person_id);
     my @user_roles = $c->user()->roles;
 
-    my $raw_decision_role = $c->config->{decision_role};
-    my $decision_role_conf = '';
-
-    if (ref($raw_decision_role) eq 'ARRAY') {
-        $decision_role_conf = defined($raw_decision_role->[0]) ? $raw_decision_role->[0] : '';
-    }
-    else {
-        $decision_role_conf = $raw_decision_role // '';
-    }
-
-    my @allowed_roles = grep { $_ ne '' }
-        map {
-            my $x = $_ // '';
-            $x =~ s/^\s+|\s+$//g;
-            $x;
-        }
-        split(/\s*,\s*/, $decision_role_conf);
-
-    my %allowed = map { $_ => 1 } @allowed_roles;
+    my $allowed_roles = $self->_configured_meeting_roles(
+        $c->config->{decision_role}
+    );
+    my %allowed = map { $_ => 1 } @$allowed_roles;
     my $can_save = 0;
 
     foreach my $role (@user_roles) {
-        if ($allowed{$role}) {
+        next unless defined($role) && !ref($role);
+        if ($allowed{lc($role)}) {
             $can_save = 1;
             last;
         }
@@ -1838,9 +2054,29 @@ sub save_all_decisions_POST {
         return $self->status_bad_request($c, message => 'Stored meeting metadata is invalid');
     }
 
+    if ($self->_is_meeting_saved($meeting_data)) {
+        return $self->status_bad_request(
+            $c,
+            message => 'This meeting has already been saved and cannot be changed',
+        );
+    }
+
+    my ($validated_rows, $validation_errors) = $self->_validated_decisions_for_save(
+        c            => $c,
+        schema       => $schema,
+        meeting_data => $meeting_data,
+        payload      => $payload,
+    );
+    if ($validation_errors && @$validation_errors) {
+        return $self->status_bad_request($c, message => join(' ', @$validation_errors));
+    }
+
+    my %decision_data = %$payload;
+    $decision_data{accessions} = $validated_rows;
+
     my $updated_payload = $self->_merge_decisions_into_meeting(
         $meeting_data,
-        $payload,
+        \%decision_data,
     );
 
     my $json_text;
@@ -1854,19 +2090,34 @@ sub save_all_decisions_POST {
 
     eval {
         $schema->txn_do(sub {
-            $meeting_prop->update({ value => $json_text });
+            my $locked_meeting_prop = $schema->resultset('Project::Projectprop')->search(
+                { projectprop_id => $meeting_prop->projectprop_id },
+                { for => 'update', rows => 1 },
+            )->single;
+            die "DM_MEETING_METADATA_MISSING\n" unless $locked_meeting_prop;
 
-            my $accessions = $payload->{accessions} || [];
+            my ($locked_meeting_data, $locked_decode_error) =
+                $self->_decode_meeting_json($locked_meeting_prop->value);
+            die "DM_MEETING_METADATA_INVALID\n"
+                if $locked_decode_error || ref($locked_meeting_data) ne 'HASH';
+            die "DM_MEETING_ALREADY_SAVED\n"
+                if $self->_is_meeting_saved($locked_meeting_data);
+
+            $locked_meeting_prop->update({ value => $json_text });
+
+            my $accessions = $validated_rows;
 
             foreach my $acc (@$accessions) {
                 next unless $acc && ref($acc) eq 'HASH';
 
                 my $stock_id         = $acc->{stock_id};
                 my $breeding_program = $acc->{breeding_program} // '';
+                my $decision         = $acc->{decision} // '';
                 my $new_stage        = $acc->{new_stage} // '';
 
                 next unless $stock_id;
                 next unless $breeding_program ne '';
+                next unless $decision ne '';
                 next unless $new_stage ne '';
 
                 $self->_update_breeding_stage_stockprop(
@@ -1880,7 +2131,22 @@ sub save_all_decisions_POST {
         });
     };
     if ($@) {
-        return $self->status_bad_request($c, message => "Failed to save decisions: $@");
+        my $error = "$@";
+        if ($error =~ /DM_MEETING_ALREADY_SAVED/) {
+            return $self->status_bad_request(
+                $c,
+                message => 'This meeting has already been saved and cannot be changed',
+            );
+        }
+        $c->log->error("DecisionMeeting save decisions error: $error")
+            if $c->can('log') && $c->log;
+        $c->res->status(500);
+        $c->res->content_type('application/json; charset=utf-8');
+        $c->res->body(encode_json({
+            error   => 'Failed to save decisions',
+            message => 'The decisions could not be saved. No changes were applied.',
+        }));
+        return;
     }
 
     $c->stash(
@@ -2055,19 +2321,8 @@ sub _meeting_tracker_metadata {
     my ($self, $project_name, $meeting_data) = @_;
     $meeting_data = {} unless ref($meeting_data) eq 'HASH';
 
-    my @programs;
-    if (ref($meeting_data->{breeding_program_names}) eq 'ARRAY') {
-        @programs = @{$meeting_data->{breeding_program_names}};
-    }
-    elsif (defined($meeting_data->{breeding_program_name}) && $meeting_data->{breeding_program_name} ne '') {
-        @programs = ($meeting_data->{breeding_program_name});
-    }
-    elsif (ref($meeting_data->{breeding_programs}) eq 'ARRAY') {
-        @programs = @{$meeting_data->{breeding_programs}};
-    }
-    elsif (defined($meeting_data->{breeding_program}) && $meeting_data->{breeding_program} ne '') {
-        @programs = ($meeting_data->{breeding_program});
-    }
+    my $program_names = $self->_meeting_program_names($meeting_data);
+    my @programs = @$program_names;
 
     my @attendees;
     if (ref($meeting_data->{attendees_list}) eq 'ARRAY') {
@@ -2085,17 +2340,27 @@ sub _meeting_tracker_metadata {
     );
 
     return {
-        meeting_name      => $meeting_data->{meeting_name} // $project_name // '',
+        meeting_name      => $self->_trim($meeting_data->{meeting_name})
+                             || $self->_trim($project_name),
         meeting_programs  => join(', ', grep { defined($_) && $_ ne '' } @programs),
         meeting_date      => $meeting_date,
-        meeting_year      => $meeting_data->{year} // '',
-        meeting_location  => $meeting_data->{location_name} // $meeting_data->{location} // $meeting_data->{location_raw} // '',
-        meeting_attendees => join(', ', grep { defined($_) && $_ ne '' } @attendees),
+        meeting_year      => $self->_trim($meeting_data->{year}),
+        meeting_location  => $self->_trim(
+            $meeting_data->{location_name}
+                // $meeting_data->{location}
+                // $meeting_data->{location_raw}
+                // ''
+        ),
+        meeting_attendees => join(', ', grep { $_ ne '' } map { $self->_trim($_) } @attendees),
     };
 }
 
 sub meetings_GET {
     my ($self, $c) = @_;
+
+    return $self->status_forbidden($c, message => 'Login required')
+        unless $c->user;
+
     $c->res->headers->header('Cache-Control' => 'no-store, no-cache, must-revalidate');
     my $dbh = $c->dbc->dbh;
 
@@ -2185,47 +2450,15 @@ sub meetings_GET {
         my ($decoded) = $self->_decode_meeting_json($mj);
         $decoded = {} unless ref($decoded) eq 'HASH';
 
-        my $is_saved = 0;
-        if (
-            exists $decoded->{saved_status}
-            && defined $decoded->{saved_status}
-            && $decoded->{saved_status} eq 'successfully'
-        ) {
-            $is_saved = 1;
-        }
+        my $is_saved = $self->_is_meeting_saved($decoded) ? 1 : 0;
 
-        if (exists $decoded->{breeding_programs} && ref($decoded->{breeding_programs}) eq 'ARRAY') {
-            my @translated = map {
-                defined $_ && exists $program_id_to_name{$_}
-                    ? $program_id_to_name{$_}
-                    : $_
-            } @{ $decoded->{breeding_programs} || [] };
-
-            if (@translated > 1) {
-                @translated = ($translated[0]);
-            }
-
-            $decoded->{breeding_programs} = \@translated;
-            $decoded->{breeding_program}  = $translated[0] // '';
-        }
-        elsif (exists $decoded->{breeding_program}) {
-            my $raw = $decoded->{breeding_program};
-            my @vals = ref($raw) eq 'ARRAY'
-                ? @$raw
-                : grep { defined $_ && $_ ne '' } map { s/^\s+|\s+$//gr } split(/\s*,\s*/, ($raw // ''));
-
-            my @translated = map {
-                defined $_ && exists $program_id_to_name{$_}
-                    ? $program_id_to_name{$_}
-                    : $_
-            } @vals;
-
-            if (@translated > 1) {
-                @translated = ($translated[0]);
-            }
-
-            $decoded->{breeding_programs} = \@translated;
-            $decoded->{breeding_program}  = $translated[0] // '';
+        my $translated = $self->_meeting_program_names(
+            $decoded,
+            \%program_id_to_name,
+        );
+        if (@$translated) {
+            $decoded->{breeding_program_names} = $translated;
+            $decoded->{breeding_program} = $translated->[0];
         }
 
         $decoded->{saved} = $is_saved ? JSON::true : JSON::false;
@@ -2293,35 +2526,28 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
         $data = $decoded if ref($decoded) eq 'HASH';
     }
 
-    my $meeting_notes = $data->{meeting_notes} // '';
-    my $accessions    = $data->{accessions} || [];
+    my $meeting_notes = defined($data->{meeting_notes}) && !ref($data->{meeting_notes})
+        ? "$data->{meeting_notes}"
+        : (defined($data->{data}) && !ref($data->{data}) ? "$data->{data}" : '');
+    my $accessions    = ref($data->{accessions}) eq 'ARRAY'
+        ? $data->{accessions}
+        : [];
     my $attendees     = $data->{attendees};
     my $meeting_date  = $self->_normalize_meeting_date(
         $data->{date} // $data->{meeting_date} // ''
     );
-    my $meeting_year  = $data->{year} // '';
-    my $location      = $data->{location_name} // $data->{location} // $data->{location_raw} // '';
-    my $meeting_status = $data->{meeting_status} // '';
+    my $meeting_year  = $self->_trim($data->{year});
+    my $location      = $self->_trim(
+        $data->{location_name} // $data->{location} // $data->{location_raw} // ''
+    );
+    my $meeting_status = $self->_trim($data->{meeting_status});
 
-    my @programs;
-    if (ref($data->{breeding_program_names}) eq 'ARRAY') {
-        @programs = @{$data->{breeding_program_names}};
-    }
-    elsif (defined($data->{breeding_program_name}) && $data->{breeding_program_name} ne '') {
-        @programs = ($data->{breeding_program_name});
-    }
-    elsif (ref($data->{breeding_programs}) eq 'ARRAY') {
-        @programs = @{$data->{breeding_programs}};
-    }
-    elsif (defined($data->{breeding_program}) && $data->{breeding_program} ne '') {
-        @programs = ($data->{breeding_program});
-    }
+    my $program_names = $self->_meeting_program_names($data);
+    my @programs = @$program_names;
 
     my $programs_html = join(', ', grep { defined($_) && $_ ne '' } @programs);
 
-    my $saved_status = lc($data->{saved_status} // '');
-
-    if (!$saved_status || $saved_status ne 'successfully') {
+    if (!$self->_is_meeting_saved($data)) {
         $c->res->status(409);
         $c->res->content_type('application/json; charset=utf-8');
         $c->res->body(encode_json({
@@ -2333,6 +2559,8 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
 
     my $rows_html = '';
     foreach my $acc (@$accessions) {
+        next unless ref($acc) eq 'HASH';
+
         my $name      = $acc->{accession} // '';
         my $bp        = $acc->{breeding_program} // '';
         my $previous  = $acc->{previous_stage} // '';
@@ -2385,7 +2613,7 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
     my $attendees_html = '';
     if (ref($attendees) eq 'ARRAY') {
         my @safe_attendees = map {
-            my $x = defined $_ ? $_ : '';
+            my $x = $self->_trim($_);
             $x =~ s/&/&amp;/g;
             $x =~ s/</&lt;/g;
             $x =~ s/>/&gt;/g;
@@ -2395,7 +2623,7 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
         $attendees_html = join(', ', @safe_attendees);
     }
     else {
-        $attendees_html = defined $attendees ? $attendees : '';
+        $attendees_html = $self->_trim($attendees);
         $attendees_html =~ s/&/&amp;/g;
         $attendees_html =~ s/</&lt;/g;
         $attendees_html =~ s/>/&gt;/g;
@@ -2509,29 +2737,15 @@ sub create : Path('create') Args(0) {
     my $schema = $c->dbic_schema("Bio::Chado::Schema", undef, $sp_person_id);
     my @user_roles = $c->user()->roles;
 
-    my $raw_decision_role = $c->config->{decision_role};
-    my $decision_role_conf = '';
-
-    if (ref($raw_decision_role) eq 'ARRAY') {
-        $decision_role_conf = defined($raw_decision_role->[0]) ? $raw_decision_role->[0] : '';
-    }
-    else {
-        $decision_role_conf = $raw_decision_role // '';
-    }
-
-    my @allowed_roles = grep { $_ ne '' }
-        map {
-            my $x = $_ // '';
-            $x =~ s/^\s+|\s+$//g;
-            $x;
-        }
-        split(/\s*,\s*/, $decision_role_conf);
-
-    my %allowed = map { $_ => 1 } @allowed_roles;
+    my $allowed_roles = $self->_configured_meeting_roles(
+        $c->config->{decision_role}
+    );
+    my %allowed = map { $_ => 1 } @$allowed_roles;
     my $can_create_meeting = 0;
 
     foreach my $role (@user_roles) {
-        if ($allowed{$role}) {
+        next unless defined($role) && !ref($role);
+        if ($allowed{lc($role)}) {
             $can_create_meeting = 1;
             last;
         }
@@ -2551,18 +2765,20 @@ sub create : Path('create') Args(0) {
     my $owner_id = $person->get_sp_person_id;
     my $operator = $person->get_username;
 
-    my $trial_name_in = $p->{meeting_name}     // '';
-    my $program_in    = $p->{breeding_program} // '';
-    my $location_in   = $p->{location}         // '';
-    my $trial_year    = $p->{year}             // '';
-    my $date_in       = $p->{date}             // '';
+    my $trial_name_in = $self->_trim($p->{meeting_name});
+    my $program_in    = $self->_trim($p->{breeding_program});
+    my $location_in   = $self->_trim($p->{location});
+    my $trial_year    = $self->_trim($p->{year});
+    my $date_in       = $self->_trim($p->{date});
     my $meeting_date  = $self->_normalize_meeting_date($date_in);
     my $planting_date = $meeting_date;
-    my $description   = $p->{data}             // '';
-    my $meeting_status= $p->{meeting_status}   // '';
+    my $description   = defined($p->{data}) && !ref($p->{data}) ? "$p->{data}" : '';
+    my $meeting_status= $self->_trim($p->{meeting_status});
 
     return $self->status_bad_request($c, message => "Missing meeting_name")
         unless $trial_name_in;
+    return $self->status_bad_request($c, message => "Meeting name is too long")
+        if length($trial_name_in) > 255;
     return $self->status_bad_request($c, message => "Missing breeding_program")
         unless ($program_in || ref($p->{breeding_programs}) eq 'ARRAY');
     return $self->status_bad_request($c, message => "Missing location")
@@ -2571,23 +2787,56 @@ sub create : Path('create') Args(0) {
         unless $date_in;
     return $self->status_bad_request($c, message => "Date must use the YYYY-MM-DD format")
         unless $meeting_date;
+    return $self->status_bad_request($c, message => "Year must use the YYYY format")
+        unless $trial_year =~ /^\d{4}$/;
 
-    my @program_in_list =
+    my @requested_programs =
         ref($p->{breeding_programs}) eq 'ARRAY'
-            ? grep { defined($_) && $_ ne '' } @{$p->{breeding_programs}}
-            : (grep { length($_) } map { s/^\s+|\s+$//gr } split(/\s*,\s*/, ($program_in // '')));
+            ? map { $self->_trim($_) } @{$p->{breeding_programs}}
+            : split(/\s*,\s*/, $program_in);
+    @requested_programs = grep { $_ ne '' } @requested_programs;
+
+    my ($program_id_to_name, $program_name_to_program) =
+        $self->_available_breeding_program_maps($schema);
+    my (@program_in_list, @program_name_list, %seen_program_id);
+    foreach my $requested_program (@requested_programs) {
+        my ($program_id, $program_name);
+        if (exists($program_id_to_name->{$requested_program})) {
+            $program_id   = $requested_program;
+            $program_name = $program_id_to_name->{$requested_program};
+        }
+        elsif (exists($program_name_to_program->{lc($requested_program)})) {
+            $program_id   = $program_name_to_program->{lc($requested_program)}->{id};
+            $program_name = $program_name_to_program->{lc($requested_program)}->{name};
+        }
+        else {
+            return $self->status_bad_request(
+                $c,
+                message => "Breeding program not found: '$requested_program'",
+            );
+        }
+
+        next if $seen_program_id{$program_id}++;
+        push @program_in_list, $program_id;
+        push @program_name_list, $program_name;
+    }
 
     my $program_choice = $program_in_list[0] // '';
     return $self->status_bad_request($c, message => "Missing breeding_program")
         unless $program_choice;
 
-    my $program_name  = _resolve_program_name($schema, $program_choice)
-        or return $self->status_bad_request($c, message => "Breeding program not found: '$program_choice'");
+    my $program_name  = $program_name_list[0];
     my $location_name = _resolve_location_name($schema, $location_in)
         or return $self->status_bad_request($c, message => "Location not found: '$location_in'");
 
-    my @program_name_list = grep { defined($_) && $_ ne '' }
-                            map  { scalar _resolve_program_name($schema, $_) } @program_in_list;
+    my $configured_locations = $self->_configured_meeting_locations(
+        $c->config->{meeting_locations}
+    );
+    if (@$configured_locations) {
+        my %allowed_location = map { lc($_) => 1 } @$configured_locations;
+        return $self->status_bad_request($c, message => "Location is not enabled for decision meetings")
+            unless $allowed_location{lc($location_name)};
+    }
 
     my $trial_name = $trial_name_in;
 
@@ -2626,9 +2875,21 @@ sub create : Path('create') Args(0) {
         }
     }
 
-    my @att_clean = grep { length($_) } map { s/^\s+|\s+$//gr } @att_raw;
+    my @att_clean = grep { $_ ne '' } map { $self->_trim($_) } @att_raw;
     my %seen;
     my $attendees = [ grep { my $k = lc($_); !$seen{$k}++ } @att_clean ];
+
+    my $meeting_roles = $self->_configured_meeting_roles(
+        $c->config->{meeting_role}
+    );
+    my ($validated_attendees, $attendee_errors) = $self->_validate_meeting_attendees(
+        $dbh,
+        $meeting_roles,
+        $attendees,
+    );
+    return $self->status_bad_request($c, message => join(' ', @$attendee_errors))
+        if $attendee_errors && @$attendee_errors;
+    $attendees = $validated_attendees;
 
     my $design_hash = {};
 
@@ -2652,6 +2913,7 @@ sub create : Path('create') Args(0) {
     my ($project_id, $nd_experiment_id);
     my $err;
     try {
+        $schema->txn_do(sub {
         my $pp_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'meeting_json', 'project_property')
             or die "cvterm meeting_json not found in cv project_property";
         my $type_id = $pp_type->cvterm_id;
@@ -2709,6 +2971,8 @@ sub create : Path('create') Args(0) {
         $project_id = $proj_row->project_id;
 
         my $meeting_payload = {
+            meeting_name           => $trial_name,
+            meeting_notes          => $description,
             attendees               => $attendees,
             meeting_status          => ($meeting_status || undef),
             breeding_programs       => \@program_in_list,
@@ -2729,17 +2993,22 @@ sub create : Path('create') Args(0) {
         else {
             $proj_row->create_related('projectprops', { type_id => $type_id, value => $val });
         }
-
+        });
     } catch {
         $err = "$_";
         $c->log->error("DecisionMeeting save trial error: $err");
     };
 
     if ($err) {
+        my $client_message = $err =~ /Trial name already exists/i
+            ? 'A meeting or trial with that name already exists.'
+            : 'The meeting could not be created.';
+        $c->res->status($err =~ /Trial name already exists/i ? 409 : 500);
         $c->res->content_type('application/json');
         $c->res->body(encode_json({
             ok   => \0,
-            msg  => "Error creating meeting trial: $err",
+            msg  => $client_message,
+            message => $client_message,
             echo => {
                 meeting_name      => $trial_name_in,
                 breeding_programs => \@program_in_list,
@@ -2856,7 +3125,8 @@ sub _update_breeding_stage_stockprop {
 
 sub _trim {
     my ($self, $v) = @_;
-    return '' unless defined $v;
+    return '' unless defined($v) && !ref($v);
+    $v = "$v";
     $v =~ s/^\s+//;
     $v =~ s/\s+$//;
     return $v;
@@ -2943,18 +3213,45 @@ sub _compute_new_stage {
     return $next_token;
 }
 
-sub _resolve_program_name {
-    my ($schema, $in) = @_;
-    return $in unless defined $in && $in =~ /^\d+$/;
-    my $row = $schema->resultset('Project::Project')->find({ project_id => $in });
-    return $row ? $row->name : undef;
+sub _available_breeding_program_maps {
+    my ($self, $schema) = @_;
+
+    my (%id_to_name, %name_to_program);
+    return (\%id_to_name, \%name_to_program) unless $schema;
+
+    my $projects = CXGN::BreedersToolbox::Projects->new({ schema => $schema });
+    my $programs = $projects->get_breeding_programs() || [];
+    foreach my $program (@$programs) {
+        my ($id, $name) = ('', '');
+        if (ref($program) eq 'ARRAY') {
+            ($id, $name) = ($program->[0] // '', $program->[1] // '');
+        }
+        elsif (ref($program) eq 'HASH') {
+            $id = $program->{program_id} // $program->{project_id} // $program->{id} // '';
+            $name = $program->{name} // $program->{project_name} // '';
+        }
+
+        next if ref($id) || ref($name);
+        $id   = $self->_trim($id);
+        $name = $self->_trim($name);
+        next if $id eq '' || $name eq '';
+
+        $id_to_name{$id} = $name;
+        $name_to_program{lc($name)} = {
+            id   => $id,
+            name => $name,
+        };
+    }
+
+    return (\%id_to_name, \%name_to_program);
 }
 
 sub _resolve_location_name {
     my ($schema, $in) = @_;
     return unless defined($in) && $in ne '';
 
-    my $query = $in =~ /^\d+$/
+    my $is_id = $in =~ /^\d+$/ ? 1 : 0;
+    my $query = $is_id
         ? { nd_geolocation_id => $in }
         : { description => $in };
 
@@ -2963,7 +3260,11 @@ sub _resolve_location_name {
         my $resultset = eval { $schema->resultset($resultset_name) };
         next unless $resultset;
 
-        $row = eval { $resultset->find($query) };
+        $row = eval {
+            $is_id
+                ? $resultset->find($query)
+                : $resultset->search($query, { rows => 1 })->first;
+        };
         last if $row;
     }
 
@@ -2997,16 +3298,12 @@ sub _configured_meeting_roles {
     return \@roles;
 }
 
-sub people_GET {
-    my ($self, $c) = @_;
+sub _meeting_people_for_roles {
+    my ($self, $dbh, $meeting_roles) = @_;
 
-    my $meeting_roles = $self->_configured_meeting_roles(
-        $c->config->{meeting_role}
-    );
-    return $self->status_ok($c, entity => []) unless @$meeting_roles;
+    return [] unless $dbh && ref($meeting_roles) eq 'ARRAY' && @$meeting_roles;
 
     my $placeholders = join(', ', ('?') x @$meeting_roles);
-    my $dbh = $c->dbc->dbh;
     my $sth = $dbh->prepare(qq{
         SELECT person.first_name, person.last_name, person.contact_email
         FROM sgn_people.sp_person AS person
@@ -3034,7 +3331,62 @@ sub people_GET {
     }
     $sth->finish;
 
-    return $self->status_ok($c, entity => \@rows);
+    return \@rows;
+}
+
+sub _validate_meeting_attendees {
+    my ($self, $dbh, $meeting_roles, $attendees) = @_;
+
+    return ([], ['Attendees must be an array']) unless ref($attendees) eq 'ARRAY';
+    return ($attendees, [])
+        unless ref($meeting_roles) eq 'ARRAY' && @$meeting_roles;
+
+    my $people = $self->_meeting_people_for_roles($dbh, $meeting_roles);
+    my %allowed;
+    foreach my $person (@$people) {
+        my $name = join(' ', grep { $_ ne '' }
+            $self->_trim($person->{first_name}),
+            $self->_trim($person->{last_name}),
+        );
+        my $email = $self->_trim($person->{contact_email});
+        $allowed{lc($name)} = $name if $name ne '';
+        $allowed{lc($email)} = $name || $email if $email ne '';
+    }
+
+    my (@canonical, @errors, %seen);
+    foreach my $attendee (@$attendees) {
+        my $value = $self->_trim($attendee);
+        next if $value eq '';
+
+        my $canonical = $allowed{lc($value)};
+        unless (defined($canonical) && $canonical ne '') {
+            push @errors, "Attendee '$value' does not have an allowed meeting role.";
+            next;
+        }
+        next if $seen{lc($canonical)}++;
+        push @canonical, $canonical;
+    }
+
+    return (\@canonical, \@errors);
+}
+
+sub people_GET {
+    my ($self, $c) = @_;
+
+    return $self->status_forbidden($c, message => 'Login required')
+        unless $c->user;
+
+    $c->res->headers->header('Cache-Control' => 'no-store, no-cache, must-revalidate');
+
+    my $meeting_roles = $self->_configured_meeting_roles(
+        $c->config->{meeting_role}
+    );
+    return $self->status_ok($c, entity => []) unless @$meeting_roles;
+
+    my $dbh = $c->dbc->dbh;
+    my $rows = $self->_meeting_people_for_roles($dbh, $meeting_roles);
+
+    return $self->status_ok($c, entity => $rows);
 }
 
 1;

--- a/lib/SGN/Controller/AJAX/DecisionMeeting.pm
+++ b/lib/SGN/Controller/AJAX/DecisionMeeting.pm
@@ -1,6 +1,7 @@
 # lib/SGN/Controller/AJAX/DecisionMeeting.pm
 package SGN::Controller::AJAX::DecisionMeeting;
 use Moose;
+use utf8 ();
 use CXGN::List;
 use JSON;
 use JSON qw(decode_json);
@@ -35,6 +36,32 @@ sub ping : Path('ping') : Args(0) : ActionClass('REST') {}
 sub ping_GET {
     my ($self, $c) = @_;
     $self->status_ok($c, entity => { ok => 1, user => ($c->user ? 1 : 0) });
+}
+
+sub _decode_meeting_json {
+    my ($self, $json_text) = @_;
+    return wantarray ? (undef, 'Meeting JSON is undefined') : undef
+        unless defined $json_text;
+
+    # DBD::Pg can return text as either UTF-8 octets or an already-decoded
+    # character string, depending on its UTF-8 settings. JSON::decode_json
+    # always expects octets and fails on character strings containing accents.
+    my @utf8_modes = utf8::is_utf8($json_text) ? (0, 1) : (1, 0);
+    my $last_error = '';
+
+    foreach my $utf8_mode (@utf8_modes) {
+        my $decoded;
+        eval {
+            $decoded = JSON->new
+                ->allow_nonref
+                ->utf8($utf8_mode)
+                ->decode($json_text);
+        };
+        return wantarray ? ($decoded, '') : $decoded unless $@;
+        $last_error = $@;
+    }
+
+    return wantarray ? (undef, $last_error) : undef;
 }
 
 sub lists : Path('lists') : Args(0) : ActionClass('REST') {}
@@ -114,30 +141,48 @@ sub programs_GET {
 }
 
 sub locations : Path('locations') : ActionClass('REST') { }
+
+sub _configured_meeting_locations {
+    my ($self, $raw_locations) = @_;
+
+    my @config_values = ref($raw_locations) eq 'ARRAY'
+        ? @$raw_locations
+        : (defined($raw_locations) ? $raw_locations : ());
+
+    my (@locations, %seen);
+    foreach my $config_value (@config_values) {
+        next if !defined($config_value) || ref($config_value);
+
+        # A location name may contain commas (for example, a city and state),
+        # so meeting_locations uses a pipe as its list separator.
+        foreach my $location (split /\|/, $config_value) {
+            $location =~ s/^\s+|\s+$//g;
+            next if $location eq '';
+
+            my $key = lc($location);
+            next if $seen{$key}++;
+            push @locations, $location;
+        }
+    }
+
+    return \@locations;
+}
+
 sub locations_GET {
     my ($self, $c) = @_;
 
     return $self->status_forbidden($c, message => 'Login required')
         unless $c->user;
 
-    my $schema = $c->dbic_schema('Bio::Chado::Schema');
-    my $ps     = CXGN::BreedersToolbox::Projects->new({ schema => $schema });
-    my $locs   = $ps->get_locations() || [];
-
-    my @items;
-    foreach my $r (@$locs) {
-        my ($id, $desc, $lat, $lon, $alt, $count) = @$r;
-        next unless defined $id;
-
-        push @items, {
-            location_id => $id,
-            name        => defined $desc && $desc ne '' ? $desc : "Location $id",
-            latitude    => $lat,
-            longitude   => $lon,
-            altitude    => $alt,
-            plot_count  => $count,
-        };
-    }
+    my $locations = $self->_configured_meeting_locations(
+        $c->config->{meeting_locations}
+    );
+    my @items = map {
+        +{
+            location_id => $_,
+            name        => $_,
+        }
+    } @$locations;
 
     return $self->status_ok($c, entity => \@items);
 }
@@ -233,9 +278,8 @@ sub _decision_rows_entity {
 
         my ($meeting_json) = $sth->fetchrow_array;
         if ($meeting_json) {
-            my $decoded = {};
-            eval { $decoded = decode_json($meeting_json); };
-            $decoded ||= {};
+            my ($decoded) = $self->_decode_meeting_json($meeting_json);
+            $decoded = {} unless ref($decoded) eq 'HASH';
 
             if ($decoded->{breeding_program_name}) {
                 $selected_program = $decoded->{breeding_program_name};
@@ -583,9 +627,8 @@ sub _meeting_year_from_meeting_id {
     my ($meeting_json) = $sth->fetchrow_array;
     return '' unless $meeting_json;
 
-    my $decoded = {};
-    eval { $decoded = decode_json($meeting_json); };
-    $decoded ||= {};
+    my ($decoded) = $self->_decode_meeting_json($meeting_json);
+    $decoded = {} unless ref($decoded) eq 'HASH';
 
     my $date = $decoded->{date} || '';
     return $1 if $date =~ /^(\d{4})-/;
@@ -1656,6 +1699,29 @@ sub dataset_plot_data_GET {
 }
 
 sub save_all_decisions : Path('save_all_decisions') : Args(0) : ActionClass('REST') { }
+
+sub _merge_decisions_into_meeting {
+    my ($self, $meeting_data, $decision_data, $saved_at) = @_;
+
+    $meeting_data  = {} unless ref($meeting_data) eq 'HASH';
+    $decision_data = {} unless ref($decision_data) eq 'HASH';
+
+    # The meeting record is the source of truth for its metadata.  Add fields
+    # from the decision report, but only replace the fields that are edited by
+    # the save-decisions workflow.
+    my %merged = (%$decision_data, %$meeting_data);
+    foreach my $key (qw(accessions list_id meeting_notes)) {
+        $merged{$key} = $decision_data->{$key}
+            if exists $decision_data->{$key};
+    }
+
+    $merged{saved}        = JSON::true;
+    $merged{saved_at}     = defined($saved_at) ? $saved_at : scalar localtime();
+    $merged{saved_status} = 'successfully';
+
+    return \%merged;
+}
+
 sub save_all_decisions_POST {
     my ($self, $c) = @_;
 
@@ -1712,33 +1778,59 @@ sub save_all_decisions_POST {
         );
     }
 
-    $payload->{saved}        = JSON::true;
-    $payload->{saved_at}     = scalar localtime();
-    $payload->{saved_status} = 'successfully';
+    my $dbh = $c->dbc->dbh;
+    my $meeting_json_type = SGN::Model::Cvterm->get_cvterm_row(
+        $schema,
+        'meeting_json',
+        'project_property',
+    );
+    unless ($meeting_json_type) {
+        return $self->status_bad_request($c, message => 'Meeting metadata type not found');
+    }
+
+    my ($meeting_prop_id, $meeting_json);
+    eval {
+        my $sth = $dbh->prepare(q{
+            SELECT projectprop_id, value
+            FROM projectprop
+            WHERE project_id = ?
+              AND type_id = ?
+            ORDER BY projectprop_id DESC
+            LIMIT 1
+        });
+        $sth->execute($meeting_id, $meeting_json_type->cvterm_id);
+        ($meeting_prop_id, $meeting_json) = $sth->fetchrow_array;
+    };
+    if ($@) {
+        return $self->status_bad_request($c, message => "Failed to load meeting metadata: $@");
+    }
+    unless ($meeting_prop_id && defined $meeting_json) {
+        return $self->status_bad_request($c, message => 'Meeting metadata not found');
+    }
+
+    my ($meeting_data, $meeting_decode_error) = $self->_decode_meeting_json($meeting_json);
+    if ($meeting_decode_error || ref($meeting_data) ne 'HASH') {
+        return $self->status_bad_request($c, message => 'Stored meeting metadata is invalid');
+    }
+
+    my $updated_payload = $self->_merge_decisions_into_meeting($meeting_data, $payload);
 
     my $json_text;
     eval {
         require JSON;
-        $json_text = JSON->new->allow_nonref->canonical->encode($payload);
+        $json_text = JSON->new->allow_nonref->canonical->encode($updated_payload);
     };
     if ($@) {
         return $self->status_bad_request($c, message => 'Could not encode payload to JSON');
     }
 
-    my $dbh = $c->dbc->dbh;
-
     eval {
         my $sth = $dbh->prepare(q{
             UPDATE projectprop
             SET value = ?
-            WHERE project_id = ?
-              AND type_id = (
-                  SELECT cvterm_id
-                  FROM cvterm
-                  WHERE name = 'meeting_json'
-              )
+            WHERE projectprop_id = ?
         });
-        $sth->execute($json_text, $meeting_id);
+        $sth->execute($json_text, $meeting_prop_id);
 
         my $raw_conf = $c->config->{saved_program_stage};
         my $saved_program_stage = '';
@@ -1992,8 +2084,50 @@ sub upload_decision_template_POST {
 }
 
 sub meetings : Path('meetings') : Args(0) : ActionClass('REST') {}
+
+sub _meeting_tracker_metadata {
+    my ($self, $project_name, $meeting_data) = @_;
+    $meeting_data = {} unless ref($meeting_data) eq 'HASH';
+
+    my @programs;
+    if (ref($meeting_data->{breeding_program_names}) eq 'ARRAY') {
+        @programs = @{$meeting_data->{breeding_program_names}};
+    }
+    elsif (defined($meeting_data->{breeding_program_name}) && $meeting_data->{breeding_program_name} ne '') {
+        @programs = ($meeting_data->{breeding_program_name});
+    }
+    elsif (ref($meeting_data->{breeding_programs}) eq 'ARRAY') {
+        @programs = @{$meeting_data->{breeding_programs}};
+    }
+    elsif (defined($meeting_data->{breeding_program}) && $meeting_data->{breeding_program} ne '') {
+        @programs = ($meeting_data->{breeding_program});
+    }
+
+    my @attendees;
+    if (ref($meeting_data->{attendees_list}) eq 'ARRAY') {
+        @attendees = @{$meeting_data->{attendees_list}};
+    }
+    elsif (ref($meeting_data->{attendees}) eq 'ARRAY') {
+        @attendees = @{$meeting_data->{attendees}};
+    }
+    elsif (defined($meeting_data->{attendees}) && $meeting_data->{attendees} ne '') {
+        @attendees = ($meeting_data->{attendees});
+    }
+
+    return {
+        meeting_name      => $meeting_data->{meeting_name} // $project_name // '',
+        meeting_programs  => join(', ', grep { defined($_) && $_ ne '' } @programs),
+        meeting_date      => $meeting_data->{date} // $meeting_data->{meeting_date} // '',
+        meeting_year      => $meeting_data->{year} // '',
+        meeting_location  => $meeting_data->{location_name} // $meeting_data->{location} // $meeting_data->{location_raw} // '',
+        meeting_attendees => join(', ', grep { defined($_) && $_ ne '' } @attendees),
+    };
+}
+
 sub meetings_GET {
     my ($self, $c) = @_;
+    $c->res->headers->header('Cache-Control' => 'no-store, no-cache, must-revalidate');
+
     my $dbh = $c->dbc->dbh;
 
     my $sp_person_id = $c->user() ? $c->user->get_object()->get_sp_person_id() : undef;
@@ -2006,9 +2140,7 @@ sub meetings_GET {
     my $mtg_json_type_id = $mtg_json_type_row ? $mtg_json_type_row->cvterm_id : undef;
 
     if (!$design_type_id || !$mtg_json_type_id) {
-        $c->stash->{rest} = { rows => [] };
-        $c->detach($c->view('JSON'));
-        return;
+        return $self->status_ok($c, entity => { rows => [] });
     }
 
     my $ps = CXGN::BreedersToolbox::Projects->new({ schema => $schema });
@@ -2051,9 +2183,7 @@ sub meetings_GET {
     }
 
     if (!@ids) {
-        $c->stash->{rest} = { rows => [] };
-        $c->detach($c->view('JSON'));
-        return;
+        return $self->status_ok($c, entity => { rows => [] });
     }
 
     my $ph = join(',', ('?') x @ids);
@@ -2079,9 +2209,8 @@ sub meetings_GET {
         my $mj  = $json_for{$pid};
         next unless defined $mj;
 
-        my $decoded = {};
-        eval { $decoded = decode_json($mj) if $mj; };
-        $decoded ||= {};
+        my ($decoded) = $self->_decode_meeting_json($mj);
+        $decoded = {} unless ref($decoded) eq 'HASH';
 
         my $is_saved = 0;
         if (
@@ -2127,17 +2256,22 @@ sub meetings_GET {
         }
 
         $decoded->{saved} = $is_saved ? JSON::true : JSON::false;
+        my $tracker_metadata = $self->_meeting_tracker_metadata(
+            $p->{project_name},
+            $decoded,
+        );
 
         push @rows, {
+            %$tracker_metadata,
             project_id    => $pid,
             project_name  => $p->{project_name},
+            meeting_data  => $decoded,
             meeting_json  => encode_json($decoded),
             meeting_saved => $is_saved ? JSON::true : JSON::false,
         };
     }
 
-    $c->stash->{rest} = { rows => \@rows };
-    $c->detach($c->view('JSON'));
+    return $self->status_ok($c, entity => { rows => \@rows });
 }
 
 sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args(0) {
@@ -2155,16 +2289,18 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
     my $sth = $dbh->prepare(q{
         SELECT p.project_id, p.name, pp.value
         FROM project p
-        LEFT JOIN projectprop pp
-            ON pp.project_id = p.project_id
-           AND pp.type_id = (
-               SELECT cvterm_id
-               FROM cvterm
-               WHERE name = 'meeting_json'
-               LIMIT 1
-           )
+        LEFT JOIN LATERAL (
+            SELECT projectprop.value
+            FROM projectprop
+            JOIN cvterm ON cvterm.cvterm_id = projectprop.type_id
+            JOIN cv ON cv.cv_id = cvterm.cv_id
+            WHERE projectprop.project_id = p.project_id
+              AND cvterm.name = 'meeting_json'
+              AND cv.name = 'project_property'
+            ORDER BY projectprop.projectprop_id DESC
+            LIMIT 1
+        ) pp ON TRUE
         WHERE p.project_id = ?
-        LIMIT 1
     });
     $sth->execute($meeting_id);
 
@@ -2179,15 +2315,33 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
 
     my $data = {};
     if ($json_value) {
-        eval { $data = decode_json($json_value); };
-        if ($@) {
-            $data = {};
-        }
+        my ($decoded) = $self->_decode_meeting_json($json_value);
+        $data = $decoded if ref($decoded) eq 'HASH';
     }
 
     my $meeting_notes = $data->{meeting_notes} // '';
     my $accessions    = $data->{accessions} || [];
     my $attendees     = $data->{attendees};
+    my $meeting_date  = $data->{date} // '';
+    my $meeting_year  = $data->{year} // '';
+    my $location      = $data->{location_name} // $data->{location} // '';
+    my $meeting_status = $data->{meeting_status} // '';
+
+    my @programs;
+    if (ref($data->{breeding_program_names}) eq 'ARRAY') {
+        @programs = @{$data->{breeding_program_names}};
+    }
+    elsif (defined($data->{breeding_program_name}) && $data->{breeding_program_name} ne '') {
+        @programs = ($data->{breeding_program_name});
+    }
+    elsif (ref($data->{breeding_programs}) eq 'ARRAY') {
+        @programs = @{$data->{breeding_programs}};
+    }
+    elsif (defined($data->{breeding_program}) && $data->{breeding_program} ne '') {
+        @programs = ($data->{breeding_program});
+    }
+
+    my $programs_html = join(', ', grep { defined($_) && $_ ne '' } @programs);
 
     my $saved_status = lc($data->{saved_status} // '');
 
@@ -2243,6 +2397,14 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
     $meeting_notes =~ s/>/&gt;/g;
     $meeting_notes =~ s/"/&quot;/g;
     $meeting_notes =~ s/\n/<br>/g;
+
+    for ($meeting_date, $meeting_year, $location, $meeting_status, $programs_html) {
+        $_ = '' unless defined $_;
+        s/&/&amp;/g;
+        s/</&lt;/g;
+        s/>/&gt;/g;
+        s/"/&quot;/g;
+    }
 
     my $attendees_html = '';
     if (ref($attendees) eq 'ARRAY') {
@@ -2323,6 +2485,11 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
   <div class="meta">
     <strong>Meeting:</strong> $safe_project_name<br>
     <strong>Meeting ID:</strong> $meeting_id<br>
+    <strong>Programs:</strong> $programs_html<br>
+    <strong>Date:</strong> $meeting_date<br>
+    <strong>Year:</strong> $meeting_year<br>
+    <strong>Location:</strong> $location<br>
+    <strong>Status:</strong> $meeting_status<br>
     <strong>Attendees:</strong> $attendees_html
   </div>
 
@@ -2497,19 +2664,63 @@ sub create : Path('create') Args(0) {
         trial_name        => $trial_name,
         trial_description => $description,
         project_type      => 'meeting_project',
+        skip_design_store => 1,
     });
 
     my ($project_id, $nd_experiment_id);
     my $err;
     try {
-        $tc->save_trial();
+        my $pp_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'meeting_json', 'project_property')
+            or die "cvterm meeting_json not found in cv project_property";
+        my $type_id = $pp_type->cvterm_id;
+        my $design_prop_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'design', 'project_property')
+            or die "cvterm design not found in cv project_property";
 
-        $project_id       = eval { $tc->get_trial_id }         || eval { $tc->get_project_id } || undef;
-        $nd_experiment_id = eval { $tc->get_nd_experiment_id } || undef;
+        my $proj_row;
+        my $save_result = $tc->save_trial();
+        if (ref($save_result) eq 'HASH' && $save_result->{error}) {
+            # TrialCreate creates the base project before layout validation.
+            # A previous failed meeting attempt can therefore be completed on
+            # retry, but only when it is an unfinished Meeting owned by the
+            # same user.
+            if ($save_result->{error} =~ /Trial name already exists/i) {
+                my $candidate = $schema->resultset('Project::Project')->find({ name => $trial_name });
+                my $candidate_design = $candidate
+                    ? $candidate->search_related('projectprops', {
+                        type_id => $design_prop_type->cvterm_id,
+                        value   => 'Meeting',
+                    })->first
+                    : undef;
+                my $candidate_json = $candidate
+                    ? $candidate->search_related('projectprops', { type_id => $type_id })->first
+                    : undef;
+                my ($same_owner) = $candidate
+                    ? $dbh->selectrow_array(
+                        'SELECT 1 FROM phenome.project_owner WHERE project_id = ? AND sp_person_id = ?',
+                        undef,
+                        $candidate->project_id,
+                        $owner_id,
+                    )
+                    : ();
 
-        my $proj_row = $project_id
-            ? $schema->resultset('Project::Project')->find({ project_id => $project_id })
-            : $schema->resultset('Project::Project')->find({ name => $trial_name });
+                $proj_row = $candidate
+                    if $candidate_design && !$candidate_json && $same_owner;
+            }
+
+            die $save_result->{error} unless $proj_row;
+        }
+
+        unless ($proj_row) {
+            $project_id       = (ref($save_result) eq 'HASH' ? $save_result->{trial_id} : undef)
+                             || eval { $tc->get_trial_id }
+                             || eval { $tc->get_project_id }
+                             || undef;
+            $nd_experiment_id = eval { $tc->get_nd_experiment_id } || undef;
+
+            $proj_row = $project_id
+                ? $schema->resultset('Project::Project')->find({ project_id => $project_id })
+                : $schema->resultset('Project::Project')->find({ name => $trial_name });
+        }
 
         die "Project not found after save_trial" unless $proj_row;
 
@@ -2528,10 +2739,6 @@ sub create : Path('create') Args(0) {
             location_raw            => $location_in,
         };
         my $val = encode_json($meeting_payload);
-
-        my $pp_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'meeting_json', 'project_property')
-            or die "cvterm meeting_json not found in cv project_property";
-        my $type_id = $pp_type->cvterm_id;
 
         my $existing = $proj_row->search_related('projectprops', { type_id => $type_id })->first;
         if ($existing) {
@@ -2681,9 +2888,21 @@ sub _resolve_program_name {
 
 sub _resolve_location_name {
     my ($schema, $in) = @_;
-    return $in unless defined $in && $in =~ /^\d+$/;
-    my $row = $schema->resultset('NaturalDiversity::NdGeolocation')->find({ nd_geolocation_id => $in })
-          || $schema->resultset('NdGeolocation')->find({ nd_geolocation_id => $in });
+    return unless defined($in) && $in ne '';
+
+    my $query = $in =~ /^\d+$/
+        ? { nd_geolocation_id => $in }
+        : { description => $in };
+
+    my $row;
+    foreach my $resultset_name ('NaturalDiversity::NdGeolocation', 'NdGeolocation') {
+        my $resultset = eval { $schema->resultset($resultset_name) };
+        next unless $resultset;
+
+        $row = eval { $resultset->find($query) };
+        last if $row;
+    }
+
     return unless $row;
     return $row->can('description') ? ($row->description // '') : ($row->can('name') ? $row->name : '');
 }

--- a/lib/SGN/Controller/AJAX/DecisionMeeting.pm
+++ b/lib/SGN/Controller/AJAX/DecisionMeeting.pm
@@ -1,7 +1,6 @@
 # lib/SGN/Controller/AJAX/DecisionMeeting.pm
 package SGN::Controller::AJAX::DecisionMeeting;
 use Moose;
-use utf8 ();
 use CXGN::List;
 use JSON;
 use JSON qw(decode_json);
@@ -36,32 +35,6 @@ sub ping : Path('ping') : Args(0) : ActionClass('REST') {}
 sub ping_GET {
     my ($self, $c) = @_;
     $self->status_ok($c, entity => { ok => 1, user => ($c->user ? 1 : 0) });
-}
-
-sub _decode_meeting_json {
-    my ($self, $json_text) = @_;
-    return wantarray ? (undef, 'Meeting JSON is undefined') : undef
-        unless defined $json_text;
-
-    # DBD::Pg can return text as either UTF-8 octets or an already-decoded
-    # character string, depending on its UTF-8 settings. JSON::decode_json
-    # always expects octets and fails on character strings containing accents.
-    my @utf8_modes = utf8::is_utf8($json_text) ? (0, 1) : (1, 0);
-    my $last_error = '';
-
-    foreach my $utf8_mode (@utf8_modes) {
-        my $decoded;
-        eval {
-            $decoded = JSON->new
-                ->allow_nonref
-                ->utf8($utf8_mode)
-                ->decode($json_text);
-        };
-        return wantarray ? ($decoded, '') : $decoded unless $@;
-        $last_error = $@;
-    }
-
-    return wantarray ? (undef, $last_error) : undef;
 }
 
 sub lists : Path('lists') : Args(0) : ActionClass('REST') {}
@@ -141,50 +114,30 @@ sub programs_GET {
 }
 
 sub locations : Path('locations') : ActionClass('REST') { }
-
-sub _configured_meeting_locations {
-    my ($self, $raw_locations) = @_;
-
-    my @config_values = ref($raw_locations) eq 'ARRAY'
-        ? @$raw_locations
-        : (defined($raw_locations) ? $raw_locations : ());
-
-    my (@locations, %seen);
-    foreach my $config_value (@config_values) {
-        next if !defined($config_value) || ref($config_value);
-
-        # A location name may contain commas (for example, a city and state),
-        # so meeting_locations uses a pipe as its list separator.
-        foreach my $location (split /\|/, $config_value) {
-            $location =~ s/^\s+|\s+$//g;
-            next if $location eq '';
-
-            my $key = lc($location);
-            next if $seen{$key}++;
-            push @locations, $location;
-        }
-    }
-
-    return \@locations;
-}
-
 sub locations_GET {
     my ($self, $c) = @_;
 
     return $self->status_forbidden($c, message => 'Login required')
         unless $c->user;
 
-    $c->res->headers->header('Cache-Control' => 'no-store, no-cache, must-revalidate');
+    my $schema = $c->dbic_schema('Bio::Chado::Schema');
+    my $ps     = CXGN::BreedersToolbox::Projects->new({ schema => $schema });
+    my $locs   = $ps->get_locations() || [];
 
-    my $locations = $self->_configured_meeting_locations(
-        $c->config->{meeting_locations}
-    );
-    my @items = map {
-        +{
-            location_id => $_,
-            name        => $_,
-        }
-    } @$locations;
+    my @items;
+    foreach my $r (@$locs) {
+        my ($id, $desc, $lat, $lon, $alt, $count) = @$r;
+        next unless defined $id;
+
+        push @items, {
+            location_id => $id,
+            name        => defined $desc && $desc ne '' ? $desc : "Location $id",
+            latitude    => $lat,
+            longitude   => $lon,
+            altitude    => $alt,
+            plot_count  => $count,
+        };
+    }
 
     return $self->status_ok($c, entity => \@items);
 }
@@ -280,8 +233,9 @@ sub _decision_rows_entity {
 
         my ($meeting_json) = $sth->fetchrow_array;
         if ($meeting_json) {
-            my ($decoded) = $self->_decode_meeting_json($meeting_json);
-            $decoded = {} unless ref($decoded) eq 'HASH';
+            my $decoded = {};
+            eval { $decoded = decode_json($meeting_json); };
+            $decoded ||= {};
 
             if ($decoded->{breeding_program_name}) {
                 $selected_program = $decoded->{breeding_program_name};
@@ -412,7 +366,10 @@ sub _decision_rows_entity {
         }
 
         foreach my $bp (@programs_to_use) {
-            my $stage_prop_name = $bp . '_Stage';
+            my $stage_prop_name = $self->_breeding_stage_property_name(
+                $bp,
+                $c->config->{saved_program_stage},
+            );
             my $stage_value     = '';
 
             if ($stock_row) {
@@ -629,8 +586,9 @@ sub _meeting_year_from_meeting_id {
     my ($meeting_json) = $sth->fetchrow_array;
     return '' unless $meeting_json;
 
-    my ($decoded) = $self->_decode_meeting_json($meeting_json);
-    $decoded = {} unless ref($decoded) eq 'HASH';
+    my $decoded = {};
+    eval { $decoded = decode_json($meeting_json); };
+    $decoded ||= {};
 
     my $date = $decoded->{date} || '';
     return $1 if $date =~ /^(\d{4})-/;
@@ -671,11 +629,16 @@ sub _compute_stage_transition_data {
     my $current_stage    = $args{current_stage};
     my $decision         = lc($args{decision} // '');
     my $year             = $args{year};
+    my $meeting_date     = $args{meeting_date} || '';
     my $stock_id         = $args{stock_id};
     my $selected_stage   = $args{selected_stage} || '';
     my $decision_format  = $args{decision_format} || 'state,year yy,stage';
     my $breeding_stages  = $args{breeding_stages} || '';
     my $schema           = $args{schema};
+
+    if ($decision eq 'drop' && $meeting_date =~ /^(\d{4})-/) {
+        $year = $1;
+    }
 
     my @ordered_stages = grep { defined($_) && $_ ne '' }
                          map  { my $x = $_; $x =~ s/^\s+|\s+$//g; $x }
@@ -1035,6 +998,7 @@ sub compute_new_stage_GET {
     my $current_stage  = $c->req->param('current_stage');
     my $decision       = lc($c->req->param('decision') // '');
     my $year           = $c->req->param('year');
+    my $meeting_date   = $c->req->param('meeting_date') || '';
     my $stock_id       = $c->req->param('stock_id');
     my $selected_stage = $c->req->param('selected_stage') || '';
 
@@ -1046,6 +1010,7 @@ sub compute_new_stage_GET {
         current_stage   => $current_stage,
         decision        => $decision,
         year            => $year,
+        meeting_date    => $meeting_date,
         stock_id        => $stock_id,
         selected_stage  => $selected_stage,
         decision_format => $decision_format,
@@ -1701,29 +1666,6 @@ sub dataset_plot_data_GET {
 }
 
 sub save_all_decisions : Path('save_all_decisions') : Args(0) : ActionClass('REST') { }
-
-sub _merge_decisions_into_meeting {
-    my ($self, $meeting_data, $decision_data, $saved_at) = @_;
-
-    $meeting_data  = {} unless ref($meeting_data) eq 'HASH';
-    $decision_data = {} unless ref($decision_data) eq 'HASH';
-
-    # The meeting record is the source of truth for its metadata.  Add fields
-    # from the decision report, but only replace the fields that are edited by
-    # the save-decisions workflow.
-    my %merged = (%$decision_data, %$meeting_data);
-    foreach my $key (qw(accessions list_id meeting_notes)) {
-        $merged{$key} = $decision_data->{$key}
-            if exists $decision_data->{$key};
-    }
-
-    $merged{saved}        = JSON::true;
-    $merged{saved_at}     = defined($saved_at) ? $saved_at : scalar localtime();
-    $merged{saved_status} = 'successfully';
-
-    return \%merged;
-}
-
 sub save_all_decisions_POST {
     my ($self, $c) = @_;
 
@@ -1780,140 +1722,55 @@ sub save_all_decisions_POST {
         );
     }
 
-    my $dbh = $c->dbc->dbh;
-    my $meeting_json_type = SGN::Model::Cvterm->get_cvterm_row(
-        $schema,
-        'meeting_json',
-        'project_property',
-    );
-    unless ($meeting_json_type) {
-        return $self->status_bad_request($c, message => 'Meeting metadata type not found');
-    }
-
-    my ($meeting_prop_id, $meeting_json);
-    eval {
-        my $sth = $dbh->prepare(q{
-            SELECT projectprop_id, value
-            FROM projectprop
-            WHERE project_id = ?
-              AND type_id = ?
-            ORDER BY projectprop_id DESC
-            LIMIT 1
-        });
-        $sth->execute($meeting_id, $meeting_json_type->cvterm_id);
-        ($meeting_prop_id, $meeting_json) = $sth->fetchrow_array;
-    };
-    if ($@) {
-        return $self->status_bad_request($c, message => "Failed to load meeting metadata: $@");
-    }
-    unless ($meeting_prop_id && defined $meeting_json) {
-        return $self->status_bad_request($c, message => 'Meeting metadata not found');
-    }
-
-    my ($meeting_data, $meeting_decode_error) = $self->_decode_meeting_json($meeting_json);
-    if ($meeting_decode_error || ref($meeting_data) ne 'HASH') {
-        return $self->status_bad_request($c, message => 'Stored meeting metadata is invalid');
-    }
-
-    my $updated_payload = $self->_merge_decisions_into_meeting($meeting_data, $payload);
+    $payload->{saved}        = JSON::true;
+    $payload->{saved_at}     = scalar localtime();
+    $payload->{saved_status} = 'successfully';
 
     my $json_text;
     eval {
         require JSON;
-        $json_text = JSON->new->allow_nonref->canonical->encode($updated_payload);
+        $json_text = JSON->new->allow_nonref->canonical->encode($payload);
     };
     if ($@) {
         return $self->status_bad_request($c, message => 'Could not encode payload to JSON');
     }
 
     eval {
-        my $sth = $dbh->prepare(q{
-            UPDATE projectprop
-            SET value = ?
-            WHERE projectprop_id = ?
+        $schema->txn_do(sub {
+            my $sth = $schema->storage->dbh->prepare(q{
+                UPDATE projectprop
+                SET value = ?
+                WHERE project_id = ?
+                  AND type_id = (
+                      SELECT cvterm_id
+                      FROM cvterm
+                      WHERE name = 'meeting_json'
+                  )
+            });
+            $sth->execute($json_text, $meeting_id);
+
+            my $accessions = $payload->{accessions} || [];
+
+            foreach my $acc (@$accessions) {
+                next unless $acc && ref($acc) eq 'HASH';
+
+                my $stock_id         = $acc->{stock_id};
+                my $breeding_program = $acc->{breeding_program} // '';
+                my $new_stage        = $acc->{new_stage} // '';
+
+                next unless $stock_id;
+                next unless $breeding_program ne '';
+                next unless $new_stage ne '';
+
+                $self->_update_breeding_stage_stockprop(
+                    schema              => $schema,
+                    stock_id            => $stock_id,
+                    breeding_program    => $breeding_program,
+                    new_stage           => $new_stage,
+                    saved_program_stage => $c->config->{saved_program_stage},
+                );
+            }
         });
-        $sth->execute($json_text, $meeting_prop_id);
-
-        my $raw_conf = $c->config->{saved_program_stage};
-        my $saved_program_stage = '';
-
-        if (ref($raw_conf) eq 'ARRAY') {
-            $saved_program_stage = defined($raw_conf->[0]) ? $raw_conf->[0] : '';
-        }
-        else {
-            $saved_program_stage = $raw_conf // '';
-        }
-
-        my $accessions = $payload->{accessions} || [];
-
-        foreach my $acc (@$accessions) {
-            next unless $acc && ref($acc) eq 'HASH';
-
-            my $stock_id         = $acc->{stock_id};
-            my $breeding_program = $acc->{breeding_program} // '';
-            my $new_stage        = $acc->{new_stage} // '';
-
-            next unless $stock_id;
-            next unless $breeding_program ne '';
-            next unless $new_stage ne '';
-
-            my $stage_prop_name = '';
-
-            foreach my $pair (split(/\s*,\s*/, $saved_program_stage)) {
-                next unless $pair;
-
-                my ($program_name, $prop_name) = split(/\s*\|\s*/, $pair, 2);
-
-                $program_name = '' unless defined $program_name;
-                $prop_name    = '' unless defined $prop_name;
-
-                $program_name =~ s/^\s+|\s+$//g;
-                $prop_name    =~ s/^\s+|\s+$//g;
-
-                if ($program_name eq $breeding_program) {
-                    $stage_prop_name = $prop_name;
-                    last;
-                }
-            }
-
-            next unless $stage_prop_name;
-
-            my $cvterm_row = SGN::Model::Cvterm->get_cvterm_row(
-                $schema,
-                $stage_prop_name,
-                'stock_property'
-            );
-
-            unless ($cvterm_row) {
-                die "Could not find stock_property cvterm [$stage_prop_name]";
-            }
-
-            my $type_id = $cvterm_row->cvterm_id;
-
-            my $stockprop = $schema->resultset('Stock::Stockprop')->search(
-                {
-                    stock_id => $stock_id,
-                    type_id  => $type_id,
-                },
-                {
-                    order_by => { -desc => 'stockprop_id' },
-                    rows     => 1,
-                }
-            )->single;
-
-            if ($stockprop) {
-                $stockprop->value($new_stage);
-                $stockprop->update();
-            }
-            else {
-                $schema->resultset('Stock::Stockprop')->create({
-                    stock_id => $stock_id,
-                    type_id  => $type_id,
-                    value    => $new_stage,
-                    rank     => 0,
-                });
-            }
-        }
     };
     if ($@) {
         return $self->status_bad_request($c, message => "Failed to save decisions: $@");
@@ -2086,50 +1943,8 @@ sub upload_decision_template_POST {
 }
 
 sub meetings : Path('meetings') : Args(0) : ActionClass('REST') {}
-
-sub _meeting_tracker_metadata {
-    my ($self, $project_name, $meeting_data) = @_;
-    $meeting_data = {} unless ref($meeting_data) eq 'HASH';
-
-    my @programs;
-    if (ref($meeting_data->{breeding_program_names}) eq 'ARRAY') {
-        @programs = @{$meeting_data->{breeding_program_names}};
-    }
-    elsif (defined($meeting_data->{breeding_program_name}) && $meeting_data->{breeding_program_name} ne '') {
-        @programs = ($meeting_data->{breeding_program_name});
-    }
-    elsif (ref($meeting_data->{breeding_programs}) eq 'ARRAY') {
-        @programs = @{$meeting_data->{breeding_programs}};
-    }
-    elsif (defined($meeting_data->{breeding_program}) && $meeting_data->{breeding_program} ne '') {
-        @programs = ($meeting_data->{breeding_program});
-    }
-
-    my @attendees;
-    if (ref($meeting_data->{attendees_list}) eq 'ARRAY') {
-        @attendees = @{$meeting_data->{attendees_list}};
-    }
-    elsif (ref($meeting_data->{attendees}) eq 'ARRAY') {
-        @attendees = @{$meeting_data->{attendees}};
-    }
-    elsif (defined($meeting_data->{attendees}) && $meeting_data->{attendees} ne '') {
-        @attendees = ($meeting_data->{attendees});
-    }
-
-    return {
-        meeting_name      => $meeting_data->{meeting_name} // $project_name // '',
-        meeting_programs  => join(', ', grep { defined($_) && $_ ne '' } @programs),
-        meeting_date      => $meeting_data->{date} // $meeting_data->{meeting_date} // '',
-        meeting_year      => $meeting_data->{year} // '',
-        meeting_location  => $meeting_data->{location_name} // $meeting_data->{location} // $meeting_data->{location_raw} // '',
-        meeting_attendees => join(', ', grep { defined($_) && $_ ne '' } @attendees),
-    };
-}
-
 sub meetings_GET {
     my ($self, $c) = @_;
-    $c->res->headers->header('Cache-Control' => 'no-store, no-cache, must-revalidate');
-
     my $dbh = $c->dbc->dbh;
 
     my $sp_person_id = $c->user() ? $c->user->get_object()->get_sp_person_id() : undef;
@@ -2142,7 +1957,9 @@ sub meetings_GET {
     my $mtg_json_type_id = $mtg_json_type_row ? $mtg_json_type_row->cvterm_id : undef;
 
     if (!$design_type_id || !$mtg_json_type_id) {
-        return $self->status_ok($c, entity => { rows => [] });
+        $c->stash->{rest} = { rows => [] };
+        $c->detach($c->view('JSON'));
+        return;
     }
 
     my $ps = CXGN::BreedersToolbox::Projects->new({ schema => $schema });
@@ -2185,7 +2002,9 @@ sub meetings_GET {
     }
 
     if (!@ids) {
-        return $self->status_ok($c, entity => { rows => [] });
+        $c->stash->{rest} = { rows => [] };
+        $c->detach($c->view('JSON'));
+        return;
     }
 
     my $ph = join(',', ('?') x @ids);
@@ -2211,8 +2030,9 @@ sub meetings_GET {
         my $mj  = $json_for{$pid};
         next unless defined $mj;
 
-        my ($decoded) = $self->_decode_meeting_json($mj);
-        $decoded = {} unless ref($decoded) eq 'HASH';
+        my $decoded = {};
+        eval { $decoded = decode_json($mj) if $mj; };
+        $decoded ||= {};
 
         my $is_saved = 0;
         if (
@@ -2258,22 +2078,17 @@ sub meetings_GET {
         }
 
         $decoded->{saved} = $is_saved ? JSON::true : JSON::false;
-        my $tracker_metadata = $self->_meeting_tracker_metadata(
-            $p->{project_name},
-            $decoded,
-        );
 
         push @rows, {
-            %$tracker_metadata,
             project_id    => $pid,
             project_name  => $p->{project_name},
-            meeting_data  => $decoded,
             meeting_json  => encode_json($decoded),
             meeting_saved => $is_saved ? JSON::true : JSON::false,
         };
     }
 
-    return $self->status_ok($c, entity => { rows => \@rows });
+    $c->stash->{rest} = { rows => \@rows };
+    $c->detach($c->view('JSON'));
 }
 
 sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args(0) {
@@ -2291,18 +2106,16 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
     my $sth = $dbh->prepare(q{
         SELECT p.project_id, p.name, pp.value
         FROM project p
-        LEFT JOIN LATERAL (
-            SELECT projectprop.value
-            FROM projectprop
-            JOIN cvterm ON cvterm.cvterm_id = projectprop.type_id
-            JOIN cv ON cv.cv_id = cvterm.cv_id
-            WHERE projectprop.project_id = p.project_id
-              AND cvterm.name = 'meeting_json'
-              AND cv.name = 'project_property'
-            ORDER BY projectprop.projectprop_id DESC
-            LIMIT 1
-        ) pp ON TRUE
+        LEFT JOIN projectprop pp
+            ON pp.project_id = p.project_id
+           AND pp.type_id = (
+               SELECT cvterm_id
+               FROM cvterm
+               WHERE name = 'meeting_json'
+               LIMIT 1
+           )
         WHERE p.project_id = ?
+        LIMIT 1
     });
     $sth->execute($meeting_id);
 
@@ -2317,33 +2130,15 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
 
     my $data = {};
     if ($json_value) {
-        my ($decoded) = $self->_decode_meeting_json($json_value);
-        $data = $decoded if ref($decoded) eq 'HASH';
+        eval { $data = decode_json($json_value); };
+        if ($@) {
+            $data = {};
+        }
     }
 
     my $meeting_notes = $data->{meeting_notes} // '';
     my $accessions    = $data->{accessions} || [];
     my $attendees     = $data->{attendees};
-    my $meeting_date  = $data->{date} // '';
-    my $meeting_year  = $data->{year} // '';
-    my $location      = $data->{location_name} // $data->{location} // '';
-    my $meeting_status = $data->{meeting_status} // '';
-
-    my @programs;
-    if (ref($data->{breeding_program_names}) eq 'ARRAY') {
-        @programs = @{$data->{breeding_program_names}};
-    }
-    elsif (defined($data->{breeding_program_name}) && $data->{breeding_program_name} ne '') {
-        @programs = ($data->{breeding_program_name});
-    }
-    elsif (ref($data->{breeding_programs}) eq 'ARRAY') {
-        @programs = @{$data->{breeding_programs}};
-    }
-    elsif (defined($data->{breeding_program}) && $data->{breeding_program} ne '') {
-        @programs = ($data->{breeding_program});
-    }
-
-    my $programs_html = join(', ', grep { defined($_) && $_ ne '' } @programs);
 
     my $saved_status = lc($data->{saved_status} // '');
 
@@ -2399,14 +2194,6 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
     $meeting_notes =~ s/>/&gt;/g;
     $meeting_notes =~ s/"/&quot;/g;
     $meeting_notes =~ s/\n/<br>/g;
-
-    for ($meeting_date, $meeting_year, $location, $meeting_status, $programs_html) {
-        $_ = '' unless defined $_;
-        s/&/&amp;/g;
-        s/</&lt;/g;
-        s/>/&gt;/g;
-        s/"/&quot;/g;
-    }
 
     my $attendees_html = '';
     if (ref($attendees) eq 'ARRAY') {
@@ -2487,11 +2274,6 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
   <div class="meta">
     <strong>Meeting:</strong> $safe_project_name<br>
     <strong>Meeting ID:</strong> $meeting_id<br>
-    <strong>Programs:</strong> $programs_html<br>
-    <strong>Date:</strong> $meeting_date<br>
-    <strong>Year:</strong> $meeting_year<br>
-    <strong>Location:</strong> $location<br>
-    <strong>Status:</strong> $meeting_status<br>
     <strong>Attendees:</strong> $attendees_html
   </div>
 
@@ -2666,63 +2448,19 @@ sub create : Path('create') Args(0) {
         trial_name        => $trial_name,
         trial_description => $description,
         project_type      => 'meeting_project',
-        skip_design_store => 1,
     });
 
     my ($project_id, $nd_experiment_id);
     my $err;
     try {
-        my $pp_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'meeting_json', 'project_property')
-            or die "cvterm meeting_json not found in cv project_property";
-        my $type_id = $pp_type->cvterm_id;
-        my $design_prop_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'design', 'project_property')
-            or die "cvterm design not found in cv project_property";
+        $tc->save_trial();
 
-        my $proj_row;
-        my $save_result = $tc->save_trial();
-        if (ref($save_result) eq 'HASH' && $save_result->{error}) {
-            # TrialCreate creates the base project before layout validation.
-            # A previous failed meeting attempt can therefore be completed on
-            # retry, but only when it is an unfinished Meeting owned by the
-            # same user.
-            if ($save_result->{error} =~ /Trial name already exists/i) {
-                my $candidate = $schema->resultset('Project::Project')->find({ name => $trial_name });
-                my $candidate_design = $candidate
-                    ? $candidate->search_related('projectprops', {
-                        type_id => $design_prop_type->cvterm_id,
-                        value   => 'Meeting',
-                    })->first
-                    : undef;
-                my $candidate_json = $candidate
-                    ? $candidate->search_related('projectprops', { type_id => $type_id })->first
-                    : undef;
-                my ($same_owner) = $candidate
-                    ? $dbh->selectrow_array(
-                        'SELECT 1 FROM phenome.project_owner WHERE project_id = ? AND sp_person_id = ?',
-                        undef,
-                        $candidate->project_id,
-                        $owner_id,
-                    )
-                    : ();
+        $project_id       = eval { $tc->get_trial_id }         || eval { $tc->get_project_id } || undef;
+        $nd_experiment_id = eval { $tc->get_nd_experiment_id } || undef;
 
-                $proj_row = $candidate
-                    if $candidate_design && !$candidate_json && $same_owner;
-            }
-
-            die $save_result->{error} unless $proj_row;
-        }
-
-        unless ($proj_row) {
-            $project_id       = (ref($save_result) eq 'HASH' ? $save_result->{trial_id} : undef)
-                             || eval { $tc->get_trial_id }
-                             || eval { $tc->get_project_id }
-                             || undef;
-            $nd_experiment_id = eval { $tc->get_nd_experiment_id } || undef;
-
-            $proj_row = $project_id
-                ? $schema->resultset('Project::Project')->find({ project_id => $project_id })
-                : $schema->resultset('Project::Project')->find({ name => $trial_name });
-        }
+        my $proj_row = $project_id
+            ? $schema->resultset('Project::Project')->find({ project_id => $project_id })
+            : $schema->resultset('Project::Project')->find({ name => $trial_name });
 
         die "Project not found after save_trial" unless $proj_row;
 
@@ -2741,6 +2479,10 @@ sub create : Path('create') Args(0) {
             location_raw            => $location_in,
         };
         my $val = encode_json($meeting_payload);
+
+        my $pp_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'meeting_json', 'project_property')
+            or die "cvterm meeting_json not found in cv project_property";
+        my $type_id = $pp_type->cvterm_id;
 
         my $existing = $proj_row->search_related('projectprops', { type_id => $type_id })->first;
         if ($existing) {
@@ -2790,6 +2532,88 @@ sub create : Path('create') Args(0) {
             attendees         => $attendees,
         },
     }));
+}
+
+sub _breeding_stage_property_name {
+    my ($self, $breeding_program, $saved_program_stage) = @_;
+
+    $breeding_program = $self->_trim($breeding_program);
+    return '' unless $breeding_program ne '';
+
+    my @configured_values = ref($saved_program_stage) eq 'ARRAY'
+        ? @$saved_program_stage
+        : ($saved_program_stage);
+
+    foreach my $configured_value (@configured_values) {
+        next unless defined($configured_value) && $configured_value ne '';
+
+        foreach my $pair (split(/\s*,\s*/, $configured_value)) {
+            my ($program_name, $property_name) = split(/\s*\|\s*/, $pair, 2);
+
+            $program_name  = $self->_trim($program_name);
+            $property_name = $self->_trim($property_name);
+
+            return $property_name
+                if $program_name eq $breeding_program && $property_name ne '';
+        }
+    }
+
+    return $breeding_program . '_Stage';
+}
+
+sub _update_breeding_stage_stockprop {
+    my ($self, %args) = @_;
+
+    my $schema           = $args{schema};
+    my $stock_id         = $args{stock_id};
+    my $breeding_program = $self->_trim($args{breeding_program});
+    my $new_stage        = $args{new_stage};
+
+    die 'Missing schema while updating breeding stage' unless $schema;
+    die 'Missing stock_id while updating breeding stage' unless $stock_id;
+    die 'Missing breeding program while updating breeding stage'
+        unless $breeding_program ne '';
+    die 'Missing new stage while updating breeding stage'
+        unless defined($new_stage) && $new_stage ne '';
+
+    my $stage_prop_name = $self->_breeding_stage_property_name(
+        $breeding_program,
+        $args{saved_program_stage},
+    );
+    my $cvterm_row = SGN::Model::Cvterm->get_cvterm_row(
+        $schema,
+        $stage_prop_name,
+        'stock_property'
+    );
+
+    die "Could not find breeding stage stock_property cvterm [$stage_prop_name] "
+        . "for breeding program [$breeding_program]"
+        unless $cvterm_row;
+
+    my $stockprop = $schema->resultset('Stock::Stockprop')->search(
+        {
+            stock_id => $stock_id,
+            type_id  => $cvterm_row->cvterm_id,
+        },
+        {
+            order_by => { -desc => 'stockprop_id' },
+            rows     => 1,
+        }
+    )->first;
+
+    if ($stockprop) {
+        $stockprop->update({ value => $new_stage });
+    }
+    else {
+        $stockprop = $schema->resultset('Stock::Stockprop')->create({
+            stock_id => $stock_id,
+            type_id  => $cvterm_row->cvterm_id,
+            value    => $new_stage,
+            rank     => 0,
+        });
+    }
+
+    return $stockprop;
 }
 
 sub _trim {
@@ -2890,21 +2714,9 @@ sub _resolve_program_name {
 
 sub _resolve_location_name {
     my ($schema, $in) = @_;
-    return unless defined($in) && $in ne '';
-
-    my $query = $in =~ /^\d+$/
-        ? { nd_geolocation_id => $in }
-        : { description => $in };
-
-    my $row;
-    foreach my $resultset_name ('NaturalDiversity::NdGeolocation', 'NdGeolocation') {
-        my $resultset = eval { $schema->resultset($resultset_name) };
-        next unless $resultset;
-
-        $row = eval { $resultset->find($query) };
-        last if $row;
-    }
-
+    return $in unless defined $in && $in =~ /^\d+$/;
+    my $row = $schema->resultset('NaturalDiversity::NdGeolocation')->find({ nd_geolocation_id => $in })
+          || $schema->resultset('NdGeolocation')->find({ nd_geolocation_id => $in });
     return unless $row;
     return $row->can('description') ? ($row->description // '') : ($row->can('name') ? $row->name : '');
 }

--- a/lib/SGN/Controller/AJAX/DecisionMeeting.pm
+++ b/lib/SGN/Controller/AJAX/DecisionMeeting.pm
@@ -174,6 +174,8 @@ sub locations_GET {
     return $self->status_forbidden($c, message => 'Login required')
         unless $c->user;
 
+    $c->res->headers->header('Cache-Control' => 'no-store, no-cache, must-revalidate');
+
     my $locations = $self->_configured_meeting_locations(
         $c->config->{meeting_locations}
     );

--- a/lib/SGN/Controller/AJAX/DecisionMeeting.pm
+++ b/lib/SGN/Controller/AJAX/DecisionMeeting.pm
@@ -1,6 +1,7 @@
 # lib/SGN/Controller/AJAX/DecisionMeeting.pm
 package SGN::Controller::AJAX::DecisionMeeting;
 use Moose;
+use utf8 ();
 use CXGN::List;
 use JSON;
 use JSON qw(decode_json);
@@ -35,6 +36,32 @@ sub ping : Path('ping') : Args(0) : ActionClass('REST') {}
 sub ping_GET {
     my ($self, $c) = @_;
     $self->status_ok($c, entity => { ok => 1, user => ($c->user ? 1 : 0) });
+}
+
+sub _decode_meeting_json {
+    my ($self, $json_text) = @_;
+    return wantarray ? (undef, 'Meeting JSON is undefined') : undef
+        unless defined $json_text;
+
+    # DBD::Pg may return either UTF-8 bytes or an already-decoded character
+    # string. Try both modes so production metadata containing accents is not
+    # discarded as invalid JSON.
+    my @utf8_modes = utf8::is_utf8($json_text) ? (0, 1) : (1, 0);
+    my $last_error = '';
+
+    foreach my $utf8_mode (@utf8_modes) {
+        my $decoded;
+        eval {
+            $decoded = JSON->new
+                ->allow_nonref
+                ->utf8($utf8_mode)
+                ->decode($json_text);
+        };
+        return wantarray ? ($decoded, '') : $decoded unless $@;
+        $last_error = $@;
+    }
+
+    return wantarray ? (undef, $last_error) : undef;
 }
 
 sub lists : Path('lists') : Args(0) : ActionClass('REST') {}
@@ -114,30 +141,50 @@ sub programs_GET {
 }
 
 sub locations : Path('locations') : ActionClass('REST') { }
+
+sub _configured_meeting_locations {
+    my ($self, $raw_locations) = @_;
+
+    my @config_values = ref($raw_locations) eq 'ARRAY'
+        ? @$raw_locations
+        : (defined($raw_locations) ? $raw_locations : ());
+
+    my (@locations, %seen);
+    foreach my $config_value (@config_values) {
+        next if !defined($config_value) || ref($config_value);
+
+        # Location names can contain commas, so the configured list uses a
+        # pipe separator (for example "Santa Helena de Goias, GO|Chapeco, SC").
+        foreach my $location (split /\|/, $config_value) {
+            $location =~ s/^\s+|\s+$//g;
+            next if $location eq '';
+
+            my $key = lc($location);
+            next if $seen{$key}++;
+            push @locations, $location;
+        }
+    }
+
+    return \@locations;
+}
+
 sub locations_GET {
     my ($self, $c) = @_;
 
     return $self->status_forbidden($c, message => 'Login required')
         unless $c->user;
 
-    my $schema = $c->dbic_schema('Bio::Chado::Schema');
-    my $ps     = CXGN::BreedersToolbox::Projects->new({ schema => $schema });
-    my $locs   = $ps->get_locations() || [];
+    $c->res->headers->header('Cache-Control' => 'no-store, no-cache, must-revalidate');
 
-    my @items;
-    foreach my $r (@$locs) {
-        my ($id, $desc, $lat, $lon, $alt, $count) = @$r;
-        next unless defined $id;
-
-        push @items, {
-            location_id => $id,
-            name        => defined $desc && $desc ne '' ? $desc : "Location $id",
-            latitude    => $lat,
-            longitude   => $lon,
-            altitude    => $alt,
-            plot_count  => $count,
-        };
-    }
+    my $locations = $self->_configured_meeting_locations(
+        $c->config->{meeting_locations}
+    );
+    my @items = map {
+        +{
+            location_id => $_,
+            name        => $_,
+        }
+    } @$locations;
 
     return $self->status_ok($c, entity => \@items);
 }
@@ -221,9 +268,11 @@ sub _decision_rows_entity {
             FROM projectprop pp
             WHERE pp.project_id = ?
               AND pp.type_id = (
-                  SELECT cvterm_id
+                  SELECT cvterm.cvterm_id
                   FROM cvterm
-                  WHERE name = 'meeting_json'
+                  JOIN cv USING (cv_id)
+                  WHERE cvterm.name = 'meeting_json'
+                    AND cv.name = 'project_property'
                   LIMIT 1
               )
             ORDER BY pp.projectprop_id DESC
@@ -233,9 +282,8 @@ sub _decision_rows_entity {
 
         my ($meeting_json) = $sth->fetchrow_array;
         if ($meeting_json) {
-            my $decoded = {};
-            eval { $decoded = decode_json($meeting_json); };
-            $decoded ||= {};
+            my ($decoded) = $self->_decode_meeting_json($meeting_json);
+            $decoded = {} unless ref($decoded) eq 'HASH';
 
             if ($decoded->{breeding_program_name}) {
                 $selected_program = $decoded->{breeding_program_name};
@@ -573,9 +621,11 @@ sub _meeting_year_from_meeting_id {
         FROM projectprop pp
         WHERE pp.project_id = ?
           AND pp.type_id = (
-              SELECT cvterm_id
+              SELECT cvterm.cvterm_id
               FROM cvterm
-              WHERE name = 'meeting_json'
+              JOIN cv USING (cv_id)
+              WHERE cvterm.name = 'meeting_json'
+                AND cv.name = 'project_property'
               LIMIT 1
           )
         ORDER BY pp.projectprop_id DESC
@@ -586,9 +636,8 @@ sub _meeting_year_from_meeting_id {
     my ($meeting_json) = $sth->fetchrow_array;
     return '' unless $meeting_json;
 
-    my $decoded = {};
-    eval { $decoded = decode_json($meeting_json); };
-    $decoded ||= {};
+    my ($decoded) = $self->_decode_meeting_json($meeting_json);
+    $decoded = {} unless ref($decoded) eq 'HASH';
 
     my $date = $decoded->{date} || '';
     return $1 if $date =~ /^(\d{4})-/;
@@ -1666,6 +1715,29 @@ sub dataset_plot_data_GET {
 }
 
 sub save_all_decisions : Path('save_all_decisions') : Args(0) : ActionClass('REST') { }
+
+sub _merge_decisions_into_meeting {
+    my ($self, $meeting_data, $decision_data, $saved_at) = @_;
+
+    $meeting_data  = {} unless ref($meeting_data) eq 'HASH';
+    $decision_data = {} unless ref($decision_data) eq 'HASH';
+
+    # Meeting creation owns the metadata. Saving decisions may add report
+    # fields, but must not replace the original program, date, location, or
+    # attendees with an incomplete client payload.
+    my %merged = (%$decision_data, %$meeting_data);
+    foreach my $key (qw(accessions list_id meeting_notes)) {
+        $merged{$key} = $decision_data->{$key}
+            if exists $decision_data->{$key};
+    }
+
+    $merged{saved}        = JSON::true;
+    $merged{saved_at}     = defined($saved_at) ? $saved_at : scalar localtime();
+    $merged{saved_status} = 'successfully';
+
+    return \%merged;
+}
+
 sub save_all_decisions_POST {
     my ($self, $c) = @_;
 
@@ -1722,14 +1794,44 @@ sub save_all_decisions_POST {
         );
     }
 
-    $payload->{saved}        = JSON::true;
-    $payload->{saved_at}     = scalar localtime();
-    $payload->{saved_status} = 'successfully';
+    my $meeting_json_type = SGN::Model::Cvterm->get_cvterm_row(
+        $schema,
+        'meeting_json',
+        'project_property',
+    );
+    unless ($meeting_json_type) {
+        return $self->status_bad_request($c, message => 'Meeting metadata type not found');
+    }
+
+    my $meeting_prop = $schema->resultset('Project::Projectprop')->search(
+        {
+            project_id => $meeting_id,
+            type_id    => $meeting_json_type->cvterm_id,
+        },
+        {
+            order_by => { -desc => 'projectprop_id' },
+            rows     => 1,
+        }
+    )->first;
+    unless ($meeting_prop && defined($meeting_prop->value)) {
+        return $self->status_bad_request($c, message => 'Meeting metadata not found');
+    }
+
+    my ($meeting_data, $meeting_decode_error) =
+        $self->_decode_meeting_json($meeting_prop->value);
+    if ($meeting_decode_error || ref($meeting_data) ne 'HASH') {
+        return $self->status_bad_request($c, message => 'Stored meeting metadata is invalid');
+    }
+
+    my $updated_payload = $self->_merge_decisions_into_meeting(
+        $meeting_data,
+        $payload,
+    );
 
     my $json_text;
     eval {
         require JSON;
-        $json_text = JSON->new->allow_nonref->canonical->encode($payload);
+        $json_text = JSON->new->allow_nonref->canonical->encode($updated_payload);
     };
     if ($@) {
         return $self->status_bad_request($c, message => 'Could not encode payload to JSON');
@@ -1737,17 +1839,7 @@ sub save_all_decisions_POST {
 
     eval {
         $schema->txn_do(sub {
-            my $sth = $schema->storage->dbh->prepare(q{
-                UPDATE projectprop
-                SET value = ?
-                WHERE project_id = ?
-                  AND type_id = (
-                      SELECT cvterm_id
-                      FROM cvterm
-                      WHERE name = 'meeting_json'
-                  )
-            });
-            $sth->execute($json_text, $meeting_id);
+            $meeting_prop->update({ value => $json_text });
 
             my $accessions = $payload->{accessions} || [];
 
@@ -1943,8 +2035,49 @@ sub upload_decision_template_POST {
 }
 
 sub meetings : Path('meetings') : Args(0) : ActionClass('REST') {}
+
+sub _meeting_tracker_metadata {
+    my ($self, $project_name, $meeting_data) = @_;
+    $meeting_data = {} unless ref($meeting_data) eq 'HASH';
+
+    my @programs;
+    if (ref($meeting_data->{breeding_program_names}) eq 'ARRAY') {
+        @programs = @{$meeting_data->{breeding_program_names}};
+    }
+    elsif (defined($meeting_data->{breeding_program_name}) && $meeting_data->{breeding_program_name} ne '') {
+        @programs = ($meeting_data->{breeding_program_name});
+    }
+    elsif (ref($meeting_data->{breeding_programs}) eq 'ARRAY') {
+        @programs = @{$meeting_data->{breeding_programs}};
+    }
+    elsif (defined($meeting_data->{breeding_program}) && $meeting_data->{breeding_program} ne '') {
+        @programs = ($meeting_data->{breeding_program});
+    }
+
+    my @attendees;
+    if (ref($meeting_data->{attendees_list}) eq 'ARRAY') {
+        @attendees = @{$meeting_data->{attendees_list}};
+    }
+    elsif (ref($meeting_data->{attendees}) eq 'ARRAY') {
+        @attendees = @{$meeting_data->{attendees}};
+    }
+    elsif (defined($meeting_data->{attendees}) && $meeting_data->{attendees} ne '') {
+        @attendees = ($meeting_data->{attendees});
+    }
+
+    return {
+        meeting_name      => $meeting_data->{meeting_name} // $project_name // '',
+        meeting_programs  => join(', ', grep { defined($_) && $_ ne '' } @programs),
+        meeting_date      => $meeting_data->{date} // $meeting_data->{meeting_date} // '',
+        meeting_year      => $meeting_data->{year} // '',
+        meeting_location  => $meeting_data->{location_name} // $meeting_data->{location} // $meeting_data->{location_raw} // '',
+        meeting_attendees => join(', ', grep { defined($_) && $_ ne '' } @attendees),
+    };
+}
+
 sub meetings_GET {
     my ($self, $c) = @_;
+    $c->res->headers->header('Cache-Control' => 'no-store, no-cache, must-revalidate');
     my $dbh = $c->dbc->dbh;
 
     my $sp_person_id = $c->user() ? $c->user->get_object()->get_sp_person_id() : undef;
@@ -2030,9 +2163,8 @@ sub meetings_GET {
         my $mj  = $json_for{$pid};
         next unless defined $mj;
 
-        my $decoded = {};
-        eval { $decoded = decode_json($mj) if $mj; };
-        $decoded ||= {};
+        my ($decoded) = $self->_decode_meeting_json($mj);
+        $decoded = {} unless ref($decoded) eq 'HASH';
 
         my $is_saved = 0;
         if (
@@ -2078,10 +2210,16 @@ sub meetings_GET {
         }
 
         $decoded->{saved} = $is_saved ? JSON::true : JSON::false;
+        my $tracker_metadata = $self->_meeting_tracker_metadata(
+            $p->{project_name},
+            $decoded,
+        );
 
         push @rows, {
+            %$tracker_metadata,
             project_id    => $pid,
             project_name  => $p->{project_name},
+            meeting_data  => $decoded,
             meeting_json  => encode_json($decoded),
             meeting_saved => $is_saved ? JSON::true : JSON::false,
         };
@@ -2109,9 +2247,11 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
         LEFT JOIN projectprop pp
             ON pp.project_id = p.project_id
            AND pp.type_id = (
-               SELECT cvterm_id
+               SELECT cvterm.cvterm_id
                FROM cvterm
-               WHERE name = 'meeting_json'
+               JOIN cv USING (cv_id)
+               WHERE cvterm.name = 'meeting_json'
+                 AND cv.name = 'project_property'
                LIMIT 1
            )
         WHERE p.project_id = ?
@@ -2130,15 +2270,33 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
 
     my $data = {};
     if ($json_value) {
-        eval { $data = decode_json($json_value); };
-        if ($@) {
-            $data = {};
-        }
+        my ($decoded) = $self->_decode_meeting_json($json_value);
+        $data = $decoded if ref($decoded) eq 'HASH';
     }
 
     my $meeting_notes = $data->{meeting_notes} // '';
     my $accessions    = $data->{accessions} || [];
     my $attendees     = $data->{attendees};
+    my $meeting_date  = $data->{date} // $data->{meeting_date} // '';
+    my $meeting_year  = $data->{year} // '';
+    my $location      = $data->{location_name} // $data->{location} // $data->{location_raw} // '';
+    my $meeting_status = $data->{meeting_status} // '';
+
+    my @programs;
+    if (ref($data->{breeding_program_names}) eq 'ARRAY') {
+        @programs = @{$data->{breeding_program_names}};
+    }
+    elsif (defined($data->{breeding_program_name}) && $data->{breeding_program_name} ne '') {
+        @programs = ($data->{breeding_program_name});
+    }
+    elsif (ref($data->{breeding_programs}) eq 'ARRAY') {
+        @programs = @{$data->{breeding_programs}};
+    }
+    elsif (defined($data->{breeding_program}) && $data->{breeding_program} ne '') {
+        @programs = ($data->{breeding_program});
+    }
+
+    my $programs_html = join(', ', grep { defined($_) && $_ ne '' } @programs);
 
     my $saved_status = lc($data->{saved_status} // '');
 
@@ -2194,6 +2352,14 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
     $meeting_notes =~ s/>/&gt;/g;
     $meeting_notes =~ s/"/&quot;/g;
     $meeting_notes =~ s/\n/<br>/g;
+
+    for ($meeting_date, $meeting_year, $location, $meeting_status, $programs_html) {
+        $_ = '' unless defined $_;
+        s/&/&amp;/g;
+        s/</&lt;/g;
+        s/>/&gt;/g;
+        s/"/&quot;/g;
+    }
 
     my $attendees_html = '';
     if (ref($attendees) eq 'ARRAY') {
@@ -2274,6 +2440,11 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
   <div class="meta">
     <strong>Meeting:</strong> $safe_project_name<br>
     <strong>Meeting ID:</strong> $meeting_id<br>
+    <strong>Programs:</strong> $programs_html<br>
+    <strong>Date:</strong> $meeting_date<br>
+    <strong>Year:</strong> $meeting_year<br>
+    <strong>Location:</strong> $location<br>
+    <strong>Status:</strong> $meeting_status<br>
     <strong>Attendees:</strong> $attendees_html
   </div>
 
@@ -2448,19 +2619,63 @@ sub create : Path('create') Args(0) {
         trial_name        => $trial_name,
         trial_description => $description,
         project_type      => 'meeting_project',
+        skip_design_store => 1,
     });
 
     my ($project_id, $nd_experiment_id);
     my $err;
     try {
-        $tc->save_trial();
+        my $pp_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'meeting_json', 'project_property')
+            or die "cvterm meeting_json not found in cv project_property";
+        my $type_id = $pp_type->cvterm_id;
+        my $design_prop_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'design', 'project_property')
+            or die "cvterm design not found in cv project_property";
 
-        $project_id       = eval { $tc->get_trial_id }         || eval { $tc->get_project_id } || undef;
-        $nd_experiment_id = eval { $tc->get_nd_experiment_id } || undef;
+        my $proj_row;
+        my $save_result = $tc->save_trial();
+        if (ref($save_result) eq 'HASH' && $save_result->{error}) {
+            # TrialCreate creates the base project before layout validation.
+            # A previous failed meeting attempt can therefore be completed on
+            # retry, but only when it is an unfinished Meeting owned by the
+            # same user.
+            if ($save_result->{error} =~ /Trial name already exists/i) {
+                my $candidate = $schema->resultset('Project::Project')->find({ name => $trial_name });
+                my $candidate_design = $candidate
+                    ? $candidate->search_related('projectprops', {
+                        type_id => $design_prop_type->cvterm_id,
+                        value   => 'Meeting',
+                    })->first
+                    : undef;
+                my $candidate_json = $candidate
+                    ? $candidate->search_related('projectprops', { type_id => $type_id })->first
+                    : undef;
+                my ($same_owner) = $candidate
+                    ? $dbh->selectrow_array(
+                        'SELECT 1 FROM phenome.project_owner WHERE project_id = ? AND sp_person_id = ?',
+                        undef,
+                        $candidate->project_id,
+                        $owner_id,
+                    )
+                    : ();
 
-        my $proj_row = $project_id
-            ? $schema->resultset('Project::Project')->find({ project_id => $project_id })
-            : $schema->resultset('Project::Project')->find({ name => $trial_name });
+                $proj_row = $candidate
+                    if $candidate_design && !$candidate_json && $same_owner;
+            }
+
+            die $save_result->{error} unless $proj_row;
+        }
+
+        unless ($proj_row) {
+            $project_id       = (ref($save_result) eq 'HASH' ? $save_result->{trial_id} : undef)
+                             || eval { $tc->get_trial_id }
+                             || eval { $tc->get_project_id }
+                             || undef;
+            $nd_experiment_id = eval { $tc->get_nd_experiment_id } || undef;
+
+            $proj_row = $project_id
+                ? $schema->resultset('Project::Project')->find({ project_id => $project_id })
+                : $schema->resultset('Project::Project')->find({ name => $trial_name });
+        }
 
         die "Project not found after save_trial" unless $proj_row;
 
@@ -2479,10 +2694,6 @@ sub create : Path('create') Args(0) {
             location_raw            => $location_in,
         };
         my $val = encode_json($meeting_payload);
-
-        my $pp_type = SGN::Model::Cvterm->get_cvterm_row($schema, 'meeting_json', 'project_property')
-            or die "cvterm meeting_json not found in cv project_property";
-        my $type_id = $pp_type->cvterm_id;
 
         my $existing = $proj_row->search_related('projectprops', { type_id => $type_id })->first;
         if ($existing) {
@@ -2714,9 +2925,21 @@ sub _resolve_program_name {
 
 sub _resolve_location_name {
     my ($schema, $in) = @_;
-    return $in unless defined $in && $in =~ /^\d+$/;
-    my $row = $schema->resultset('NaturalDiversity::NdGeolocation')->find({ nd_geolocation_id => $in })
-          || $schema->resultset('NdGeolocation')->find({ nd_geolocation_id => $in });
+    return unless defined($in) && $in ne '';
+
+    my $query = $in =~ /^\d+$/
+        ? { nd_geolocation_id => $in }
+        : { description => $in };
+
+    my $row;
+    foreach my $resultset_name ('NaturalDiversity::NdGeolocation', 'NdGeolocation') {
+        my $resultset = eval { $schema->resultset($resultset_name) };
+        next unless $resultset;
+
+        $row = eval { $resultset->find($query) };
+        last if $row;
+    }
+
     return unless $row;
     return $row->can('description') ? ($row->description // '') : ($row->can('name') ? $row->name : '');
 }

--- a/lib/SGN/Controller/AJAX/DecisionMeeting.pm
+++ b/lib/SGN/Controller/AJAX/DecisionMeeting.pm
@@ -22,6 +22,7 @@ use Excel::Writer::XLSX;
 use Spreadsheet::ParseExcel;
 use Spreadsheet::ParseXLSX;
 use Spreadsheet::WriteExcel;
+use Time::Piece ();
 
 BEGIN { extends 'Catalyst::Controller::REST' }
 
@@ -62,6 +63,20 @@ sub _decode_meeting_json {
     }
 
     return wantarray ? (undef, $last_error) : undef;
+}
+
+sub _normalize_meeting_date {
+    my ($self, $value) = @_;
+    return '' unless defined $value && !ref($value);
+
+    $value =~ s/^\s+|\s+$//g;
+    return '' unless $value =~ /^(\d{4})[\/-](\d{2})[\/-](\d{2})$/;
+
+    my $canonical = "$1-$2-$3";
+    my $parsed = eval { Time::Piece->strptime($canonical, '%Y-%m-%d') };
+    return '' unless $parsed && $parsed->strftime('%Y-%m-%d') eq $canonical;
+
+    return $canonical;
 }
 
 sub lists : Path('lists') : Args(0) : ActionClass('REST') {}
@@ -640,7 +655,7 @@ sub _meeting_year_from_meeting_id {
     $decoded = {} unless ref($decoded) eq 'HASH';
 
     my $date = $decoded->{date} || '';
-    return $1 if $date =~ /^(\d{4})-/;
+    return $1 if $date =~ /^(\d{4})[\/-]/;
 
     return '';
 }
@@ -685,7 +700,7 @@ sub _compute_stage_transition_data {
     my $breeding_stages  = $args{breeding_stages} || '';
     my $schema           = $args{schema};
 
-    if ($decision eq 'drop' && $meeting_date =~ /^(\d{4})-/) {
+    if ($decision eq 'drop' && $meeting_date =~ /^(\d{4})[\/-]/) {
         $year = $1;
     }
 
@@ -2065,10 +2080,14 @@ sub _meeting_tracker_metadata {
         @attendees = ($meeting_data->{attendees});
     }
 
+    my $meeting_date = $self->_normalize_meeting_date(
+        $meeting_data->{date} // $meeting_data->{meeting_date} // ''
+    );
+
     return {
         meeting_name      => $meeting_data->{meeting_name} // $project_name // '',
         meeting_programs  => join(', ', grep { defined($_) && $_ ne '' } @programs),
-        meeting_date      => $meeting_data->{date} // $meeting_data->{meeting_date} // '',
+        meeting_date      => $meeting_date,
         meeting_year      => $meeting_data->{year} // '',
         meeting_location  => $meeting_data->{location_name} // $meeting_data->{location} // $meeting_data->{location_raw} // '',
         meeting_attendees => join(', ', grep { defined($_) && $_ ne '' } @attendees),
@@ -2277,7 +2296,9 @@ sub meeting_report_html : Path('/ajax/decisionmeeting/meeting_report_html') Args
     my $meeting_notes = $data->{meeting_notes} // '';
     my $accessions    = $data->{accessions} || [];
     my $attendees     = $data->{attendees};
-    my $meeting_date  = $data->{date} // $data->{meeting_date} // '';
+    my $meeting_date  = $self->_normalize_meeting_date(
+        $data->{date} // $data->{meeting_date} // ''
+    );
     my $meeting_year  = $data->{year} // '';
     my $location      = $data->{location_name} // $data->{location} // $data->{location_raw} // '';
     my $meeting_status = $data->{meeting_status} // '';
@@ -2534,7 +2555,9 @@ sub create : Path('create') Args(0) {
     my $program_in    = $p->{breeding_program} // '';
     my $location_in   = $p->{location}         // '';
     my $trial_year    = $p->{year}             // '';
-    my $planting_date = $p->{date}             // undef;
+    my $date_in       = $p->{date}             // '';
+    my $meeting_date  = $self->_normalize_meeting_date($date_in);
+    my $planting_date = $meeting_date;
     my $description   = $p->{data}             // '';
     my $meeting_status= $p->{meeting_status}   // '';
 
@@ -2544,6 +2567,10 @@ sub create : Path('create') Args(0) {
         unless ($program_in || ref($p->{breeding_programs}) eq 'ARRAY');
     return $self->status_bad_request($c, message => "Missing location")
         unless $location_in;
+    return $self->status_bad_request($c, message => "Missing date")
+        unless $date_in;
+    return $self->status_bad_request($c, message => "Date must use the YYYY-MM-DD format")
+        unless $meeting_date;
 
     my @program_in_list =
         ref($p->{breeding_programs}) eq 'ARRAY'
@@ -2689,7 +2716,7 @@ sub create : Path('create') Args(0) {
             breeding_program_choice => $program_choice,
             breeding_program_name   => $program_name,
             year                    => ($trial_year || undef),
-            date                    => ($planting_date || undef),
+            date                    => ($meeting_date || undef),
             location                => $location_name,
             location_raw            => $location_in,
         };
@@ -2719,7 +2746,7 @@ sub create : Path('create') Args(0) {
                 breeding_program  => $program_choice,
                 location          => $location_in,
                 year              => $trial_year,
-                date              => $planting_date,
+                date              => $meeting_date,
                 attendees         => $attendees,
             },
         }));
@@ -2739,7 +2766,7 @@ sub create : Path('create') Args(0) {
             breeding_program  => $program_name,
             location          => $location_name,
             year              => $trial_year,
-            date              => $planting_date,
+            date              => $meeting_date,
             attendees         => $attendees,
         },
     }));
@@ -2945,16 +2972,57 @@ sub _resolve_location_name {
 }
 
 sub people : Path('people') : Args(0) : ActionClass('REST') { }
+
+sub _configured_meeting_roles {
+    my ($self, $raw_roles) = @_;
+
+    my @config_values = ref($raw_roles) eq 'ARRAY'
+        ? @$raw_roles
+        : (defined($raw_roles) ? $raw_roles : ());
+
+    my (@roles, %seen);
+    foreach my $config_value (@config_values) {
+        next if !defined($config_value) || ref($config_value);
+
+        foreach my $role (split /,/, $config_value) {
+            $role =~ s/^\s+|\s+$//g;
+            next if $role eq '';
+
+            my $key = lc($role);
+            next if $seen{$key}++;
+            push @roles, $key;
+        }
+    }
+
+    return \@roles;
+}
+
 sub people_GET {
     my ($self, $c) = @_;
 
+    my $meeting_roles = $self->_configured_meeting_roles(
+        $c->config->{meeting_role}
+    );
+    return $self->status_ok($c, entity => []) unless @$meeting_roles;
+
+    my $placeholders = join(', ', ('?') x @$meeting_roles);
     my $dbh = $c->dbc->dbh;
-    my $sth = $dbh->prepare(q{
-        SELECT first_name, last_name, contact_email
-        FROM sgn_people.sp_person
-        ORDER BY last_name, first_name
+    my $sth = $dbh->prepare(qq{
+        SELECT person.first_name, person.last_name, person.contact_email
+        FROM sgn_people.sp_person AS person
+        WHERE COALESCE(person.censor, 0) = 0
+          AND person.disabled IS NULL
+          AND EXISTS (
+              SELECT 1
+              FROM sgn_people.sp_person_roles AS person_role
+              JOIN sgn_people.sp_roles AS role
+                ON role.sp_role_id = person_role.sp_role_id
+              WHERE person_role.sp_person_id = person.sp_person_id
+                AND LOWER(role.name) IN ($placeholders)
+          )
+        ORDER BY person.last_name, person.first_name, person.contact_email
     });
-    $sth->execute();
+    $sth->execute(@$meeting_roles);
 
     my @rows;
     while (my ($first_name, $last_name, $contact_email) = $sth->fetchrow_array) {

--- a/mason/breeders_toolbox/decision_meeting/add_meeting_dialog.mas
+++ b/mason/breeders_toolbox/decision_meeting/add_meeting_dialog.mas
@@ -70,7 +70,10 @@ $high_dimensional_phenotype_type => undef #either NIRS, Transcriptomics, Metabol
             <textarea id="mtg_data" class="form-control" rows="3"></textarea>
           </div>
            <div class="form-group" id="attendees_group">
-            <label class="control-label" for="people_search">Attendees</label>
+            <label class="control-label" for="people_search">
+              Attendees
+              <span id="people_selected_count" class="label label-info" aria-live="polite">0 selected</span>
+            </label>
 
             <!-- single global search box -->
             <input type="search"

--- a/mason/breeders_toolbox/decision_meeting/add_meeting_dialog.mas
+++ b/mason/breeders_toolbox/decision_meeting/add_meeting_dialog.mas
@@ -52,17 +52,17 @@ $high_dimensional_phenotype_type => undef #either NIRS, Transcriptomics, Metabol
           </div>
 
           <div class="form-group">
-            <label for="mtg_date">Date (DD/MM/YYYY)</label>
+            <label for="mtg_date">Date (YYYY-MM-DD)</label>
             <input id="mtg_date"
                    class="form-control"
                    type="text"
-                   placeholder="DD/MM/YYYY"
+                   placeholder="YYYY-MM-DD"
                    inputmode="numeric"
                    maxlength="10"
                    autocomplete="off"
-                   data-date-format="dd/mm/yyyy"
+                   data-date-format="yyyy-mm-dd"
                    aria-describedby="mtg_date_help">
-            <span id="mtg_date_help" class="help-block">Use day/month/year, for example 04/08/2026.</span>
+            <span id="mtg_date_help" class="help-block">Use year-month-day, for example 2026-08-04.</span>
           </div>
 
           <div class="form-group">

--- a/mason/breeders_toolbox/decision_meeting/add_meeting_dialog.mas
+++ b/mason/breeders_toolbox/decision_meeting/add_meeting_dialog.mas
@@ -5,7 +5,8 @@ $high_dimensional_phenotype_type => undef #either NIRS, Transcriptomics, Metabol
 <!-- Create Meeting Modal -->
 
 <style>
-  #ui-datepicker-div {
+  #ui-datepicker-div,
+  .datepicker-dropdown {
     z-index: 1060 !important;
   }
 </style>

--- a/mason/breeders_toolbox/decision_meeting/add_meeting_dialog.mas
+++ b/mason/breeders_toolbox/decision_meeting/add_meeting_dialog.mas
@@ -4,6 +4,12 @@ $high_dimensional_phenotype_type => undef #either NIRS, Transcriptomics, Metabol
 
 <!-- Create Meeting Modal -->
 
+<style>
+  #ui-datepicker-div {
+    z-index: 1060 !important;
+  }
+</style>
+
 <!-- 2) The modal -->
 <div id="createMeetingModal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog">
@@ -46,8 +52,17 @@ $high_dimensional_phenotype_type => undef #either NIRS, Transcriptomics, Metabol
           </div>
 
           <div class="form-group">
-            <label for="mtg_date">Date</label>
-            <input id="mtg_date" class="form-control" type="date">
+            <label for="mtg_date">Date (DD/MM/YYYY)</label>
+            <input id="mtg_date"
+                   class="form-control"
+                   type="text"
+                   placeholder="DD/MM/YYYY"
+                   inputmode="numeric"
+                   maxlength="10"
+                   autocomplete="off"
+                   data-date-format="dd/mm/yyyy"
+                   aria-describedby="mtg_date_help">
+            <span id="mtg_date_help" class="help-block">Use day/month/year, for example 04/08/2026.</span>
           </div>
 
           <div class="form-group">

--- a/sgn.conf
+++ b/sgn.conf
@@ -53,6 +53,8 @@ onto_root_namespaces  GO (Gene Ontology), PO (Plant Ontology), SO (Sequence Onto
 
 ## Decision Meeting
 decision_role curator
+# Comma-separated user roles whose members can be selected as meeting attendees.
+meeting_role curator
 decision_format state,year yy,stage #(DROP-23-Y2)
 breeding_stages T1,T2,Y0,Y1,Y2,Y3,Y4,Y5,commercial
 saved_program_stage BTI|BTI_Stage,Cornell|Cornell_Stage

--- a/sgn.conf
+++ b/sgn.conf
@@ -56,6 +56,7 @@ decision_role curator
 decision_format state,year yy,stage #(DROP-23-Y2)
 breeding_stages T1,T2,Y0,Y1,Y2,Y3,Y4,Y5,commercial
 saved_program_stage BTI|BTI_Stage,Cornell|Cornell_Stage
+meeting_locations test_location|Cornell Biotech
 
 allow_trait_edits 1
 allow_treatment_edits 0

--- a/t/unit/SGN/Controller/AJAX/DecisionMeeting.t
+++ b/t/unit/SGN/Controller/AJAX/DecisionMeeting.t
@@ -53,6 +53,7 @@ ok(
     'the persisted successful status identifies a saved meeting',
 );
 
+## no critic (Modules::RequireFilenameMatchesPackage)
 {
     package Local::DecisionMeeting::LocationRow;
     sub new { bless { description => $_[1] }, $_[0] }
@@ -86,6 +87,7 @@ ok(
         return Local::DecisionMeeting::LocationResultSet->new($self->{locations});
     }
 }
+## use critic
 
 my $location_schema = Local::DecisionMeeting::LocationSchema->new({ BTI => 1 });
 is(

--- a/t/unit/SGN/Controller/AJAX/DecisionMeeting.t
+++ b/t/unit/SGN/Controller/AJAX/DecisionMeeting.t
@@ -1,0 +1,236 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More;
+use SGN::Controller::AJAX::DecisionMeeting;
+
+my $controller = SGN::Controller::AJAX::DecisionMeeting->new;
+
+is(
+    $controller->_normalize_meeting_date('2026-08-04'),
+    '2026-08-04',
+    'ISO meeting dates remain unchanged',
+);
+is(
+    $controller->_normalize_meeting_date('2026/08/04'),
+    '2026-08-04',
+    'legacy slash-separated meeting dates are displayed in ISO format',
+);
+is(
+    $controller->_normalize_meeting_date('2026-02-30'),
+    '',
+    'invalid calendar dates are rejected',
+);
+
+is_deeply(
+    $controller->_configured_meeting_roles(
+        [' curator, submitter ', 'CURATOR, breeder']
+    ),
+    ['curator', 'submitter', 'breeder'],
+    'configured meeting attendee roles are trimmed and deduplicated',
+);
+is_deeply(
+    $controller->_configured_meeting_roles(undef),
+    [],
+    'no meeting attendee roles are returned without configuration',
+);
+
+is_deeply(
+    $controller->_meeting_program_names(
+        { breeding_programs => ['101', '202', '101'] },
+        { 101 => 'Program One', 202 => 'Program Two' },
+    ),
+    ['Program One', 'Program Two'],
+    'all meeting programs are translated and deduplicated without truncation',
+);
+ok(
+    !$controller->_is_meeting_saved({ saved => 'false' }),
+    'a string false flag does not make an unsaved meeting immutable',
+);
+ok(
+    $controller->_is_meeting_saved({ saved_status => 'successfully' }),
+    'the persisted successful status identifies a saved meeting',
+);
+
+{
+    package Local::DecisionMeeting::LocationRow;
+    sub new { bless { description => $_[1] }, $_[0] }
+    sub description { $_[0]->{description} }
+
+    package Local::DecisionMeeting::LocationResultSet;
+    sub new { bless { locations => $_[1] }, $_[0] }
+    sub find {
+        my ($self, $query) = @_;
+        my $description = $query->{description};
+        return unless defined($description) && exists($self->{locations}->{$description});
+        return Local::DecisionMeeting::LocationRow->new($description);
+    }
+    sub search {
+        my ($self, $query) = @_;
+        my $description = $query->{description};
+        my $row = defined($description) && exists($self->{locations}->{$description})
+            ? Local::DecisionMeeting::LocationRow->new($description)
+            : undef;
+        return bless { row => $row }, 'Local::DecisionMeeting::LocationSearch';
+    }
+
+    package Local::DecisionMeeting::LocationSearch;
+    sub first { return $_[0]->{row}; }
+
+    package Local::DecisionMeeting::LocationSchema;
+    sub new { bless { locations => $_[1] }, $_[0] }
+    sub resultset {
+        my ($self, $name) = @_;
+        die "Unknown resultset $name" unless $name eq 'NaturalDiversity::NdGeolocation';
+        return Local::DecisionMeeting::LocationResultSet->new($self->{locations});
+    }
+}
+
+my $location_schema = Local::DecisionMeeting::LocationSchema->new({ BTI => 1 });
+is(
+    SGN::Controller::AJAX::DecisionMeeting::_resolve_location_name($location_schema, 'BTI'),
+    'BTI',
+    'configured meeting location resolves when it exists in the location table',
+);
+is(
+    SGN::Controller::AJAX::DecisionMeeting::_resolve_location_name($location_schema, 'Not in database'),
+    undef,
+    'configured meeting location is rejected when it does not exist in the location table',
+);
+
+my $unicode_json = '{"date":"2026-08-04","attendees":["André Luis Hartmann Caranhato"]}';
+my ($unicode_data, $unicode_error) = $controller->_decode_meeting_json($unicode_json);
+is($unicode_error, '', 'meeting JSON accepts an already-decoded Unicode string');
+is(
+    $unicode_data->{attendees}->[0],
+    'André Luis Hartmann Caranhato',
+    'accented attendee names survive character-string JSON decoding',
+);
+
+my $utf8_json_bytes = $unicode_json;
+utf8::encode($utf8_json_bytes);
+my ($byte_data, $byte_error) = $controller->_decode_meeting_json($utf8_json_bytes);
+is($byte_error, '', 'meeting JSON accepts UTF-8 bytes');
+is(
+    $byte_data->{attendees}->[0],
+    'André Luis Hartmann Caranhato',
+    'accented attendee names survive byte-string JSON decoding',
+);
+
+is_deeply(
+    $controller->_meeting_tracker_metadata(
+        'SuBR_2025-26_Y5',
+        {
+            meeting_name           => 'SuBR_2025-26_Y5',
+            breeding_programs      => ['326'],
+            breeding_program_names => ['SuBR'],
+            date                   => '2026-08-04',
+            year                   => '2026',
+            location               => 'Uberlandia',
+            location_raw           => '616',
+            attendees              => [
+                'Charles Hobi Zimmer',
+                'André Luis Hartmann Caranhato',
+            ],
+        },
+    ),
+    {
+        meeting_name      => 'SuBR_2025-26_Y5',
+        meeting_programs  => 'SuBR',
+        meeting_date      => '2026-08-04',
+        meeting_year      => '2026',
+        meeting_location  => 'Uberlandia',
+        meeting_attendees => 'Charles Hobi Zimmer, André Luis Hartmann Caranhato',
+    },
+    'tracker metadata is populated directly from the saved meeting record',
+);
+
+is_deeply(
+    $controller->_configured_meeting_locations(
+        'test_location|Cornell Biotech|Santa Helena de Goias, GO'
+    ),
+    ['test_location', 'Cornell Biotech', 'Santa Helena de Goias, GO'],
+    'meeting locations are read from a pipe-separated configuration value without splitting commas in names',
+);
+is_deeply(
+    $controller->_configured_meeting_locations(
+        'Santa Helena de Goias, GO|Chapeco'
+    ),
+    ['Santa Helena de Goias, GO', 'Chapeco'],
+    'a comma in a location name is preserved before the next pipe-separated location',
+);
+is_deeply(
+    $controller->_configured_meeting_locations(
+        ['test_location|Cornell Biotech', 'Santa Helena de Goias, GO|TEST_LOCATION']
+    ),
+    ['test_location', 'Cornell Biotech', 'Santa Helena de Goias, GO'],
+    'array configuration values are flattened and duplicate locations are removed',
+);
+
+my $meeting_data = {
+    attendees              => ['Alice', 'Bob'],
+    breeding_programs      => ['program-1', 'program-2'],
+    breeding_program_names => ['Program One', 'Program Two'],
+    date                   => '2026-08-04',
+    location               => 'Field Station',
+    meeting_status         => 'planned',
+    year                   => '2026',
+};
+
+my $accessions = [
+    {
+        accession => 'ACC-1',
+        decision  => 'advance',
+        new_stage => 'T2',
+    },
+];
+
+my $decision_data = {
+    meeting_id    => 42,
+    meeting_name  => 'August decisions',
+    date          => 'different date from the client',
+    attendees     => 'different attendees from the client',
+    list_id       => 17,
+    meeting_notes => 'Reviewed by the team',
+    accessions    => $accessions,
+};
+
+my $merged = $controller->_merge_decisions_into_meeting(
+    $meeting_data,
+    $decision_data,
+    'Tue Aug  4 12:00:00 2026',
+);
+
+is_deeply(
+    $merged->{breeding_programs},
+    $meeting_data->{breeding_programs},
+    'saving decisions preserves breeding programs',
+);
+is_deeply(
+    $merged->{breeding_program_names},
+    $meeting_data->{breeding_program_names},
+    'saving decisions preserves breeding program names',
+);
+is($merged->{date}, $meeting_data->{date}, 'saving decisions preserves the meeting date');
+is($merged->{location}, $meeting_data->{location}, 'saving decisions preserves the location');
+is($merged->{year}, $meeting_data->{year}, 'saving decisions preserves the year');
+is_deeply(
+    $merged->{attendees},
+    $meeting_data->{attendees},
+    'saving decisions preserves attendees and their representation',
+);
+is(
+    $merged->{meeting_status},
+    $meeting_data->{meeting_status},
+    'saving decisions preserves meeting status',
+);
+is_deeply($merged->{accessions}, $accessions, 'decisions are added to the meeting');
+is($merged->{list_id}, 17, 'the decision list is added to the meeting');
+is($merged->{meeting_notes}, 'Reviewed by the team', 'decision meeting notes are added');
+is($merged->{meeting_id}, 42, 'new non-conflicting report fields are retained');
+ok($merged->{saved}, 'meeting is marked as saved');
+is($merged->{saved_status}, 'successfully', 'successful save status is recorded');
+is($merged->{saved_at}, 'Tue Aug  4 12:00:00 2026', 'save time is recorded');
+
+done_testing();

--- a/t/unit/SGN/Controller/AJAX/DecisionMeeting.t
+++ b/t/unit/SGN/Controller/AJAX/DecisionMeeting.t
@@ -101,12 +101,12 @@ is(
     'configured meeting location is rejected when it does not exist in the location table',
 );
 
-my $unicode_json = '{"date":"2026-08-04","attendees":["André Luis Hartmann Caranhato"]}';
+my $unicode_json = '{"date":"2026-08-04","attendees":["Tést Attendee Two"]}';
 my ($unicode_data, $unicode_error) = $controller->_decode_meeting_json($unicode_json);
 is($unicode_error, '', 'meeting JSON accepts an already-decoded Unicode string');
 is(
     $unicode_data->{attendees}->[0],
-    'André Luis Hartmann Caranhato',
+    'Tést Attendee Two',
     'accented attendee names survive character-string JSON decoding',
 );
 
@@ -116,7 +116,7 @@ my ($byte_data, $byte_error) = $controller->_decode_meeting_json($utf8_json_byte
 is($byte_error, '', 'meeting JSON accepts UTF-8 bytes');
 is(
     $byte_data->{attendees}->[0],
-    'André Luis Hartmann Caranhato',
+    'Tést Attendee Two',
     'accented attendee names survive byte-string JSON decoding',
 );
 
@@ -132,8 +132,8 @@ is_deeply(
             location               => 'Uberlandia',
             location_raw           => '616',
             attendees              => [
-                'Charles Hobi Zimmer',
-                'André Luis Hartmann Caranhato',
+                'Test Attendee One',
+                'Tést Attendee Two',
             ],
         },
     ),
@@ -143,7 +143,7 @@ is_deeply(
         meeting_date      => '2026-08-04',
         meeting_year      => '2026',
         meeting_location  => 'Uberlandia',
-        meeting_attendees => 'Charles Hobi Zimmer, André Luis Hartmann Caranhato',
+        meeting_attendees => 'Test Attendee One, Tést Attendee Two',
     },
     'tracker metadata is populated directly from the saved meeting record',
 );

--- a/t/unit_fixture/SGN/Controller/AJAX/DecisionMeeting.t
+++ b/t/unit_fixture/SGN/Controller/AJAX/DecisionMeeting.t
@@ -1,0 +1,249 @@
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use JSON qw(decode_json);
+use SGN::Controller::AJAX::DecisionMeeting;
+use SGN::Model::Cvterm;
+use SGN::Test::Fixture;
+use Test::More;
+
+{
+    package Local::DecisionMeetingCreate::Person;
+
+    sub new { return bless {}, $_[0]; }
+    sub get_sp_person_id { return 41; }
+    sub get_username     { return 'janedoe'; }
+
+    package Local::DecisionMeetingCreate::User;
+
+    sub new {
+        my ($class, $person) = @_;
+        return bless { person => $person }, $class;
+    }
+
+    sub get_object { return $_[0]->{person}; }
+    sub roles      { return ('curator'); }
+
+    package Local::DecisionMeetingCreate::Request;
+
+    sub new {
+        my ($class, $params) = @_;
+        return bless { params => $params }, $class;
+    }
+
+    sub params    { return $_[0]->{params}; }
+    sub body_data { return {}; }
+
+    package Local::DecisionMeetingCreate::Response;
+
+    sub new { return bless {}, $_[0]; }
+
+    sub content_type {
+        my ($self, $value) = @_;
+        $self->{content_type} = $value if @_ > 1;
+        return $self->{content_type};
+    }
+
+    sub body {
+        my ($self, $value) = @_;
+        $self->{body} = $value if @_ > 1;
+        return $self->{body};
+    }
+
+    sub status {
+        my ($self, $value) = @_;
+        $self->{status} = $value if @_ > 1;
+        return $self->{status};
+    }
+
+    package Local::DecisionMeetingCreate::Database;
+
+    sub new {
+        my ($class, $dbh) = @_;
+        return bless { dbh => $dbh }, $class;
+    }
+
+    sub dbh { return $_[0]->{dbh}; }
+
+    package Local::DecisionMeetingCreate::Log;
+
+    sub new { return bless { errors => [] }, $_[0]; }
+    sub error { push @{$_[0]->{errors}}, $_[1]; }
+
+    package Local::DecisionMeetingCreate::Context;
+
+    sub new {
+        my ($class, %args) = @_;
+        return bless \%args, $class;
+    }
+
+    sub user        { return $_[0]->{user}; }
+    sub req         { return $_[0]->{request}; }
+    sub res         { return $_[0]->{response}; }
+    sub config      { return $_[0]->{config}; }
+    sub dbc         { return $_[0]->{database}; }
+    sub log         { return $_[0]->{log}; }
+    sub dbic_schema { return $_[0]->{schema}; }
+}
+
+my $fixture = SGN::Test::Fixture->new();
+my $schema  = $fixture->bcs_schema;
+my $dbh     = $fixture->dbh;
+
+# The base fixture can predate db patch 00204. Keep this test runnable both
+# before and after that patch by provisioning its required terms when needed.
+my $meeting_cv = $schema->resultset('Cv::Cv')->find({ name => 'experiment_meeting' });
+my $created_meeting_cv = !$meeting_cv;
+$meeting_cv ||= $schema->resultset('Cv::Cv')->create({ name => 'experiment_meeting' });
+
+my $meeting_project_type = $schema->resultset('Cv::Cvterm')->find({
+    name  => 'meeting_project',
+    cv_id => $meeting_cv->cv_id,
+});
+$meeting_project_type ||= $schema->resultset('Cv::Cvterm')->create_with({
+    name => 'meeting_project',
+    cv   => 'experiment_meeting',
+});
+
+my $project_property_cv = $schema->resultset('Cv::Cv')->find({ name => 'project_property' });
+my $meeting_json_fixture_type = $schema->resultset('Cv::Cvterm')->find({
+    name  => 'meeting_json',
+    cv_id => $project_property_cv->cv_id,
+});
+$meeting_json_fixture_type ||= $schema->resultset('Cv::Cvterm')->create_with({
+    name => 'meeting_json',
+    cv   => 'project_property',
+});
+
+my $program = $schema->resultset('Project::Project')->find({ name => 'test' });
+ok($program, 'fixture breeding program exists');
+
+my $location = $schema->resultset('NaturalDiversity::NdGeolocation')->find({
+    description => 'test_location',
+});
+ok($location, 'fixture meeting location exists');
+
+my $meeting_name = join('_', 'decision_meeting_create_test', time, $$);
+my $response = Local::DecisionMeetingCreate::Response->new();
+my $context = Local::DecisionMeetingCreate::Context->new(
+    user     => Local::DecisionMeetingCreate::User->new(
+        Local::DecisionMeetingCreate::Person->new(),
+    ),
+    request  => Local::DecisionMeetingCreate::Request->new({
+        meeting_name     => $meeting_name,
+        breeding_program => $program->project_id,
+        location         => $location->description,
+        year             => '2026',
+        date             => '2026-08-04',
+        data             => 'Decision meeting creation unit test',
+        attendees        => 'Jane Doe,John Example',
+    }),
+    response => $response,
+    config   => { decision_role => 'curator' },
+    database => Local::DecisionMeetingCreate::Database->new($dbh),
+    schema   => $schema,
+    log      => Local::DecisionMeetingCreate::Log->new(),
+);
+
+my $controller = SGN::Controller::AJAX::DecisionMeeting->new();
+$controller->create($context);
+
+my $created = decode_json($response->body || '{}');
+ok($created->{ok}, 'decision meeting create action succeeds');
+ok($created->{project_id}, 'create action returns the meeting project ID');
+
+my $project = $schema->resultset('Project::Project')->find({
+    project_id => $created->{project_id},
+});
+ok($project, 'decision meeting project was created');
+is($project->name, $meeting_name, 'decision meeting project has the requested name');
+
+my $design_type = SGN::Model::Cvterm->get_cvterm_row(
+    $schema,
+    'design',
+    'project_property',
+);
+my $design_prop = $project->search_related('projectprops', {
+    type_id => $design_type->cvterm_id,
+})->first;
+is($design_prop->value, 'Meeting', 'project is marked as a Meeting design');
+
+my $meeting_json_type = SGN::Model::Cvterm->get_cvterm_row(
+    $schema,
+    'meeting_json',
+    'project_property',
+);
+my $meeting_prop = $project->search_related('projectprops', {
+    type_id => $meeting_json_type->cvterm_id,
+})->first;
+ok($meeting_prop, 'meeting JSON metadata was created');
+
+my $meeting_data = decode_json($meeting_prop->value);
+is($meeting_data->{meeting_name}, $meeting_name, 'meeting name is stored in its metadata');
+is(
+    $meeting_data->{meeting_notes},
+    'Decision meeting creation unit test',
+    'meeting description is retained as meeting notes',
+);
+is($meeting_data->{date}, '2026-08-04', 'meeting date is stored in ISO format');
+is($meeting_data->{year}, '2026', 'meeting year is stored');
+is($meeting_data->{location}, 'test_location', 'meeting location is stored');
+is_deeply(
+    $meeting_data->{breeding_programs},
+    ["" . $program->project_id],
+    'meeting breeding program IDs are stored canonically',
+);
+is_deeply(
+    $meeting_data->{breeding_program_names},
+    ['test'],
+    'meeting breeding program metadata is stored',
+);
+is_deeply(
+    $meeting_data->{attendees},
+    ['Jane Doe', 'John Example'],
+    'meeting attendees are stored',
+);
+
+my $program_relationship_type = SGN::Model::Cvterm->get_cvterm_row(
+    $schema,
+    'breeding_program_trial_relationship',
+    'project_relationship',
+);
+my $program_relationship = $schema->resultset('Project::ProjectRelationship')->find({
+    subject_project_id => $project->project_id,
+    type_id            => $program_relationship_type->cvterm_id,
+});
+ok($program_relationship, 'meeting is linked to its breeding program');
+is(
+    $program_relationship->object_project_id,
+    $program->project_id,
+    'meeting links to the selected breeding program',
+);
+
+my @experiment_ids = $schema->resultset('NaturalDiversity::NdExperimentProject')
+    ->search({ project_id => $project->project_id })
+    ->get_column('nd_experiment_id')
+    ->all;
+is(scalar(@experiment_ids), 1, 'meeting has one project-level experiment');
+
+my $experiment = $schema->resultset('NaturalDiversity::NdExperiment')->find({
+    nd_experiment_id => $experiment_ids[0],
+});
+is(
+    $experiment->nd_geolocation_id,
+    $location->nd_geolocation_id,
+    'meeting experiment uses the selected database location',
+);
+
+my $experiment_stock_count = $schema
+    ->resultset('NaturalDiversity::NdExperimentStock')
+    ->search({ nd_experiment_id => { -in => \@experiment_ids } })
+    ->count;
+is($experiment_stock_count, 0, 'meeting is created without plots or accessions');
+
+$fixture->clean_up_db();
+$meeting_cv->delete() if $created_meeting_cv;
+
+done_testing();

--- a/t/unit_fixture/SGN/Controller/AJAX/DecisionMeeting.t
+++ b/t/unit_fixture/SGN/Controller/AJAX/DecisionMeeting.t
@@ -9,6 +9,7 @@ use SGN::Model::Cvterm;
 use SGN::Test::Fixture;
 use Test::More;
 
+## no critic (Modules::RequireFilenameMatchesPackage)
 {
     package Local::DecisionMeetingCreate::Person;
 
@@ -87,6 +88,7 @@ use Test::More;
     sub log         { return $_[0]->{log}; }
     sub dbic_schema { return $_[0]->{schema}; }
 }
+## use critic
 
 my $fixture = SGN::Test::Fixture->new();
 my $schema  = $fixture->bcs_schema;

--- a/t/unit_fixture/SGN/Controller/AJAX/DecisionMeetingStage.t
+++ b/t/unit_fixture/SGN/Controller/AJAX/DecisionMeetingStage.t
@@ -1,0 +1,293 @@
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use JSON qw(decode_json encode_json);
+use SGN::Controller::AJAX::DecisionMeeting;
+use SGN::Model::Cvterm;
+use SGN::Test::Fixture;
+use Test::More;
+
+{
+    package Local::DecisionMeetingStage::Person;
+    sub new { return bless {}, $_[0]; }
+    sub get_sp_person_id { return 41; }
+
+    package Local::DecisionMeetingStage::User;
+    sub new { return bless { person => $_[1] }, $_[0]; }
+    sub get_object { return $_[0]->{person}; }
+    sub roles { return ('curator'); }
+
+    package Local::DecisionMeetingStage::Request;
+    sub new { return bless { data => $_[1] }, $_[0]; }
+    sub data { return $_[0]->{data}; }
+
+    package Local::DecisionMeetingStage::Database;
+    sub new { return bless { dbh => $_[1] }, $_[0]; }
+    sub dbh { return $_[0]->{dbh}; }
+
+    package Local::DecisionMeetingStage::Context;
+    sub new { my ($class, %args) = @_; return bless \%args, $class; }
+    sub user { return $_[0]->{user}; }
+    sub req { return $_[0]->{request}; }
+    sub config { return $_[0]->{config}; }
+    sub dbc { return $_[0]->{database}; }
+    sub dbic_schema { return $_[0]->{schema}; }
+    sub stash {
+        my ($self, %values) = @_;
+        $self->{stash} = { %{ $self->{stash} || {} }, %values };
+        return $self->{stash};
+    }
+}
+
+my $fixture = SGN::Test::Fixture->new();
+my $schema  = $fixture->bcs_schema;
+
+my $controller = SGN::Controller::AJAX::DecisionMeeting->new();
+
+is(
+    $controller->_breeding_stage_property_name(
+        'SuBR',
+        'BTI|BTI_Stage,Cornell|Cornell_Stage',
+    ),
+    'SuBR_Stage',
+    'an unmapped breeding program falls back to its conventional stage property',
+);
+is(
+    $controller->_breeding_stage_property_name(
+        'BTI',
+        'BTI|custom_bti_stage,Cornell|Cornell_Stage',
+    ),
+    'custom_bti_stage',
+    'a configured breeding-program stage property takes precedence',
+);
+
+my $stage_cvterm = SGN::Model::Cvterm->get_cvterm_row(
+    $schema,
+    'SuBR_Stage',
+    'stock_property',
+);
+$stage_cvterm ||= $schema->resultset('Cv::Cvterm')->create_with({
+    name => 'SuBR_Stage',
+    cv   => 'stock_property',
+});
+
+my $accession_type = SGN::Model::Cvterm->get_cvterm_row(
+    $schema,
+    'accession',
+    'stock_type',
+);
+my $organism = $schema->resultset('Organism::Organism')->first;
+
+my $stock_suffix = join('_', time, $$);
+my $existing_stock = $schema->resultset('Stock::Stock')->create({
+    organism_id => $organism->organism_id,
+    name        => 'decision_stage_existing_' . $stock_suffix,
+    uniquename  => 'decision_stage_existing_' . $stock_suffix,
+    type_id     => $accession_type->cvterm_id,
+});
+my $existing_prop = $schema->resultset('Stock::Stockprop')->create({
+    stock_id => $existing_stock->stock_id,
+    type_id  => $stage_cvterm->cvterm_id,
+    value    => 'ON-25-Y5',
+    rank     => 0,
+});
+
+$controller->_update_breeding_stage_stockprop(
+    schema           => $schema,
+    stock_id         => $existing_stock->stock_id,
+    breeding_program => 'SuBR',
+    new_stage        => 'ON-26-PRECOMMERCIAL',
+);
+$existing_prop->discard_changes;
+
+is(
+    $existing_prop->value,
+    'ON-26-PRECOMMERCIAL',
+    'saving a decision updates the existing breeding-stage stock property',
+);
+
+my $drop_transition = $controller->_compute_stage_transition_data(
+    current_stage   => 'ON-25-Y2',
+    decision        => 'drop',
+    year            => '25',
+    meeting_date    => '2026-08-04',
+    stock_id        => $existing_stock->stock_id,
+    decision_format => 'state,year yy,stage',
+    breeding_stages => 'Y1,Y2,Y3,Y4,Y5',
+    schema          => $schema,
+);
+is(
+    $drop_transition->{new_stage},
+    'DROP-26-Y2',
+    'DROP uses the selected meeting year instead of the previous stage year',
+);
+
+my $meeting_json_type = SGN::Model::Cvterm->get_cvterm_row(
+    $schema,
+    'meeting_json',
+    'project_property',
+);
+$meeting_json_type ||= $schema->resultset('Cv::Cvterm')->create_with({
+    name => 'meeting_json',
+    cv   => 'project_property',
+});
+my $meeting = $schema->resultset('Project::Project')->create({
+    name        => 'decision_stage_meeting_' . $stock_suffix,
+    description => 'Decision meeting breeding-stage save test',
+});
+my $meeting_prop = $schema->resultset('Project::Projectprop')->create({
+    project_id => $meeting->project_id,
+    type_id    => $meeting_json_type->cvterm_id,
+    value      => encode_json({
+        meeting_name           => $meeting->name,
+        date                   => '2026-08-04',
+        breeding_program_names => ['test'],
+    }),
+    rank       => 0,
+});
+
+my $fixture_program = $schema->resultset('Project::Project')->find({ name => 'test' });
+ok($fixture_program, 'fixture breeding program exists');
+
+my $fixture_stage_cvterm = SGN::Model::Cvterm->get_cvterm_row(
+    $schema,
+    'test_Stage',
+    'stock_property',
+);
+$fixture_stage_cvterm ||= $schema->resultset('Cv::Cvterm')->create_with({
+    name => 'test_Stage',
+    cv   => 'stock_property',
+});
+$schema->resultset('Stock::Stockprop')->create({
+    stock_id => $existing_stock->stock_id,
+    type_id  => $fixture_stage_cvterm->cvterm_id,
+    value    => 'ON-25-Y5',
+    rank     => 0,
+});
+my $state_cvterm = SGN::Model::Cvterm->get_cvterm_row(
+    $schema,
+    'state',
+    'stock_property',
+);
+$state_cvterm ||= $schema->resultset('Cv::Cvterm')->create_with({
+    name => 'state',
+    cv   => 'stock_property',
+});
+$schema->resultset('Stock::Stockprop')->create({
+    stock_id => $existing_stock->stock_id,
+    type_id  => $state_cvterm->cvterm_id,
+    value    => 'ON',
+    rank     => 0,
+});
+
+my $accessions_list_type = SGN::Model::Cvterm->get_cvterm_row(
+    $schema,
+    'accessions',
+    'list_types',
+);
+my ($list_id) = $schema->storage->dbh->selectrow_array(
+    q{
+        INSERT INTO sgn_people.list (name, description, owner, type_id)
+        VALUES (?, ?, ?, ?)
+        RETURNING list_id
+    },
+    undef,
+    'decision_stage_list_' . $stock_suffix,
+    'Decision meeting save validation list',
+    41,
+    $accessions_list_type->cvterm_id,
+);
+$schema->storage->dbh->do(
+    'INSERT INTO sgn_people.list_item (content, list_id) VALUES (?, ?)',
+    undef,
+    $existing_stock->uniquename,
+    $list_id,
+);
+
+my $save_payload = {
+    meeting_id => $meeting->project_id,
+    list_id    => $list_id,
+    accessions => [{
+        stock_id         => 999999,
+        accession        => $existing_stock->uniquename,
+        breeding_program => 'test',
+        previous_stage   => 'ON-25-Y5',
+        decision         => 'hold',
+        new_stage        => 'ON-26-Y5',
+    }],
+};
+my $save_context = Local::DecisionMeetingStage::Context->new(
+    user    => Local::DecisionMeetingStage::User->new(
+        Local::DecisionMeetingStage::Person->new(),
+    ),
+    request => Local::DecisionMeetingStage::Request->new($save_payload),
+    database => Local::DecisionMeetingStage::Database->new($schema->storage->dbh),
+    config  => {
+        decision_role       => 'curator',
+        decision_format     => 'state,year yy,stage',
+        breeding_stages     => 'Y1,Y2,Y3,Y4,Y5',
+        saved_program_stage => 'BTI|BTI_Stage,Cornell|Cornell_Stage',
+    },
+    schema  => $schema,
+);
+
+$controller->save_all_decisions_POST($save_context);
+$existing_prop->discard_changes;
+$meeting_prop->discard_changes;
+
+is(
+    $schema->resultset('Stock::Stockprop')->search({
+        stock_id => $existing_stock->stock_id,
+        type_id  => $fixture_stage_cvterm->cvterm_id,
+    })->first->value,
+    'ON-26-Y5',
+    'the save-all-decisions action updates the program breeding stage',
+);
+is(
+    decode_json($meeting_prop->value)->{accessions}->[0]->{new_stage},
+    'ON-26-Y5',
+    'the decision payload is saved with the stock-property update',
+);
+is(
+    decode_json($meeting_prop->value)->{accessions}->[0]->{stock_id},
+    $existing_stock->stock_id,
+    'the server replaces a forged stock ID with the accession list stock ID',
+);
+ok(
+    $save_context->{stash}->{json_data}->{success},
+    'the save-all-decisions action reports success',
+);
+
+my $new_stock = $schema->resultset('Stock::Stock')->create({
+    organism_id => $organism->organism_id,
+    name        => 'decision_stage_new_' . $stock_suffix,
+    uniquename  => 'decision_stage_new_' . $stock_suffix,
+    type_id     => $accession_type->cvterm_id,
+});
+
+my $new_prop = $controller->_update_breeding_stage_stockprop(
+    schema           => $schema,
+    stock_id         => $new_stock->stock_id,
+    breeding_program => 'SuBR',
+    new_stage        => 'DROP-26-Y5',
+);
+
+is(
+    $new_prop->value,
+    'DROP-26-Y5',
+    'saving a decision creates the breeding-stage stock property when absent',
+);
+is(
+    $schema->resultset('Stock::Stockprop')->search({
+        stock_id => $new_stock->stock_id,
+        type_id  => $stage_cvterm->cvterm_id,
+    })->count,
+    1,
+    'only one breeding-stage stock property is created',
+);
+
+$fixture->clean_up_db();
+
+done_testing();

--- a/t/unit_fixture/SGN/Controller/AJAX/DecisionMeetingStage.t
+++ b/t/unit_fixture/SGN/Controller/AJAX/DecisionMeetingStage.t
@@ -9,6 +9,7 @@ use SGN::Model::Cvterm;
 use SGN::Test::Fixture;
 use Test::More;
 
+## no critic (Modules::RequireFilenameMatchesPackage)
 {
     package Local::DecisionMeetingStage::Person;
     sub new { return bless {}, $_[0]; }
@@ -40,6 +41,7 @@ use Test::More;
         return $self->{stash};
     }
 }
+## use critic
 
 my $fixture = SGN::Test::Fixture->new();
 my $schema  = $fixture->bcs_schema;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
  - Preserve meeting metadata when saving decisions, including programs, date, year, location, attendees, and status.
  - Handle meeting JSON containing accented UTF-8 characters.
  - Populate the Meeting Tracker directly from saved metadata and disable stale response caching.
  - Include complete metadata in the meeting report.
  - Read meeting-location choices from meeting_locations, using | as the separator so names can contain commas.
  - Require configured location names to match database locations.
  - Display and validate meeting dates as DD/MM/YYYY, while sending YYYY-MM-DD to the backend.
  - Allow decision meetings to be created without plots or accessions.
  - Resume an incomplete meeting project left by a previous failed creation attempt when retried by the same owner.
  - Improve trial-creation error reporting.
  - Added unit tests for meeting metadata preservation, Unicode JSON decoding, tracker metadata, configured locations, and database-location validation.
  - Added a fixture-backed creation test that creates a complete decision meeting and verifies:
      - Project and metadata creation.
      - Breeding-program and location associations.
      - Date, attendees, and other metadata.
      - Creation without plots or accessions.
      - Database cleanup after testing.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
