### PR TITLE
Fix exif image verification with no trait ID

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/UploadImages.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/UploadImages.js
@@ -276,86 +276,99 @@ function reportVerifyResult(result) {
 }
 
 function verifyExifData(result) {
-    const successMessages =[];
+    const successMessages = [];
     const errorMessages = [];
     const finalSuccessMessage = [];
+    const validFilenames = [];
+    const invalidFilenames = [];
     let exifFiles = 0;
     let nonExifFiles = 0;
-    //console.log("image data", result.images[0].exif);
 
     result.images.forEach((img, index) => {
         const imgName = img.filename || `Image ${index + 1}`;
         const exif = img.exif || {};
+        const imgErrors = [];
 
-        if (result.images[index].status === "no_exif") {
+        if (img.status === "no_exif") {
             errorMessages.push(`${imgName} does not have EXIF data`);
+            invalidFilenames.push(imgName);
             nonExifFiles++;
             return;
         } else {
             exifFiles++;
         }
 
-        const hasObsUnit = exif.observation_unit && exif.observation_unit.observation_unit_db_id;
-        const hasObsVar = exif.observation_variable && exif.observation_variable.observation_variable_name;
-        const obsVariableName = exif.observation_variable.observation_variable_name;
+        const obsUnit = exif.observation_unit;
+        const obsVar = exif.observation_variable;
+        const hasObsUnit = obsUnit && obsUnit.observation_unit_db_id;
+        const hasObsVar = obsVar && obsVar.observation_variable_name;
         const hasTimestamp = exif.timestamp;
         const hasCvtermId = exif.cvterm_id;
         const stockName = exif.stock_name;
-        
+
         if (hasObsUnit) {
-            successMessages.push(`${imgName}: ObservationUnitDbId: ${exif.observation_unit.observation_unit_db_id}`);
+            successMessages.push(`${imgName}: ObservationUnitDbId: ${obsUnit.observation_unit_db_id}`);
         } else {
-            errorMessages.push(`${imgName}: Missing ObservationUnitDbId`);
+            imgErrors.push(`${imgName}: Missing ObservationUnitDbId`);
         }
 
-        if (hasObsVar) {
-            successMessages.push(`${imgName}: Observation Variable: ${exif.observation_variable.observation_variable_name}`);
+        // Specific: field missing entirely vs. present but empty/not found
+        if (!obsVar) {
+            imgErrors.push(`${imgName}: No trait field found in EXIF data`);
+        } else if (!hasObsVar && !obsVar.external_db_id) {
+            imgErrors.push(`${imgName}: Trait field is present but is missing both a trait ID and trait name`);
         } else {
-            errorMessages.push(`${imgName}: Missing Observation Variable Name`);
+            successMessages.push(`${imgName}: Observation Variable: ${obsVar.observation_variable_name || obsVar.external_db_id}`);
+            if (!hasCvtermId) {
+                if (img.trait_lookup_type === "id") {
+                    imgErrors.push(`${imgName}: Trait ID "${img.trait_lookup_value}" does not exist in the database`);
+                } else if (img.trait_lookup_type === "name") {
+                    imgErrors.push(`${imgName}: Trait name "${img.trait_lookup_value}" does not exist in the database`);
+                } else {
+                    imgErrors.push(`${imgName}: Associated trait does not exist in the database`);
+                }
+            }
         }
 
         if (hasTimestamp) {
             successMessages.push(`${imgName}: Timestamp: ${exif.timestamp}`);
         } else {
-            errorMessages.push(`${imgName}: Missing Timestamp`);
+            imgErrors.push(`${imgName}: Missing Timestamp`);
         }
 
-        if (!hasCvtermId) {
-            errorMessages.push(`${imgName} associated trait ${obsVariableName} does not exist in the database`);
+        if (img.stock_exists === "false") {
+            imgErrors.push(`${imgName}: ObservationUnitDbId ${obsUnit.observation_unit_db_id} does not exist in the database`);
+        } else if (hasObsUnit && !stockName) {
+            imgErrors.push(`${imgName}: Stock associated with ObservationUnitDbId ${obsUnit.observation_unit_db_id} could not be found`);
         }
 
-        if (result.images[index].stock_exists === "false") {
-            errorMessages.push(`${imgName}: ObservationUnitDbId ${exif.observation_unit.observation_unit_db_id} does not exist in the database`);
-        } else if (!stockName) {
-            errorMessages.push(`${imgName} Stock ${stockName} does not exist in the database`);
-        }
-
-        if (errorMessages.length === 0) {
-            finalSuccessMessage.push(`${imgName} has valid EXIF data. Associated stock: ${exif.stock_name} Associated trait: ${obsVariableName}. Ready to store image`);
+        if (imgErrors.length === 0) {
+            finalSuccessMessage.push(`${imgName} has valid EXIF data. Associated stock: ${stockName}. Associated trait: ${obsVar.observation_variable_name}. Ready to store image`);
+            validFilenames.push(imgName);
+        } else {
+            errorMessages.push(...imgErrors);
+            invalidFilenames.push(imgName);
         }
     });
 
-    let validExif;
     if (errorMessages.length === 0) {
         jQuery('#upload_images_submit_store').attr('disabled', false);
         jQuery('#upload_images_status').html(
             formatMessage(finalSuccessMessage, "success")
         );
-        return true;
-    } else if (exifFiles > 0 && nonExifFiles > 0) {
-        errorMessages.push("Please load files all containing EXIF data or with the same file naming pattern");
-        validExif = errorMessages;
-    } else if (errorMessages.length > 0 && successMessages.length > 0) {
-        validExif = errorMessages;
-    } else {
-        return false;
+        return { valid: true, validFilenames: validFilenames, invalidFilenames: invalidFilenames };
     }
 
-    jQuery('#upload_images_submit_store').attr('disbled', true);
+    if (exifFiles > 0 && nonExifFiles > 0) {
+        errorMessages.push("Please load files all containing EXIF data or with the same file naming pattern");
+    }
+
+    jQuery('#upload_images_submit_store').attr('disabled', true);
     jQuery('#upload_images_status').html(
         formatMessage(errorMessages, "error")
     );
-    return validExif;
+
+    return { valid: false, validFilenames: validFilenames, invalidFilenames: invalidFilenames, errorMessages: errorMessages };
 }
 
 function parseExifData(exifData, imageFiles) {

--- a/js/source/legacy/CXGN/BreedersToolbox/UploadImages.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/UploadImages.js
@@ -322,11 +322,13 @@ function verifyExifData(result) {
             if (!hasCvtermId) {
                 if (img.trait_lookup_type === "id") {
                     imgErrors.push(`${imgName}: Trait ID "${img.trait_lookup_value}" does not exist in the database`);
-                } else if (img.trait_lookup_type === "name") {
+                } else if (img.trait_lookup_type === "name" || img.trait_lookup_type === "synonym") {
                     imgErrors.push(`${imgName}: Trait name "${img.trait_lookup_value}" does not exist in the database`);
                 } else {
                     imgErrors.push(`${imgName}: Associated trait does not exist in the database`);
                 }
+            } else if (img.trait_lookup_type === "synonym") {
+                successMessages.push(`${imgName}: Trait name "${img.trait_lookup_value}" matched via synonym to "${img.trait_matched_name}"`);
             }
         }
 

--- a/js/source/legacy/CXGN/BreedersToolbox/UploadImages.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/UploadImages.js
@@ -304,7 +304,8 @@ function verifyExifData(result) {
         const hasObsVar = obsVar && obsVar.observation_variable_name;
         const hasTimestamp = exif.timestamp;
         const hasCvtermId = exif.cvterm_id;
-        const stockName = exif.stock_name;
+        const stockName = exif.stock_name; 
+        let traitName = obsVar.observation_variable_name;
 
         if (hasObsUnit) {
             successMessages.push(`${imgName}: ObservationUnitDbId: ${obsUnit.observation_unit_db_id}`);
@@ -328,6 +329,7 @@ function verifyExifData(result) {
                     imgErrors.push(`${imgName}: Associated trait does not exist in the database`);
                 }
             } else if (img.trait_lookup_type === "synonym") {
+                traitName = img.trait_matched_name;
                 successMessages.push(`${imgName}: Trait name "${img.trait_lookup_value}" matched via synonym to "${img.trait_matched_name}"`);
             }
         }
@@ -345,7 +347,7 @@ function verifyExifData(result) {
         }
 
         if (imgErrors.length === 0) {
-            finalSuccessMessage.push(`${imgName} has valid EXIF data. Associated stock: ${stockName}. Associated trait: ${obsVar.observation_variable_name}. Ready to store image`);
+            finalSuccessMessage.push(`${imgName} has valid EXIF data. Associated stock: ${stockName}. Associated trait: ${traitName}. Ready to store image`);
             validFilenames.push(imgName);
         } else {
             errorMessages.push(...imgErrors);

--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -386,25 +386,41 @@ sub verify_exif_POST {
                 }
             }
             # Get cvterm_id of recorded trait
+            my $observation_variable = $decoded_json->{observation_variable};
             my $trait_id = $decoded_json->{observation_variable}->{external_db_id};
+            my $trait_name = $observation_variable->{observation_variable_name};
+            print STDERR "trait id test: $trait_id";
             my $cvterm_id;
+            my $trait_lookup_type;
+            my $trait_lookup_value;
 
-            if (!$trait_id) {
-                my $trait_name = $decoded_json->{observation_variable}->{observation_variable_name};
+            if ($trait_id) {
+                $trait_lookup_type  = "id";
+                $trait_lookup_value = $trait_id;
+                $cvterm_id = SGN::Model::Cvterm->find_trait_by_id($schema, $trait_id);
+            }
+            elsif ($trait_name) {
+                $trait_lookup_type  = "name";
+                $trait_lookup_value = $trait_name;
                 my $cvterm = $schema->resultset('Cv::Cvterm')->find({ name => $trait_name });
                 if ($cvterm) {
                     $cvterm_id = $cvterm->cvterm_id();
                 }
-            }
-            else {
-                $cvterm_id = SGN::Model::Cvterm->find_trait_by_id($schema, $trait_id);
             }
 
             $decoded_json->{stock_name} = $stock_name;
             if ($cvterm_id) {
                 $decoded_json->{cvterm_id} = $cvterm_id;
             }
-            push @results, { filename => $filename, exif => $decoded_json, status => "success", stock_exists => $stock_exists };
+            push @results, {
+                filename        => $filename,
+                exif            => $decoded_json,
+                stock_exists    => $stock_exists,
+                trait_present   => $observation_variable ? "true" : "false",
+                trait_exists    => $cvterm_id ? "true" : "false",
+                trait_lookup_type => $trait_lookup_type,
+                trait_lookup_value => $trait_lookup_value,
+            };
             
         } else {
             push @results, { filename => $filename, exif => undef, status => "no_exif" };

--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -392,6 +392,7 @@ sub verify_exif_POST {
             my $cvterm_id;
             my $trait_lookup_type;
             my $trait_lookup_value;
+            my $trait_matched_name;
 
             if ($trait_id) {
                 $trait_lookup_type  = "id";
@@ -405,14 +406,20 @@ sub verify_exif_POST {
                 if ($cvterm) {
                     $cvterm_id = $cvterm->cvterm_id();
                 } else {
-                    # Check if it's a synyonym if name not found
-                    my $synonym_row = $schema->resultset('Cv::Cvtermsynonym')->find({ synonym => $trait_name });
+                    my $escaped_name = $trait_name;
+                    $escaped_name =~ s/([%_\\])/\\$1/g;
+
+                    my $synonym_row = $schema->resultset('Cv::Cvtermsynonym')->search( { synonym => { -ilike => '"' . $escaped_name . '"%' } } )->first;
+
                     if ($synonym_row) {
                         $cvterm_id = $synonym_row->cvterm_id();
-                        $trait_lookup_type  = "synonym";
-                        $trait_matched_name = $synonym_row->cvterm->name();
+                        $trait_lookup_type = "synonym";
+
+                        my $matched_cvterm = $schema->resultset('Cv::Cvterm')->find({ cvterm_id => $cvterm_id });
+                        $trait_matched_name = $matched_cvterm ? $matched_cvterm->name() : undef;
+                        print STDERR "trait matched name: $trait_matched_name";
                     } else {
-                        $cvterm = undef;
+                        $cvterm_id = undef;
                     }
                 }
             }
@@ -429,6 +436,7 @@ sub verify_exif_POST {
                 trait_exists    => $cvterm_id ? "true" : "false",
                 trait_lookup_type => $trait_lookup_type,
                 trait_lookup_value => $trait_lookup_value,
+                trait_matched_name => $trait_matched_name,
             };
             
         } else {

--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -389,7 +389,6 @@ sub verify_exif_POST {
             my $observation_variable = $decoded_json->{observation_variable};
             my $trait_id = $decoded_json->{observation_variable}->{external_db_id};
             my $trait_name = $observation_variable->{observation_variable_name};
-            print STDERR "trait id test: $trait_id";
             my $cvterm_id;
             my $trait_lookup_type;
             my $trait_lookup_value;
@@ -405,6 +404,14 @@ sub verify_exif_POST {
                 my $cvterm = $schema->resultset('Cv::Cvterm')->find({ name => $trait_name });
                 if ($cvterm) {
                     $cvterm_id = $cvterm->cvterm_id();
+                } else {
+                    # Check if it's a synyonym if name not found
+                    my $synonym_row = $schema->resultset('Cv::Cvtermsynonym')->find({ synonym => $trait_name });
+                    if ($synonym_row) {
+                        $cvterm_id = $synonym_row->cvterm_id();
+                        $trait_lookup_type  = "synonym";
+                        $trait_matched_name = $synonym_row->cvterm->name();
+                    }
                 }
             }
 

--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -411,6 +411,8 @@ sub verify_exif_POST {
                         $cvterm_id = $synonym_row->cvterm_id();
                         $trait_lookup_type  = "synonym";
                         $trait_matched_name = $synonym_row->cvterm->name();
+                    } else {
+                        $cvterm = undef;
                     }
                 }
             }

--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -387,7 +387,18 @@ sub verify_exif_POST {
             }
             # Get cvterm_id of recorded trait
             my $trait_id = $decoded_json->{observation_variable}->{external_db_id};
-            my $cvterm_id = SGN::Model::Cvterm->find_trait_by_id($schema, $trait_id);
+            my $cvterm_id;
+
+            if (!$trait_id) {
+                my $trait_name = $decoded_json->{observation_variable}->{observation_variable_name};
+                my $cvterm = $schema->resultset('Cv::Cvterm')->find({ name => $trait_name });
+                if ($cvterm) {
+                    $cvterm_id = $cvterm->cvterm_id();
+                }
+                else {
+                    $cvterm_id = SGN::Model::Cvterm->find_trait_by_id($schema, $trait_id);
+                }
+            }
 
             $decoded_json->{stock_name} = $stock_name;
             if ($cvterm_id) {

--- a/lib/SGN/Controller/AJAX/Image.pm
+++ b/lib/SGN/Controller/AJAX/Image.pm
@@ -395,9 +395,9 @@ sub verify_exif_POST {
                 if ($cvterm) {
                     $cvterm_id = $cvterm->cvterm_id();
                 }
-                else {
-                    $cvterm_id = SGN::Model::Cvterm->find_trait_by_id($schema, $trait_id);
-                }
+            }
+            else {
+                $cvterm_id = SGN::Model::Cvterm->find_trait_by_id($schema, $trait_id);
             }
 
             $decoded_json->{stock_name} = $stock_name;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes verification for exif data that does not have the observation variable id field, falls back to observation variable namae

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
