### PR TITLE
Add fine-grained cvterm edit config key

### DIFF
--- a/js/source/legacy/CXGN/BreedersToolbox/AddTrial.js
+++ b/js/source/legacy/CXGN/BreedersToolbox/AddTrial.js
@@ -524,7 +524,7 @@ jQuery(document).ready(function ($) {
     function apply_treatment_autocomplete() {
         jQuery('.treatment-name-input-box').each( function() {
             jQuery(this).autocomplete({
-                source : '/ajax/cvterm/autocompleteslim' + "?db_name=_TREATMENT",
+                source : '/ajax/cvterm/autocompleteslim' + "?db_names=EXPERIMENT_TREATMENT,COMP_EXP_TREATMENT",
                 appendTo : '#add_project_dialog'
             });
         });

--- a/lib/CXGN/Onto.pm
+++ b/lib/CXGN/Onto.pm
@@ -118,7 +118,7 @@ sub get_root_nodes {
                     JOIN dbxref USING(dbxref_id)
                     JOIN db USING(db_id)
                     LEFT JOIN cvterm_relationship ON(cvterm.cvterm_id=cvterm_relationship.subject_id)
-                    WHERE cvterm_relationship.subject_id IS NULL AND cvterm.is_obsolete= 0 AND cvterm.is_relationshiptype = 0";
+                    WHERE cvterm_relationship.subject_id IS NULL AND cvterm.is_obsolete= 0 AND cvterm.is_relationshiptype = 0 AND db.name <> '' AND db.name <> 'null'";
 
       my $h = $self->schema->storage->dbh->prepare($query);
       $h->execute($cv_type);

--- a/lib/CXGN/Trait.pm
+++ b/lib/CXGN/Trait.pm
@@ -796,6 +796,7 @@ sub delete_existing_synonyms {
 sub interactive_store {
 	my $self = shift;
     my $parent_terms_json = shift;
+	my $db_name = shift || die "No trait ontology supplied to store the new term in.\n"; # db name of the ontology the new term belongs to, e.g. CO_334
 
     my $schema = $self->bcs_schema();
 
@@ -858,25 +859,22 @@ sub interactive_store {
         "$category_details_cvterm_id" => $category_details
     );
 
-	my $trait_ontology_cvterm_id = $schema->resultset("Cv::Cvterm")->find({
-        name => 'trait_ontology'
-    })->cvterm_id();
-	my $trait_cv_id = $schema->resultset("Cv::Cvprop")->find({
-		type_id => $trait_ontology_cvterm_id
-	})->cv_id();
+	# it is possible to have multiple trait ontologies, so find the root node of the one that was requested
+	my $ontology_obj = CXGN::Onto->new({
+		schema => $schema
+	});
+	my @root_nodes = $ontology_obj->get_root_nodes('trait_ontology'); # each entry is [ cv_id, "DB:accession Term name" ]
+
+	my ($root_node) = grep { $_->[1] =~ m/^\Q$db_name\E:/ } @root_nodes;
+
+	if (!$root_node) {
+		die "No trait ontology named $db_name could be found in the database.\n";
+	}
+
+	my $trait_cv_id = $root_node->[0];
 	my $trait_ontology = $schema->resultset("Cv::Cv")->find({
 		cv_id => $trait_cv_id
 	})->name();
-
-	my $get_db_from_cv_sql = "SELECT DISTINCT(db.name) FROM cvterm 
-	JOIN dbxref USING (dbxref_id)
-	JOIN db USING (db_id)
-	WHERE cv_id=?";
-
-	my $h = $schema->storage->dbh->prepare($get_db_from_cv_sql);
-    $h->execute($trait_cv_id);
-
-	my $db_name = $h->fetchrow_array();
 
 	my $parent_terms = [];
 	if ($parent_terms_json) {
@@ -892,17 +890,12 @@ sub interactive_store {
 		}
 
 		@parent_ids = @{$transform->{transform}};
-	} else {
-		my $ontology_obj = CXGN::Onto->new({
-			schema => $schema
-		});
-		my @root_nodes = $ontology_obj->get_root_nodes('trait_ontology');
-
-		my $root_term_name = $root_nodes[0]->[1] =~ s/\w+:\d+ //r;
+	} else { # default to the root term of the ontology the new term is being added to
+		my $root_term_name = $root_node->[1] =~ s/\w+:\d+ //r;
 
 		push @parent_ids, $schema->resultset("Cv::Cvterm")->find({
 			name => $root_term_name,
-			cv_id => $root_nodes[0]->[0]
+			cv_id => $trait_cv_id
 		})->cvterm_id();
 	}
 
@@ -926,7 +919,7 @@ sub interactive_store {
         $isa_id = $isa_relationship->cvterm_id();
     }
 
-    $h = $schema->storage->dbh->prepare($get_db_accessions_sql);
+    my $h = $schema->storage->dbh->prepare($get_db_accessions_sql);
     $h->execute($db_name);
 
     my @accessions;

--- a/lib/SGN/Controller/AJAX/Cvterm.pm
+++ b/lib/SGN/Controller/AJAX/Cvterm.pm
@@ -50,7 +50,7 @@ sub autocomplete_GET :Args(0) {
     my ( $self, $c ) = @_;
 
     #my $term = $c->req->param('term_name');
-    my $db_name = $c->request->param('db_name');
+    my $db_names = $c->request->param('db_names');
     # trim and regularize whitespace
     #$term =~ s/(^\s+|\s+)$//g;
     #$term =~ s/\s+/ /g;
@@ -62,11 +62,11 @@ sub autocomplete_GET :Args(0) {
                JOIN dbxref USING (db_id ) JOIN cvterm USING (dbxref_id)
                JOIN cv USING (cv_id )
                LEFT JOIN cvtermsynonym USING (cvterm_id )
-               WHERE db.name = ? AND (cvterm.name ilike ? OR cvtermsynonym.synonym ilike ? OR cvterm.definition ilike ?) AND cvterm.is_obsolete = 0 AND is_relationshiptype = 0
+               WHERE db.name = ANY(regexp_split_to_array(?, '\\s*,\\s*')) AND (cvterm.name ilike ? OR cvtermsynonym.synonym ilike ? OR cvterm.definition ilike ?) AND cvterm.is_obsolete = 0 AND is_relationshiptype = 0
 GROUP BY cvterm.cvterm_id,cv.name, cvterm.name, dbxref.accession, db.name
 ORDER BY cv.name, cvterm.name limit 30";
     my $sth= $schema->storage->dbh->prepare($query);
-    $sth->execute($db_name, "\%$term_name\%", "\%$term_name\%", "\%$term_name\%");
+    $sth->execute($db_names, "\%$term_name\%", "\%$term_name\%", "\%$term_name\%");
     my @response_list;
     while (my ($cvterm_id, $cv_name, $cvterm_name, $accession) = $sth->fetchrow_array() ) {
         push @response_list, $cv_name . "--" . $accession . "--" . $cvterm_name ;
@@ -80,8 +80,7 @@ sub autocompleteslim_GET :Args(0) {
     my ( $self, $c ) = @_;
 
     #my $term = $c->req->param('term_name');
-    my $db_name = $c->request->param('db_name');
-    $db_name = '%'.$db_name.'%';
+    my $db_names = $c->request->param('db_names');
     # trim and regularize whitespace
     #$term =~ s/(^\s+|\s+)$//g;
     #$term =~ s/\s+/ /g;
@@ -93,11 +92,11 @@ sub autocompleteslim_GET :Args(0) {
                JOIN dbxref USING (db_id ) JOIN cvterm USING (dbxref_id)
                JOIN cv USING (cv_id )
                LEFT JOIN cvtermsynonym USING (cvterm_id )
-               WHERE db.name ilike ? AND (cvterm.name ilike ? OR cvtermsynonym.synonym ilike ? OR cvterm.definition ilike ?) AND cvterm.is_obsolete = 0 AND is_relationshiptype = 0
+               WHERE db.name = ANY(regexp_split_to_array(?, '\\s*,\\s*')) AND (cvterm.name ilike ? OR cvtermsynonym.synonym ilike ? OR cvterm.definition ilike ?) AND cvterm.is_obsolete = 0 AND is_relationshiptype = 0
 GROUP BY cvterm.cvterm_id,cv.name, cvterm.name, dbxref.accession, db.name
 ORDER BY cv.name, cvterm.name limit 30";
     my $sth= $schema->storage->dbh->prepare($query);
-    $sth->execute($db_name, "\%$term_name\%", "\%$term_name\%", "\%$term_name\%");
+    $sth->execute($db_names, "\%$term_name\%", "\%$term_name\%", "\%$term_name\%");
     my @response_list;
     while (my ($cvterm_id, $cv_name, $cvterm_name, $accession) = $sth->fetchrow_array() ) {
         push @response_list, $cvterm_name . "|" . $accession ;

--- a/lib/SGN/Controller/AJAX/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Trait.pm
@@ -36,13 +36,27 @@ sub create_trait :Path('/ajax/trait/create') {
     my $category_details = $c->req->param('category_details') ? $c->req->param('category_details') : undef;
     my $repeat_type = $c->req->param('repeat_type') ? $c->req->param('repeat_type') : undef;
     my $parent_terms = $c->req->param('parent_terms') ? $c->req->param('parent_terms') : undef;
-    my $parent_dbs = $c->req->pram('parent_dbs') ? $c->req->pram('parent_dbs') : undef;
+    my $parent_dbs = $c->req->param('parent_dbs') ? $c->req->param('parent_dbs') : undef;
+    my $ontology_db_name = $c->req->param('ontology_db_name') ? $c->req->param('ontology_db_name') : undef;
+
+    if (!$ontology_db_name) {
+        $c->stash->{rest} = {error => "You must select the trait ontology that the new trait belongs to.\n"};
+        return;
+    }
 
     my $editable_ontologies_str = $c->config->{allow_trait_edits};
     my @editable_ontologies = split(",", $editable_ontologies_str);
+    my @parent_dbs = split(",", $parent_dbs);
+    foreach my $parent_db (@parent_dbs) { # ALL of the parent DBs need to be editable, or traits need to be editable in general
+        if (! ($editable_ontologies_str == 1 || (grep {$parent_db eq $_} @editable_ontologies))) {
+            $c->stash->{rest} = {error => "Ontology $parent_db is not editable on this server - contact a system administrator.\n"};
+            return;
+        }
+    }
 
-    if (! ($editable_ontologies_str == 1 || (grep {$parent_dbs =~ m/($_)/} @editable_ontologies ) ) ) {
-        $c->stash->{rest} = {error => "You do not have permission to design new traits.\n"};
+    # the ontology the new term is stored in must be editable in its own right, since the parent dbs are supplied by the client
+    if (! ($editable_ontologies_str == 1 || (grep {$ontology_db_name eq $_} @editable_ontologies))) {
+        $c->stash->{rest} = {error => "Ontology $ontology_db_name is not editable on this server - contact a system administrator.\n"};
         return;
     }
 
@@ -143,7 +157,7 @@ sub create_trait :Path('/ajax/trait/create') {
             $new_trait->default_value($default_value);
         }
 
-        $new_trait->interactive_store($parent_terms);
+        $new_trait->interactive_store($parent_terms, $ontology_db_name);
     };
 
     if ($@) {
@@ -169,22 +183,28 @@ sub edit_trait :Path('/ajax/trait/edit') {
     my $cvterm_id = $c->req->param('cvterm_id') ? $c->req->param('cvterm_id') : undef;
     my $new_name = $c->req->param('new_name') ? $c->req->param('new_name') : undef;
     my $new_definition = $c->req->param('new_definition') ? $c->req->param('new_definition') : undef;
+    my $trait;
+    if (!$cvterm_id) {
+        $c->stash->{rest} = {error => "Cvterm ID missing.\n"};
+        return;
+    }
+
+    eval {
+        $trait = CXGN::Trait->new({
+            bcs_schema => $schema,
+            cvterm_id => $cvterm_id
+        });
+    };
+    if ($@) {
+        $c->stash->{rest} = {error => "An error occurred retreiving cvterm information: $@\n"};
+        return;
+    }
 
     my $editable_ontologies_str = $c->config->{allow_trait_edits};
     my @editable_ontologies = split(",", $editable_ontologies_str);
 
-    my $trait = CXGN::Trait->new({
-        bcs_schema => $schema,
-        cvterm_id => $cvterm_id
-    });
-
     if (! ($editable_ontologies_str == 1 || (grep {$_ eq $trait->db()} @editable_ontologies ) ) ) {
         $c->stash->{rest} = {error => "You do not have permission to edit traits.\n"};
-        return;
-    }
-
-    if (!$cvterm_id) {
-        $c->stash->{rest} = {error => "Cvterm ID missing.\n"};
         return;
     }
 

--- a/lib/SGN/Controller/AJAX/Trait.pm
+++ b/lib/SGN/Controller/AJAX/Trait.pm
@@ -26,11 +26,6 @@ sub create_trait :Path('/ajax/trait/create') {
         return;
     }
 
-    if (! $c->config->{allow_trait_edits}) {
-        $c->stash->{rest} = {error => "You do not have permission to design new traits.\n"};
-        return;
-    }
-
     my $name = $c->req->param('name') ? $c->req->param('name') : undef;
     my $definition = $c->req->param('definition') ? $c->req->param('definition') : undef;
     my $format = $c->req->param('format') ? $c->req->param('format') : undef;
@@ -41,6 +36,15 @@ sub create_trait :Path('/ajax/trait/create') {
     my $category_details = $c->req->param('category_details') ? $c->req->param('category_details') : undef;
     my $repeat_type = $c->req->param('repeat_type') ? $c->req->param('repeat_type') : undef;
     my $parent_terms = $c->req->param('parent_terms') ? $c->req->param('parent_terms') : undef;
+    my $parent_dbs = $c->req->pram('parent_dbs') ? $c->req->pram('parent_dbs') : undef;
+
+    my $editable_ontologies_str = $c->config->{allow_trait_edits};
+    my @editable_ontologies = split(",", $editable_ontologies_str);
+
+    if (! ($editable_ontologies_str == 1 || (grep {$parent_dbs =~ m/($_)/} @editable_ontologies ) ) ) {
+        $c->stash->{rest} = {error => "You do not have permission to design new traits.\n"};
+        return;
+    }
 
     $name =~ s/^\s+//;
     $name =~ s/\s+$//;
@@ -162,14 +166,22 @@ sub edit_trait :Path('/ajax/trait/edit') {
         return;
     }
 
-    if (! $c->config->{allow_trait_edits}) {
-        $c->stash->{rest} = {error => "You do not have permission to edit cvterms. Check server configuration.\n"};
-        return;
-    }
-
     my $cvterm_id = $c->req->param('cvterm_id') ? $c->req->param('cvterm_id') : undef;
     my $new_name = $c->req->param('new_name') ? $c->req->param('new_name') : undef;
     my $new_definition = $c->req->param('new_definition') ? $c->req->param('new_definition') : undef;
+
+    my $editable_ontologies_str = $c->config->{allow_trait_edits};
+    my @editable_ontologies = split(",", $editable_ontologies_str);
+
+    my $trait = CXGN::Trait->new({
+        bcs_schema => $schema,
+        cvterm_id => $cvterm_id
+    });
+
+    if (! ($editable_ontologies_str == 1 || (grep {$_ eq $trait->db()} @editable_ontologies ) ) ) {
+        $c->stash->{rest} = {error => "You do not have permission to edit traits.\n"};
+        return;
+    }
 
     if (!$cvterm_id) {
         $c->stash->{rest} = {error => "Cvterm ID missing.\n"};
@@ -177,11 +189,6 @@ sub edit_trait :Path('/ajax/trait/edit') {
     }
 
     eval {
-        my $trait = CXGN::Trait->new({
-            bcs_schema => $schema,
-            cvterm_id => $cvterm_id
-        });
-
         if (defined($new_name)) {
             $trait->name($new_name);
         }
@@ -212,11 +219,6 @@ sub delete_trait :Path('/ajax/trait/delete') {
         return;
     }
 
-    if (! $c->config->{allow_trait_edits}) {
-        $c->stash->{rest} = {error => "You do not have permission to edit cvterms. Check server configuration.\n"};
-        return;
-    }
-
     my $cvterm_id = $c->req->param('cvterm_id') ? $c->req->param('cvterm_id') : undef;
 
     if (!$cvterm_id) {
@@ -224,11 +226,20 @@ sub delete_trait :Path('/ajax/trait/delete') {
         return;
     }
 
+    my $editable_ontologies_str = $c->config->{allow_trait_edits};
+    my @editable_ontologies = split(",", $editable_ontologies_str);
+
+    my $trait = CXGN::Trait->new({
+        bcs_schema => $schema,
+        cvterm_id => $cvterm_id
+    });
+
+    if (! ($editable_ontologies_str == 1 || (grep {$_ eq $trait->db()} @editable_ontologies ) ) ) {
+        $c->stash->{rest} = {error => "You do not have permission to delete traits.\n"};
+        return;
+    }
+
     eval {
-        my $trait = CXGN::Trait->new({
-            bcs_schema => $schema,
-            cvterm_id => $cvterm_id
-        });
 
         $trait->delete();
     };

--- a/lib/SGN/Controller/AJAX/Treatment.pm
+++ b/lib/SGN/Controller/AJAX/Treatment.pm
@@ -26,7 +26,10 @@ sub create_treatment :Path('/ajax/treatment/create') {
         return;
     }
 
-    if (! $c->config->{allow_treatment_edits}) {
+    my $editable_ontologies_str = $c->config->{allow_trait_edits};
+    my @editable_ontologies = split(",", $editable_ontologies_str);
+
+    if (! grep {$_ eq "EXPERIMENT_TREATMENT"} @editable_ontologies) {
         $c->stash->{rest} = {error => "You do not have permission to design new treatments.\n"};
         return;
     }

--- a/lib/SGN/Controller/Cvterm.pm
+++ b/lib/SGN/Controller/Cvterm.pm
@@ -3,6 +3,8 @@ package SGN::Controller::Cvterm;
 
 #use CXGN::Chado::Cvterm; #DEPRECATE this !! 
 use CXGN::Cvterm;
+use CXGN::Onto;
+use Data::Dumper;
 
 use Moose;
 
@@ -45,30 +47,41 @@ sub view_cvterm : Chained('get_cvterm') PathPart('view') Args(0) {
     $sequencer = $logged_user->check_roles('sequencer') if $logged_user;
     my $props = $self->_cvtermprops($cvterm);
     my $editable_cvterm_props = "trait_format,trait_default_value,trait_minimum,trait_maximum,trait_details,trait_categories,trait_repeat_type";
-   
-    my $allow_trait_edits = 0;
-    if ($c->config->{allow_trait_edits}) {
-        $allow_trait_edits = 1;
-    }
-    my $allow_treatment_edits = 0;
-    if ($c->config->{allow_treatment_edits}) {
-        $allow_treatment_edits = 1;
+    my $schema = $c->dbic_schema("Bio::Chado::Schema", undef, $person_id);
+
+    my $db_name = $cvterm->db->name();
+
+    my $allow_edits = 0;
+    my $editable_ontologies_str = $c->config->{allow_trait_edits}; #this can be 1 or a list of dbnames
+
+     my $ontology_obj = CXGN::Onto->new({
+        schema => $schema
+    });
+    my @root_nodes = $ontology_obj->get_root_nodes('trait_ontology');
+    my $first_root_db = $root_nodes[0]->[1] =~ s/:.*//r;
+
+    if ($editable_ontologies_str == 1 && $curator && $db_name eq $first_root_db) { #just give the first hit
+        $allow_edits = 1;
+    } else { #need to actually check if ontology is editable
+        my @editable_ontologies = split(",", $editable_ontologies_str);
+        if ((grep {$_ eq $db_name} @editable_ontologies) && $curator) {
+            $allow_edits = 1;
+        }
     }
     
     $c->stash(
-	template => '/chado/cvterm.mas',
-	cvterm   => $cvterm, #deprecate this maybe? 
-    allow_trait_edits => $allow_trait_edits,
-    allow_treatment_edits => $allow_treatment_edits,
-	cvtermref => {
-	    cvterm    => $bcs_cvterm,
-	    curator   => $curator,
-            submitter => $submitter,
-            sequencer => $sequencer,
-            person_id => $person_id,
-	    props     => $props,
-	    editable_cvterm_props => $editable_cvterm_props,
-	}
+        template => '/chado/cvterm.mas',
+        cvterm   => $cvterm, #deprecate this maybe? 
+        allow_edits => $allow_edits,
+        cvtermref => {
+            cvterm    => $bcs_cvterm,
+            curator   => $curator,
+                submitter => $submitter,
+                sequencer => $sequencer,
+                person_id => $person_id,
+            props     => $props,
+            editable_cvterm_props => $editable_cvterm_props,
+        }
 	);
     
 }

--- a/lib/SGN/Controller/People.pm
+++ b/lib/SGN/Controller/People.pm
@@ -11,6 +11,7 @@ use CXGN::Phenome::Population;
 use SGN::Controller::solGS::AnalysisQueue;
 use CXGN::Page::FormattingHelpers qw/info_section_html page_title_html info_table_html simple_selectbox_html html_optional_show columnar_table_html/;
 use CXGN::Phenome::Locus;
+use CXGN::Onto;
 
 BEGIN { extends 'Catalyst::Controller' };
 
@@ -36,6 +37,7 @@ sub people_top_level : Path('/solpeople/profile') Args(1) {
         $c->res->redirect(uri( path => '/user/login', query => { goto_url => $c->req->uri->path_query } ) );
         $c->detach();
     }
+    my $schema = $c->dbic_schema("Bio::Chado::Schema", undef, $user_id);
     my $users_profile;
     if ($person_id == $user_id) {
         $users_profile = 1;
@@ -130,12 +132,25 @@ sub people_top_level : Path('/solpeople/profile') Args(1) {
     }
 
     my $allow_trait_edits = 0;
-    if ($c->config->{allow_trait_edits}) {
-        $allow_trait_edits = 1;
-    }
     my $allow_treatment_edits = 0;
-    if ($c->config->{allow_treatment_edits}) {
-        $allow_treatment_edits = 1;
+    my $editable_ontologies_str = $c->config->{allow_trait_edits};
+    if ($editable_ontologies_str == 1) {
+        $allow_trait_edits = 1;
+    } else {
+        my @editable_ontologies = split(",", $editable_ontologies_str);
+        my $ontology_obj = CXGN::Onto->new({
+            schema => $schema
+        });
+        my @root_nodes = $ontology_obj->get_root_nodes('trait_ontology');
+
+        my $root_term_name = $root_nodes[0]->[1] =~ s/\w+:\d+ //r;
+        my $db_name = $root_nodes[0]->[1] =~ s/:.*//r;
+        if (grep {$_ eq $db_name} @editable_ontologies) {
+            $allow_trait_edits = 1;
+        }
+        if (grep {$_ eq "EXPERIMENT_TREATMENT"} @editable_ontologies) {
+            $allow_treatment_edits = 1;
+        }
     }
 
     $c->stash->{site_name} = $c->config->{project_name};

--- a/lib/SGN/Controller/Trait.pm
+++ b/lib/SGN/Controller/Trait.pm
@@ -27,23 +27,26 @@ sub trait_design_page : Path('/traits/design/') Args(0) {
     my @db_names;
 
     my @root_terms = map {{name => $_->[1] =~ s/\w+:\d+ //r, cv_id => $_->[0], db_name => $_->[1] =~ s/:.*//r}} @root_nodes;
-    foreach my $term (@root_terms) { 
+    foreach my $term (@root_terms) {
         push @db_names, $term->{db_name};
     }
 
+    my %seen; # an ontology can have more than one root node, but should only be listed once
+    @db_names = grep { !$seen{$_}++ } @db_names;
+
     my $editable_ontologies_str = $c->config->{allow_trait_edits}; #this can be 1 or a list of dbnames
 
-    if ($editable_ontologies_str == 1) { #just give the first hit
+    if ($editable_ontologies_str == 1) { #every trait ontology is editable
         $c->stash(
             template => '/tools/trait_designer.mas',
-            db_names => $db_names[0]
+            db_names => join(",",@db_names)
         );
     } else { #need to actually check if trait ontology is editable
         my @editable_ontologies = split(",", $editable_ontologies_str);
         my @editable_dbnames;
-        foreach my $term (@root_terms) { 
-            if (grep {$_ eq $term->{db_name}} @editable_ontologies) { #if this root term is editable per the config, add it to the list
-                push @editable_dbnames, $term->{db_name};
+        foreach my $db_name (@db_names) {
+            if (grep {$_ eq $db_name} @editable_ontologies) { #if this ontology is editable per the config, add it to the list
+                push @editable_dbnames, $db_name;
             }
         }
         if (scalar(@editable_dbnames > 0)) {

--- a/lib/SGN/Controller/Trait.pm
+++ b/lib/SGN/Controller/Trait.pm
@@ -7,36 +7,49 @@ use CXGN::Cvterm;
 
 BEGIN { extends 'Catalyst::Controller'; }
 
-sub treatment_design_page : Path('/traits/design/') Args(0) {
+sub trait_design_page : Path('/traits/design/') Args(0) {
     my $self = shift;
     my $c = shift;
 
     my $sp_person_id = $c->user() ? $c->user->get_object()->get_sp_person_id() : undef;
     my $schema = $c->dbic_schema("Bio::Chado::Schema", undef, $sp_person_id);
 
-    if (! $c->config->{allow_trait_edits}) {
+    if (!($c->user() && $c->user->check_roles('curator'))) {
         $c->stash->{template} = '/site/error/permission_denied.mas';
-    } else {
+        return;
+    }
 
-        if ($c->user() && $c->user->check_roles('curator')) {
-            my $ontology_obj = CXGN::Onto->new({
-			    schema => $schema
-            });
-            my @root_nodes = $ontology_obj->get_root_nodes('trait_ontology');
+    my $ontology_obj = CXGN::Onto->new({
+        schema => $schema
+    });
+    my @root_nodes = $ontology_obj->get_root_nodes('trait_ontology');
 
-            my $root_term_name = $root_nodes[0]->[1] =~ s/\w+:\d+ //r;
-            my $db_name = $root_nodes[0]->[1] =~ s/:.*//r;
+    my @db_names;
 
-            my $cvterm_id = $schema->resultset("Cv::Cvterm")->find({
-                name => $root_term_name,
-                cv_id => $root_nodes[0]->[0]
-            })->cvterm_id();
+    my @root_terms = map {{name => $_->[1] =~ s/\w+:\d+ //r, cv_id => $_->[0], db_name => $_->[1] =~ s/:.*//r}} @root_nodes;
+    foreach my $term (@root_terms) { 
+        push @db_names, $term->{db_name};
+    }
 
-            my $cvterm = CXGN::Cvterm->new({ schema=>$schema, cvterm_id => $cvterm_id } );
+    my $editable_ontologies_str = $c->config->{allow_trait_edits}; #this can be 1 or a list of dbnames
+
+    if ($editable_ontologies_str == 1) { #just give the first hit
+        $c->stash(
+            template => '/tools/trait_designer.mas',
+            db_names => $db_names[0]
+        );
+    } else { #need to actually check if trait ontology is editable
+        my @editable_ontologies = split(",", $editable_ontologies_str);
+        my @editable_dbnames;
+        foreach my $term (@root_terms) { 
+            if (grep {$_ eq $term->{db_name}} @editable_ontologies) { #if this root term is editable per the config, add it to the list
+                push @editable_dbnames, $term->{db_name};
+            }
+        }
+        if (scalar(@editable_dbnames > 0)) {
             $c->stash(
                 template => '/tools/trait_designer.mas',
-                trait_root => $cvterm,
-                db_name => $db_name
+                db_names => join(",",@editable_dbnames)
             );
         } else {
             $c->stash->{template} = '/site/error/permission_denied.mas';

--- a/lib/SGN/Controller/Treatment.pm
+++ b/lib/SGN/Controller/Treatment.pm
@@ -13,35 +13,27 @@ sub treatment_design_page : Path('/treatments/design/') Args(0) {
     my $sp_person_id = $c->user() ? $c->user->get_object()->get_sp_person_id() : undef;
     my $schema = $c->dbic_schema("Bio::Chado::Schema", undef, $sp_person_id);
 
-    if (! $c->config->{allow_treatment_edits}) {
+    if (!($c->user() && $c->user->check_roles('curator'))) {
         $c->stash->{template} = '/site/error/permission_denied.mas';
-    } else {
+        return;
+    }
 
-        if ($c->user() && $c->user->check_roles('curator')) {
-            my $ontology_obj = CXGN::Onto->new({
-			    schema => $schema
-            });
-            my @root_nodes = $ontology_obj->get_root_nodes('experiment_treatment_ontology');
+    my $editable_ontologies_str = $c->config->{allow_trait_edits}; #this can be 1 or a list of dbnames
 
-            my $root_term_name = $root_nodes[0]->[1] =~ s/\w+:\d+ //r;
-            my $db_name = $root_nodes[0]->[1] =~ s/:.*//r;
+    if ($editable_ontologies_str == 1) { #shorthand for first trait ontology only - not treatments
+        $c->stash->{template} = '/site/error/permission_denied.mas';
+    } else { #need to actually check if treatment ontology is editable
+        my @editable_ontologies = split(",", $editable_ontologies_str);
 
-            my $cvterm_id = $schema->resultset("Cv::Cvterm")->find({
-                name => $root_term_name,
-                cv_id => $root_nodes[0]->[0]
-            })->cvterm_id();
-            my $cvterm = CXGN::Cvterm->new({ schema=>$schema, cvterm_id => $cvterm_id } );
+        if (grep {$_ eq "EXPERIMENT_TREATMENT"} @editable_ontologies) {
             $c->stash(
                 template => '/tools/treatment_designer.mas',
-                exp_treatment_root => $cvterm,
-                db_name => $db_name
+                db_name => "EXPERIMENT_TREATMENT"
             );
         } else {
             $c->stash->{template} = '/site/error/permission_denied.mas';
         }
-
     }
-
 }
 
 1;

--- a/mason/chado/cvterm.mas
+++ b/mason/chado/cvterm.mas
@@ -27,8 +27,7 @@ Naama Menda <nm249@cornell.edu>
 <%args>
   $cvterm
   $cvtermref
-  $allow_trait_edits => 0
-  $allow_treatment_edits => 0
+  $allow_edits => 0
 </%args>
 
 <%once>
@@ -52,11 +51,6 @@ my $comment     = '' ;#$cvterm->comment;
 #$stockref->{props} (hash of arrayrefs of cvtermprops. Keys = prop name, value = prop value)
 my $editable_cvterm_props_string = $cvtermref->{editable_cvterm_props};
 my @editable_cvterm_props = split "," , $editable_cvterm_props_string;
-
-my $allow_edits = 0;
-if (($allow_treatment_edits && $db_name =~ m/_TREATMENT/) || ($allow_trait_edits && $db_name !~ m/_TREATMENT/) ) {
-  $allow_edits = 1;
-}
 
 my $is_obsolete = $cvterm->is_obsolete();
 my @synonyms    = $cvterm->synonyms();
@@ -333,7 +327,7 @@ my $edit_privs = $curator ;
     });
 
     jQuery('#new_parent_term_input').autocomplete({
-      source: '/ajax/cvterm/autocompleteslim' + "?db_name=<% $db_name %>",
+      source: '/ajax/cvterm/autocompleteslim' + "?db_names=<% $db_name %>",
       appendTo: 'body'
     }).autocomplete('widget').css('z-index', 9999);
 

--- a/mason/stock/add_phenotype.mas
+++ b/mason/stock/add_phenotype.mas
@@ -51,7 +51,7 @@ $uri => "/ajax/cvterm/autocomplete"
 
   jQuery(function() {
      jQuery("#trait_ontology_name").autocomplete({
-      source: '<% $uri %>' + '?db_name=' + '<% $trait_ontology_db_name %>'
+      source: '<% $uri %>' + '?db_names=' + '<% $trait_ontology_db_name %>'
      });
   });
 

--- a/mason/stock/stock_search_form.mas
+++ b/mason/stock/stock_search_form.mas
@@ -64,7 +64,7 @@ div.paginate_nav {
         source: '<% $trait_autocomplete_uri %>'
      });
      jQuery("#onto").autocomplete({
-        source: '<% $onto_autocomplete_uri %>' + "?db_name=" + '<% $trait_db_name %>'
+        source: '<% $onto_autocomplete_uri %>' + "?db_names=" + '<% $trait_db_name %>'
      });
      jQuery("#stock_name").autocomplete({
         source: '/ajax/stock/stock_autocomplete',

--- a/mason/tools/trait_designer.mas
+++ b/mason/tools/trait_designer.mas
@@ -24,16 +24,26 @@
                 </div>
             </div>
             <div class="form-group">
+                <label class="col-sm-3 control-label"><span class="glyphicon glyphicon-question-sign" style="color:blue;font-size:18px" title="The ontology that the new term will belong to. This is separate from the parent term(s) that the new term is chained to."></span>&nbsp;Trait ontology:</label>
+                <div class="col-sm-9">
+                    <select style="width:70%;" class="form-control" id="new_trait_ontology_select" name="new_trait_ontology_select" type="select">
+%                   foreach my $ontology_db_name (grep { $_ } map { $_ =~ s/^\s+|\s+$//gr } split(",", $db_names)) {
+                        <option value="<% $ontology_db_name %>"><% $ontology_db_name %></option>
+%                   }
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
                 <label class="col-sm-3 control-label">Trait format:</label>
                 <div class="col-sm-9">
                     <select style="width:70%;" class="form-control" id="new_trait_format_select" name="new_trait_format_select" type="select">
-                        <option value="Numeric" selected>Numeric</option>
-                        <option value="Categorical">Categorical</option>
-                        <option value="Percent">Percent</option>
-                        <option value="Boolean">Boolean</option>
-                        <option value="Date">Date</option>
-                        <option value="Text">Text</option>
-                        <option value="Counter">Counter</option>
+                        <option value="numeric" selected>Numeric</option>
+                        <option value="categorical">Categorical</option>
+                        <option value="percent">Percent</option>
+                        <option value="boolean">Boolean</option>
+                        <option value="date">Date</option>
+                        <option value="text">Text</option>
+                        <option value="counter">Counter</option>
                         <option value="ontology">Ontology (parent to child terms)</option>
                     </select>
                 </div>
@@ -134,6 +144,7 @@ Will be the trait root term by default if none are added."></span>&nbsp;Chain to
             let name = jQuery('#new_trait_name').val();
             let definition = jQuery('#new_trait_definition').val();
             let format = jQuery('#new_trait_format_select').val();
+            let ontology_db_name = jQuery('#new_trait_ontology_select').val();
             let default_value = jQuery('#new_trait_default_value').val();
             let minimum = jQuery('#new_trait_minimum').val();
             let maximum = jQuery('#new_trait_maximum').val();
@@ -166,6 +177,7 @@ Will be the trait root term by default if none are added."></span>&nbsp;Chain to
                     category_details : category_details,
                     parent_terms : parent_terms_json,
                     repeat_type : repeat_type,
+                    ontology_db_name : ontology_db_name,
                     parent_dbs : "<% $db_names %>"
                 },
                 success: function(response) {

--- a/mason/tools/trait_designer.mas
+++ b/mason/tools/trait_designer.mas
@@ -1,6 +1,5 @@
 <%args>
-    $trait_root
-    $db_name
+    $db_names
 </%args>
 
 <div style="text-align: center; margin: 2em 0">
@@ -101,11 +100,29 @@ Will be the trait root term by default if none are added."></span>&nbsp;Chain to
     </div>
 </div>
 
+<table>
+    <tr>
+        <td>
+            <select id="trait_ontology_download_select" class="form-control">
+                <option value="">Download trait ontology...</option>
+            </select>
+        </td>
+        <td>
+            <button id="download_ontology_btn" class="btn btn-primary"><span class="glyphicon glyphicon-floppy-save"></span></button>
+        </td>
+    </tr>
+</table>
 
-<button id="download_ontology_btn" class="btn btn-primary">Download Trait Ontology</button>
+
 <br>
 <br>
-<& /ontology/embedded_browser.mas, cvterm => $trait_root &>
+% 
+% my $root_nodes = $db_names =~ s/,/ /gr;
+% 
+<&| /page/info_section.mas, title=>"Trait terms", collapsible=>1 &>
+    <& /ontology/browser.mas, root_nodes=>$root_nodes, expand=>0 &>
+</&>
+
 
 <script>
     jQuery(document).ready(function () {
@@ -148,7 +165,8 @@ Will be the trait root term by default if none are added."></span>&nbsp;Chain to
                     categories : categories,
                     category_details : category_details,
                     parent_terms : parent_terms_json,
-                    repeat_type : repeat_type
+                    repeat_type : repeat_type,
+                    parent_dbs : "<% $db_names %>"
                 },
                 success: function(response) {
                     jQuery('#working_modal').modal("hide");
@@ -168,7 +186,7 @@ Will be the trait root term by default if none are added."></span>&nbsp;Chain to
         });
 
         jQuery('#new_trait_parent_term').autocomplete({
-            source : '/ajax/cvterm/autocompleteslim' + "?db_name=<% $db_name %>"
+            source : '/ajax/cvterm/autocompleteslim' + "?db_names=<% $db_names %>"
         });
 
         jQuery('#new_trait_add_parent_btn').on('click', function(e) {
@@ -316,18 +334,35 @@ Will be the trait root term by default if none are added."></span>&nbsp;Chain to
             jQuery('#new_trait_categories').html(table_str);
         });
 
+        let ontology_db_names = "<% $db_names %>".split(",");
+        ontology_db_names.forEach(function (db_name) {
+            db_name = db_name.trim();
+            if (db_name) {
+                jQuery('#trait_ontology_download_select').append(
+                    jQuery('<option>', { value : db_name, text : db_name })
+                );
+            }
+        });
+
         jQuery('#download_ontology_btn').click(function() {
+
+            let db_name = jQuery('#trait_ontology_download_select').val();
+
+            if (!db_name || db_name == null || db_name == "") {
+                alert("Please select an ontology.");
+                return;
+            }
 
             jQuery('#working_modal').modal("show");
 
-            fetch("/ajax/onto/download_obo/<% $db_name %>")
+            fetch(`/ajax/onto/download_obo/${db_name}`)
                 .then(response => response.blob())
                 .then(blob => {
                     jQuery('#working_modal').modal("hide");
                     const url = window.URL.createObjectURL(blob);
                     const a = document.createElement('a');
                     a.href = url;
-                    a.download = "<% $db_name %>.txt";
+                    a.download = `${db_name}.txt`;
                     document.body.appendChild(a);
                     a.click();
                     a.remove();
@@ -339,6 +374,8 @@ Will be the trait root term by default if none are added."></span>&nbsp;Chain to
                     console.error('Download failed:', error)
                 });
         });
+
+        jQuery("[title='ontology browser input form']").hide();
 
         function html_table_to_json(html_str) {
             let list = html_str.replace(/^<tr>|<\/?table>|<tr>|^\s+|<td>|<\/td>|<\/tr>$|\s+$/g,'').split("</tr>").filter(str => str.trim() !== '');

--- a/mason/tools/treatment_designer.mas
+++ b/mason/tools/treatment_designer.mas
@@ -1,5 +1,4 @@
 <%args>
-    $exp_treatment_root
     $db_name
 </%args>
 
@@ -105,7 +104,12 @@ Will be the treatment root term by default if none are added."></span>&nbsp;Chai
 <button id="download_ontology_btn" class="btn btn-primary">Download Treatment Ontology</button>
 <br>
 <br>
-<& /ontology/embedded_browser.mas, cvterm => $exp_treatment_root &>
+% 
+% my $root_nodes = $db_name =~ s/,/ /gr; # should just be EXPERIMENT_TREATMENT
+% 
+<&| /page/info_section.mas, title=>"Treatment terms", collapsible=>1 &>
+    <& /ontology/browser.mas, root_nodes=>$root_nodes, expand=>0 &>
+</&>
 
 <script>
     jQuery(document).ready(function () {
@@ -148,7 +152,8 @@ Will be the treatment root term by default if none are added."></span>&nbsp;Chai
                     categories : categories,
                     category_details : category_details,
                     parent_terms : parent_terms_json,
-                    repeat_type : repeat_type
+                    repeat_type : repeat_type,
+                    parent_dbs : "<% $db_name %>"
                 },
                 success: function(response) { 
                     jQuery('#working_modal').modal("hide");
@@ -168,7 +173,7 @@ Will be the treatment root term by default if none are added."></span>&nbsp;Chai
         });
 
         jQuery('#new_treatment_parent_term').autocomplete({
-            source : '/ajax/cvterm/autocompleteslim' + "?db_name=<% $db_name %>"
+            source : '/ajax/cvterm/autocompleteslim' + "?db_names=<% $db_name %>"
         });
 
         jQuery('#new_treatment_add_parent_btn').on('click', function(e) {
@@ -339,6 +344,8 @@ Will be the treatment root term by default if none are added."></span>&nbsp;Chai
                     console.error('Download failed:', error)
                 });
         });
+
+        jQuery("[title='ontology browser input form']").hide();
 
         function html_table_to_json(html_str) {
             let list = html_str.replace(/^<tr>|<\/?table>|<tr>|^\s+|<td>|<\/td>|<\/tr>$|\s+$/g,'').split("</tr>").filter(str => str.trim() !== '');

--- a/sgn.conf
+++ b/sgn.conf
@@ -57,8 +57,9 @@ decision_format state,year yy,stage #(DROP-23-Y2)
 breeding_stages T1,T2,Y0,Y1,Y2,Y3,Y4,Y5,commercial
 saved_program_stage BTI|BTI_Stage,Cornell|Cornell_Stage
 
-allow_trait_edits 1
-allow_treatment_edits 0
+# 1 or a list of editable ontologies. allow_trait_edits=1 shorthand for edit first trait ontology
+allow_trait_edits EXPERIMENT_TREATMENT,COMP_EXP_TREATMENT,COMP,CO_334
+
 # Marker Metadata Trait Categories
 # Set the DB:Accession of the root term of the ontology used to define trait categories for marker metadata
 marker_metadata_trait_ontology_root

--- a/sgn_test.conf
+++ b/sgn_test.conf
@@ -99,8 +99,7 @@ cview_db_backend Cassava
 #Homepage controller customization
 homepage_display_phenotype_uploads 0
 
-allow_treatment_edits 1
-allow_trait_edits 0
+allow_trait_edits EXPERIMENT_TREATMENT,COMP_EXP_TREATMENT,CO_334,COMP
 
 # Marker Metadata Trait Categories
 # Using the cassava trait ontology for tests

--- a/t/selenium2/tools/trait_designer.t
+++ b/t/selenium2/tools/trait_designer.t
@@ -1,0 +1,82 @@
+use lib 't/lib';
+
+use Test::More;
+use SGN::Test::WWW::WebDriver;
+use SGN::Test::Fixture;
+use Selenium::Remote::WDKeys 'KEYS';
+use Selenium::Remote::WebElement;
+use Data::Dumper;
+
+use strict;
+
+my $f = SGN::Test::Fixture->new();
+
+my $t = SGN::Test::WWW::WebDriver->new();
+
+$t->while_logged_in_as("curator", sub {
+    sleep(2);
+
+    $t->get_ok('/traits/design');
+
+    sleep(3);
+
+    $t->find_element_ok('new_trait_name', 'id', 'fill trait name field')->send_keys("test trait");
+
+    sleep(0.5);
+    
+    $t->find_element_ok('new_trait_definition', 'id', 'fill trait definition field')->send_keys("A fake test trait to see if the trait designer can make new traits during selenium tests.");
+
+    sleep(0.5);
+
+    my $ontology_select = $t->find_element_ok('new_trait_ontology_select', 'id', 'open trait ontology select')->click();
+
+    $t->driver->find_element('//select[@id="new_trait_ontology_select"]/option[@value="CO_334"]', 'xpath')->click();
+
+    sleep(0.5);
+
+    my $format_select = $t->find_element_ok('new_trait_format_select', 'id', 'select categorical trait format')->click();
+
+    $t->driver->find_element('//select[@id="new_trait_format_select"]/option[@value="categorical"]', 'xpath')->click();
+
+    sleep(1);
+
+    $t->find_element_ok('new_trait_add_category', 'id', 'name first category')->send_keys("control");
+
+    $t->find_element_ok('new_trait_category_ordinal', 'id', 'assign first category as 0')->send_keys("0");
+
+    $t->find_element_ok('new_trait_add_category_btn', 'id', 'create first category')->click();
+
+    sleep(1);
+
+    $t->find_element_ok('new_trait_add_category', 'id', 'name second category')->send_keys("high");
+
+    $t->find_element_ok('new_trait_category_ordinal', 'id', 'assign second category as 1')->send_keys("1");
+
+    $t->find_element_ok('new_trait_add_category_btn', 'id', 'create second category')->click();
+
+    sleep(1);
+
+    $t->find_element_ok('new_trait_add_category', 'id', 'name bad category')->send_keys("testtesttest");
+
+    $t->find_element_ok('new_trait_category_ordinal', 'id', 'assign bad category as 33')->send_keys("33");
+
+    $t->find_element_ok('new_trait_add_category_btn', 'id', 'create bad category')->click();
+
+    sleep(1);
+
+    $t->find_element_ok('new_trait_remove_category_btn', 'id', 'delete bad category')->click();
+
+    sleep(1);
+
+    $t->find_element_ok('new_trait_submit_btn', 'id', 'submit new trait')->click();
+
+    sleep(2);
+
+    $t->driver->accept_alert();
+
+    sleep(1);
+});
+
+$t->driver->close();
+$f->clean_up_db();
+done_testing();

--- a/t/selenium2/tools/treatment_designer.t
+++ b/t/selenium2/tools/treatment_designer.t
@@ -71,4 +71,5 @@ $t->while_logged_in_as("curator", sub {
     sleep(1);
 });
 
+$t->driver->close();
 done_testing();

--- a/t/unit_mech/AJAX/Trait.t
+++ b/t/unit_mech/AJAX/Trait.t
@@ -1,0 +1,183 @@
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use SGN::Test::Fixture;
+use Test::More;
+use Test::WWW::Mechanize;
+
+use Data::Dumper;
+use JSON;
+
+my $f = SGN::Test::Fixture->new();
+my $schema = $f->bcs_schema();
+
+my $mech = Test::WWW::Mechanize->new;
+my $response;
+
+my $trait_ontology_db_name = "CO_334";
+my $new_trait_name = "ajax unit test trait";
+my $new_trait_definition = "A fake numeric trait created by the AJAX unit test to check that the trait designer can store new traits.";
+my $edited_trait_definition = "An edited definition for the fake numeric trait created by the AJAX unit test.";
+
+# login as a curator, since designing traits is curator only
+#
+$mech->post_ok('http://localhost:3010/brapi/v1/token', [ "username"=> "janedoe", "password"=> "secretpw", "grant_type"=> "password" ], 'login with brapi call');
+
+$response = decode_json $mech->content;
+
+is($response->{'userDisplayName'}, 'Jane Doe', 'check login name');
+
+sleep(1);
+
+# figure out which cv the trait ontology lives in, so that we can check that the new term is stored in it
+#
+my $get_trait_cv_id_sql = "SELECT DISTINCT cvterm.cv_id FROM cvterm
+JOIN dbxref USING (dbxref_id)
+JOIN db USING (db_id)
+JOIN cvprop ON (cvterm.cv_id = cvprop.cv_id)
+JOIN cvterm AS prop_type ON (cvprop.type_id = prop_type.cvterm_id)
+WHERE db.name = ? AND prop_type.name = 'trait_ontology'";
+
+my $h = $schema->storage->dbh->prepare($get_trait_cv_id_sql);
+$h->execute($trait_ontology_db_name);
+
+my $trait_cv_id = $h->fetchrow_array();
+
+ok($trait_cv_id, "found the cv of trait ontology $trait_ontology_db_name");
+
+# the root term of this ontology is what a new trait gets chained to when no parent terms are given.
+# look it up before storing anything, so that the new trait cannot show up as a root term itself.
+#
+my $get_root_term_sql = "SELECT cvterm.cvterm_id FROM cvterm
+JOIN dbxref USING (dbxref_id)
+JOIN db USING (db_id)
+LEFT JOIN cvterm_relationship ON (cvterm.cvterm_id = cvterm_relationship.subject_id)
+WHERE db.name = ? AND cvterm.cv_id = ? AND cvterm_relationship.subject_id IS NULL
+AND cvterm.is_obsolete = 0 AND cvterm.is_relationshiptype = 0";
+
+$h = $schema->storage->dbh->prepare($get_root_term_sql);
+$h->execute($trait_ontology_db_name, $trait_cv_id);
+
+my %root_term_ids; # an ontology can have more than one parentless term, any of them is an acceptable parent
+while (my $root_term_id = $h->fetchrow_array()) {
+    $root_term_ids{$root_term_id} = 1;
+}
+
+ok(scalar(keys(%root_term_ids)), "found the root term(s) of trait ontology $trait_ontology_db_name");
+
+my $rel_cv_id = $schema->resultset("Cv::Cv")->find({ name => 'relationship' })->cv_id();
+my $variable_of_id = $schema->resultset("Cv::Cvterm")->find({ name => 'VARIABLE_OF', cv_id => $rel_cv_id })->cvterm_id();
+
+# an ontology that is not in the allow_trait_edits config key cannot be added to,
+# even when every other parameter is valid
+#
+$mech->post_ok('http://localhost:3010/ajax/trait/create', [
+    name => $new_trait_name,
+    definition => $new_trait_definition,
+    format => "numeric",
+    minimum => 0,
+    maximum => 100,
+    repeat_type => "single",
+    ontology_db_name => "INVALID",
+    parent_dbs => $trait_ontology_db_name
+], 'try to create a trait in a non-editable ontology');
+
+$response = decode_json $mech->content;
+
+is($response->{error}, "Ontology INVALID is not editable on this server - contact a system administrator.\n", 'creating a trait in a non-editable ontology is rejected');
+
+is($schema->resultset("Cv::Cvterm")->search({ name => $new_trait_name })->count(), 0, 'the rejected trait was not stored');
+
+# now create the same trait in an editable ontology
+#
+$mech->post_ok('http://localhost:3010/ajax/trait/create', [
+    name => $new_trait_name,
+    definition => $new_trait_definition,
+    format => "numeric",
+    minimum => 0,
+    maximum => 100,
+    repeat_type => "single",
+    ontology_db_name => $trait_ontology_db_name,
+    parent_dbs => $trait_ontology_db_name
+], 'create a new trait');
+
+$response = decode_json $mech->content;
+
+is($response->{success}, 1, 'the new trait was created');
+
+# the new term must be in the cv of the ontology that was selected
+#
+my $new_trait = $schema->resultset("Cv::Cvterm")->search({
+    name => $new_trait_name,
+    cv_id => $trait_cv_id
+})->single();
+
+ok($new_trait, "the new trait was stored in the cv of $trait_ontology_db_name");
+
+my $new_trait_id = $new_trait->cvterm_id();
+
+is($new_trait->definition(), $new_trait_definition, 'the new trait has the definition that was submitted');
+
+is($new_trait->dbxref->db->name(), $trait_ontology_db_name, "the new trait has a dbxref in $trait_ontology_db_name");
+
+# no parent terms were given, so the new trait should hang off the root term of the selected ontology
+#
+my $parent_relationship = $schema->resultset("Cv::CvtermRelationship")->search({
+    subject_id => $new_trait_id,
+    type_id => $variable_of_id
+})->single();
+
+ok($parent_relationship, 'the new trait was chained to a parent term');
+
+my $parent_term_id = $parent_relationship->object_id();
+
+ok($root_term_ids{$parent_term_id}, "the new trait is a variable of a root term of $trait_ontology_db_name");
+
+is($schema->resultset("Cv::Cvterm")->find({
+    cvterm_id => $parent_term_id
+})->cv_id(), $trait_cv_id, "the parent term of the new trait is in the cv of $trait_ontology_db_name");
+
+# edit the definition of the new trait
+#
+$mech->post_ok('http://localhost:3010/ajax/trait/edit', [
+    cvterm_id => $new_trait_id,
+    new_definition => $edited_trait_definition
+], 'edit the definition of the new trait');
+
+$response = decode_json $mech->content;
+
+is($response->{success}, 1, 'the trait was edited');
+
+$new_trait->discard_changes();
+
+is($new_trait->definition(), $edited_trait_definition, 'the definition of the trait was updated');
+
+is($new_trait->name(), $new_trait_name, 'the name of the trait was left alone');
+
+# an edit without a cvterm_id should not be accepted
+#
+$mech->post_ok('http://localhost:3010/ajax/trait/edit', [
+    new_definition => "Another definition that should never be stored anywhere."
+], 'try to edit a trait without a cvterm id');
+
+$response = decode_json $mech->content;
+
+is($response->{error}, "Cvterm ID missing.\n", 'editing a trait without a cvterm id is rejected');
+
+# delete the new trait
+#
+$mech->post_ok('http://localhost:3010/ajax/trait/delete', [
+    cvterm_id => $new_trait_id
+], 'delete the new trait');
+
+$response = decode_json $mech->content;
+
+is($response->{success}, 1, 'the trait was deleted');
+
+is($schema->resultset("Cv::Cvterm")->search({ cvterm_id => $new_trait_id })->count(), 0, 'the trait is gone from the database');
+
+is($schema->resultset("Cv::CvtermRelationship")->search({ subject_id => $new_trait_id })->count(), 0, 'the relationship to the root term is gone as well');
+
+done_testing();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Changes the behavior of the config key `allow_trait_edits` to be a list of cvterm DB names for ontologies that can be edited.
Other changes:
- `allow_treatment_edits` is deprecated
- cvterm autocomplete now accepts multiple db names for autocompletion

<!-- If there are relevant issues, link them here: -->
Closes #6245 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
