### PR TITLE
update to node.js v24

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,6 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HTMLHINT_CONFIG_FILE: .github/linters/.htmlhintrc
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_SHELL_SHFMT: false
           VALIDATE_ANSIBLE: false
           VALIDATE_CHECKOV: false
           VALIDATE_JSCPD: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,9 +63,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Install JS deps
         working-directory: js

--- a/js/build.webpack.config.js
+++ b/js/build.webpack.config.js
@@ -24,9 +24,11 @@ module.exports = {
         path: path.resolve(__dirname, "build/"),
         publicPath: '/js',
         filename: '[name].min.js',
-        chunkFilename: `chunk.[chunkhash].js`,
-        library: ["jsMod","[name]"],
-        libraryTarget: "umd"
+	chunkFilename: `chunk.[chunkhash].js`,
+        library: {
+	    name: ["jsMod","[name]"],
+            type: "umd"
+	}
     },
     // Set up babel and JSAN processing
     module: {
@@ -59,15 +61,12 @@ module.exports = {
     // Chunks and Minimization settings
     optimization: {
         minimize: true,
-        namedChunks: true,
-        minimizer: [new TerserPlugin({
-            'sourceMap': true,
-            'parallel': 4,
-        })],
-        runtimeChunk: {
+	chunkIds: "deterministic",
+        minimizer: [new TerserPlugin({})],
+	runtimeChunk: {
             name: 'runtime'
         },
-        splitChunks: {
+	splitChunks: {
             cacheGroups: {
                 default: false,
                 shared: {

--- a/js/install_node.sh
+++ b/js/install_node.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ $(/usr/bin/id -u) -ne 0 ]]; then
-    echo "\nMust run script as root."
+    printf "\nMust run script as root."
     exit
 fi
 

--- a/js/install_node.sh
+++ b/js/install_node.sh
@@ -9,7 +9,7 @@ fi
 curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 # Add the desired NodeSource repository
-VERSION=node_20.x
+VERSION=node_24.x
 # The below command will set this correctly, but if lsb_release isn't available, you can set it manually:
 # - For Debian distributions: jessie, sid, etc...
 # - For Ubuntu distributions: xenial, bionic, etc...

--- a/js/package.json
+++ b/js/package.json
@@ -20,7 +20,7 @@
     "deepmerge": "^2.2.1",
     "del": "^3.0.0",
     "jsdom": "^16",
-    "nock": "^10.0.6",
+    "nock": "^13.5.6",
     "node-fetch": "^2.3.0",
     "requirejs": "2.3.7",
     "save-svg-as-png": "^1.4.17",

--- a/js/package.json
+++ b/js/package.json
@@ -26,9 +26,9 @@
     "requirejs": "2.3.7",
     "save-svg-as-png": "^1.4.17",
     "tape": "^4.10.1",
-    "terser-webpack-plugin": "^4.2.3",
-    "webpack": "^4.29",
-    "webpack-cli": "^4.10.0"
+    "terser-webpack-plugin": "^5",
+    "webpack": "^5",
+    "webpack-cli": "^6"
   },
   "dependencies": {
     "@solgenomics/brapijs": "github:solgenomics/brapi-js#develop",
@@ -42,7 +42,7 @@
     "internmap": "^1.0.0"
   },
   "engines": {
-    "node": ">=18.20.8",
-    "npm": ">=10.8.2"
+    "node": ">=24",
+    "npm": ">=11"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -16,11 +16,10 @@
   "devDependencies": {
     "@babel/core": "^7",
     "@babel/preset-env": "^7",
-    "babel-loader": "^8",
+    "babel-loader": "^9",
     "deepmerge": "^2.2.1",
     "del": "^3.0.0",
     "jsdom": "^16",
-    "loader-utils": "^2.0",
     "nock": "^10.0.6",
     "node-fetch": "^2.3.0",
     "requirejs": "2.3.7",

--- a/js/package.json
+++ b/js/package.json
@@ -5,10 +5,10 @@
   "main": "webpack.config.js",
   "scripts": {
     "reset": "rm -rf build/ && npm install",
-    "build": "npm run reset && NODE_OPTIONS=--openssl-legacy-provider webpack --config build.webpack.config.js",
-    "build-watch": "npm run reset && NODE_OPTIONS=--openssl-legacy-provider webpack --config build.webpack.config.js -w",
+    "build": "npm run reset && webpack --config build.webpack.config.js",
+    "build-watch": "npm run reset && webpack --config build.webpack.config.js -w",
     "reset-test": "rm -rf build_test/ && npm install",
-    "build-test": "npm run reset-test && NODE_OPTIONS=--openssl-legacy-provider webpack --config test.webpack.config.js"
+    "build-test": "npm run reset-test && webpack --config test.webpack.config.js"
   },
   "private": true,
   "author": "",

--- a/js/run-tests.js
+++ b/js/run-tests.js
@@ -51,10 +51,9 @@ test('Webpack Build '+Object.keys(webpackConfig.entry).join(", "), function (t) 
   // Run webpack
   webpack(webpackConfig).run((err,stats)=>{
     if(err) t.fail(err);
+    else if(stats.hasErrors()) t.fail(JSON.stringify(stats.toJson("errors-only")));
     else {
-      var st = JSON.stringify(stats.toJson("minimal"));
-      if(st.errors) t.fail(st);
-      t.pass(st);
+      t.pass(JSON.stringify(stats.toJson("minimal")));
       // Once the scripts build, we can run the rest of the tests.
       runTests(JSON.parse(fs.readFileSync(path.resolve(buildPath,'./mapping.json'))));
     }
@@ -86,6 +85,8 @@ function runTests(mapping){
     nock.disableNetConnect();
     // Polyfill JSDOM fetch using node-fetch
     dom.window.fetch = node_fetch;
+    // JSDOM doesn't implement SVG layout, so stub getBBox for code that measures SVG elements
+    dom.window.SVGElement.prototype.getBBox = () => ({ x: 0, y: 0, width: 0, height: 0 });
     // Ensure console.log/info/debug statements inside virtual DOM print to stderr
     // by replacing the default console with one which routes to stderr
     // This ensures "pure" tap stdout

--- a/js/source/legacy/brapi/BrAPI.js
+++ b/js/source/legacy/brapi/BrAPI.js
@@ -146,7 +146,7 @@ class ThreadNode {
         let fc = fray_data=>fray_data.forEach(d=>{
             Promise.resolve(d).then(datum=>{
                 try {
-                    return (datum instanceof Array) ? fc(datum) : c(datum.val,datum.key);
+                    return Array.isArray(datum) ? fc(datum) : c(datum.val,datum.key);
                 } catch (e) {
                     new NodeFrayError(e);
                     return []
@@ -164,7 +164,7 @@ class ThreadNode {
         let edge = frayed._connect(this);
         let fc = fray_data=>fray_data.map(d=>{
             return Promise.resolve(d).then(datum=>{
-                if(datum instanceof Array) return fc(datum);
+                if(Array.isArray(datum)) return fc(datum);
                 var returnVal;
                 try {
                     returnVal = fray_func(datum,edge.send);
@@ -222,7 +222,7 @@ class ThreadNode {
         let edge = joined._connect(this);
         let fci = i => fray_data => fray_data.map(d=>{
             return Promise.resolve(d).then(datum=>{
-                if(datum instanceof Array) return fci(i)(datum);
+                if(Array.isArray(datum)) return fci(i)(datum);
                 return joinmap.join(datum,i);
             })
         });
@@ -241,7 +241,7 @@ class ThreadNode {
     _flatten_filaments(arr){
         return Promise.all(arr).then(res_arr=>{
             return Promise.all(res_arr.map(d=>{
-                return Promise.resolve(d).then(d=>(d instanceof Array)?this._flatten_filaments(d):[d])
+                return Promise.resolve(d).then(d=>Array.isArray(d)?this._flatten_filaments(d):[d])
             })).then(peices=>peices.reduce((a, v)=>a.concat(v),[]))
         })
     }
@@ -2794,7 +2794,7 @@ class BrAPICallController {
                 param_string+="&";
             }
             param_string+=param+"=";
-            if (params[param] instanceof Array){
+            if (Array.isArray(params[param])){
                 param_string+=params[param].map(String).join("%2C");
             }
             else {

--- a/js/test.webpack.config.js
+++ b/js/test.webpack.config.js
@@ -11,8 +11,10 @@ const testBuildPath = path.resolve(__dirname, "test_build/");
 module.exports = merge(rootConfig,{
   entry: (() => {
       var entries = {};
-      glob.sync(path.resolve(testPath, "**/*.js")).forEach(val => {
-          entries[val] = val;
+      glob.sync(path.resolve(testPath, "**/*.test.js")).forEach(val => {
+          var prekey = val.replace(testPath+"/","");
+          var key = prekey.match(/(.*)\.js$/)[1];
+          entries[key] = val;
       });
       Object.setPrototypeOf(entries,null); //Make not a plain object
       return entries;

--- a/js/test/boxplotter.test.js
+++ b/js/test/boxplotter.test.js
@@ -19,10 +19,13 @@ test('Boxplot', t=>{
     t.test("populate", t=>{
         t.plan(2);
         
+        var searchResultsDbId = "test-search-id";
         var scope = nock(document.location.origin);
         scope.get('/ajax/tools/boxplotter/get_constraints').query({dataset: 7})
             .reply(200, data.constraints);
-        scope.post('/brapi/v1/phenotypes-search')
+        scope.post('/brapi/v2/search/observationunits')
+            .reply(200, {metadata: {}, result: {searchResultsDbId: searchResultsDbId}});
+        scope.get('/brapi/v2/search/observationunits/'+searchResultsDbId).query(true)
             .reply(200, data.phenotypes);
             
         setTimeout(() => {

--- a/js/webpack_util/jsan-preprocess-loader.js
+++ b/js/webpack_util/jsan-preprocess-loader.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const fs = require('fs');
-const loaderUtils = require('loader-utils');
 const {
 	JSAN_adaptor,
 	common_js_regex,
@@ -13,7 +12,7 @@ const {
 module.exports = function() {
 	this.cacheable();
 	const callback = this.async();	
-	const options = loaderUtils.getOptions(this);
+	const options = this.getOptions();
 	var rpath = this.resourcePath;
 	fs.readFile(rpath, function read(err, data) {
 	    if (err) {

--- a/js/webpack_util/webpack-filemap-plugin.js
+++ b/js/webpack_util/webpack-filemap-plugin.js
@@ -1,56 +1,64 @@
 // Creates JSON dependency mapping from webpack compilation.
 
-const path = require('path');
 const fs = require('fs');
 
-function path_inside(parent, dir) {
-    var relative_path = path.relative(parent, dir);
-    return !!relative_path && !relative_path.startsWith('..') && !path.isAbsolute(relative_path);
+const PLUGIN_NAME = 'SGNFileMapPlugin';
+
+class FileMapPlugin {
+  constructor(options) {
+    this.jsan_re = new RegExp(
+      fs.readFileSync(options.legacy_regex, "utf8").replace(/^[\s\n]+|[\s\n]+$/g, ""),
+      'g'
+    );
+  }
+
+  apply(compiler) {
+    const { Compilation } = compiler.webpack;
+    const { RawSource } = compiler.webpack.sources;
+
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          stage: Compilation.PROCESS_ASSETS_STAGE_REPORT
+        },
+        () => {
+          const entrypoints = {};
+          const legacy_lists = {};
+
+          for (const [name, entrypoint] of compilation.entrypoints) {
+            const files = entrypoint.chunks
+              .reduce((a, chunk) => a.concat([...chunk.files]), [])
+              .filter(f => f.endsWith(".js"));
+
+            entrypoints[name] = { files, legacy: [] };
+
+            files.forEach(f => {
+              legacy_lists[f] = legacy_lists[f] || [];
+              legacy_lists[f].push(entrypoints[name].legacy);
+            });
+          }
+
+          for (const chunk of compilation.chunks) {
+            for (const f of chunk.files) {
+              const lists = legacy_lists[f];
+              if (!lists) continue;
+
+              const asset = compilation.getAsset(f);
+              asset.source.source().replace(this.jsan_re, (m, g1, g2) => {
+                lists.forEach(leg_list => leg_list.push(g1 || g2));
+              });
+            }
+          }
+
+          compilation.emitAsset(
+            'mapping.json',
+            new RawSource(JSON.stringify(entrypoints, null, 2))
+          );
+        }
+      );
+    });
+  }
 }
-
-function FileMapPlugin(options) {
-  this.jsan_re = RegExp(
-    fs.readFileSync(
-      options.legacy_regex, 
-      "utf8"
-    ).replace(/^[\s\n]+|[\s\n]+$/,""),
-    'g'
-  );
-};
-
-FileMapPlugin.prototype.apply = function(compiler) {
-  var self = this;
-  compiler.hooks.emit.tapAsync('SGNFileMapPlugin', function(compilation,callback) {
-    var entrypoints = {};
-    var legacy_lists = {};
-    [...compilation.entrypoints].forEach((kvpair)=>{
-      entrypoints[kvpair[0]] = {
-        'files': kvpair[1].chunks.reduce((a,chunk)=>a.concat(chunk.files),[]).filter(f=>f.endsWith(".js")),
-        'legacy': []
-      };
-      entrypoints[kvpair[0]].files.forEach(f=>{
-        legacy_lists[f] = legacy_lists[f] || [];
-        legacy_lists[f].push(entrypoints[kvpair[0]].legacy);
-      })
-    });
-    compilation.chunks.forEach(chunk=>{
-      chunk.files.forEach(f=>{
-        compilation.assets[f].source().replace(self.jsan_re,function(m,g1,g2){
-          legacy_lists[f].forEach(leg_list=>leg_list.push(g1||g2));
-        })
-      });
-    });
-    var entrypoints_string = JSON.stringify(entrypoints,null,2);
-    compilation.assets['mapping.json'] = {
-      source: function() {
-        return entrypoints_string;
-      },
-      size: function() {
-        return entrypoints_string.length;
-      }
-    };
-    callback();
-  });
-};
 
 module.exports = FileMapPlugin;


### PR DESCRIPTION
Updates from node.js v18 to node.js v24
Updates Webpack v4 to Webpack v5, needed for node.js v24

to manually install this update run the following commands inside docker

curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
apt-get update
apt-get install nodejs

cd js
rm node_modules
rm build
npm install
chown -R production node_modules
chgrp -R production node_modules
chmod a+w node_modules/.package-lock.json
npm run build

requires clearing web browser cache


fixes #6258


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
