### PR TITLE
fix dataset limit

### DIFF
--- a/js/source/modules/wizard-datasets.js
+++ b/js/source/modules/wizard-datasets.js
@@ -110,14 +110,16 @@ export function WizardDatasets(main_id,wizard){
       }
       cols = cols.slice(0, first_irrelevant_col);
       var order = cols.map(c=>c.type);
-      var params = `?name=${name}&category_order=${JSON.stringify(order)}`
+      var params = new URLSearchParams();
+      params.append("name", name);
+      params.append("category_order", JSON.stringify(order));
       cols.forEach(c=>{
-        params+=`&${c.type}=${JSON.stringify(c.items.filter(d=>d.selected).map(d=>d.value.id))}`;
+        params.append(c.type, JSON.stringify(c.items.filter(d=>d.selected).map(d=>d.value.id)));
       })
-      console.log(document.location.origin+'/ajax/dataset/save'+params);
-      fetch(document.location.origin+'/ajax/dataset/save'+params,{
+      fetch(document.location.origin+'/ajax/dataset/save',{
         method:'post',
-        credentials: 'include'
+        credentials: 'include',
+        body: params
       }).then(response => {
         if (!response.ok){
           alert("Network error!");


### PR DESCRIPTION
When creating a dataset using wizard there was javascript error if more then a few hundred items selected.
This fix changes call from GET to POST so it will handle more items


fixes #3658 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
