### PR TITLE
BrAPI: Remove checks for POST and PUT body is array

### DIFF
--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -141,16 +141,16 @@ sub brapi : Chained('/') PathPart('brapi') CaptureArgs(1) {
 	if (defined $c->request->data){
 		# All POST requests accept for search methods require a json array body
 		if ($c->request->method eq "POST" && index($c->request->env->{REQUEST_URI}, "search") == -1){
-			if (ref $c->request->data ne 'ARRAY') {
-				my $response = CXGN::BrAPI::JSONResponse->return_error($c->stash->{status}, 'JSON array body required', 400);
-				_standard_response_construction($c, $response);
-			}
+			# if (ref $c->request->data ne 'ARRAY') {
+			# 	my $response = CXGN::BrAPI::JSONResponse->return_error($c->stash->{status}, 'JSON array body required', 400);
+			# 	_standard_response_construction($c, $response);
+			# }
 			$c->stash->{clean_inputs} = _clean_inputs($c->req->params,$c->request->data);
 		} elsif ($c->request->method eq "PUT") {
-			if (ref $c->request->data eq 'ARRAY') {
-				my $response = CXGN::BrAPI::JSONResponse->return_error($c->stash->{status}, 'JSON hash body required', 400);
-				_standard_response_construction($c, $response);
-			}
+			# if (ref $c->request->data eq 'ARRAY') {
+			# 	my $response = CXGN::BrAPI::JSONResponse->return_error($c->stash->{status}, 'JSON hash body required', 400);
+			# 	_standard_response_construction($c, $response);
+			# }
 			$c->stash->{clean_inputs} = $c->request->data;
 		} else {
 			$c->stash->{clean_inputs} = $c->request->data;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Removes the check for BrAPI POST and PUT requests that the body must be an array.

Fixes #6271 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
