### PR TITLE
Fix utf mail

### DIFF
--- a/lib/CXGN/Contact.pm
+++ b/lib/CXGN/Contact.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use Mail::Sendmail;
 use Email::Send::SMTP::Gmail;
+use Encode ();
 use Data::Dumper;
 
 use CXGN::Apache::Request;
@@ -56,6 +57,14 @@ sub send_email {
     $mailto  ||= 'sgn-bugs@sgn.cornell.edu';
 
     $body .= $request_info;
+
+    # Encode any decoded/wide-character text (e.g. non-ASCII web form input)
+    # to UTF-8 bytes so it can't crash the send with "Wide character in print".
+    # Strings that are already bytes are left alone.
+    $subject = Encode::encode( 'UTF-8', $subject, Encode::FB_DEFAULT ) if utf8::is_utf8($subject);
+    $body    = Encode::encode( 'UTF-8', $body,    Encode::FB_DEFAULT ) if utf8::is_utf8($body);
+    $subject =~ tr/\r\n//d;    # keep a bad value from breaking the headers
+
     print STDERR "$subject\n\n$body";
 
     if ( $vhost_conf->get_conf('disable_emails') ) {
@@ -137,23 +146,27 @@ sub send_email {
 sub _send_email_with_optional_attachment {
     my ( $mail, $from, $to, $subject, $body, $attachment ) = @_;
 
-    if ( $attachment && -e $attachment ) {
-        $mail->send(
-            -from        => $from,
-            -to          => $to,
-            -subject     => $subject,
-            -body        => $body,
-            -attachments => $attachment,
-        );
-    }
-    else {
-        $mail->send(
-            -from    => $from,
-            -to      => $to,
-            -subject => $subject,
-            -body    => $body,
-        );
-    }
+    my $ok = eval {
+        if ( $attachment && -e $attachment ) {
+            $mail->send(
+                -from        => $from,
+                -to          => $to,
+                -subject     => $subject,
+                -body        => $body,
+                -attachments => $attachment,
+            );
+        }
+        else {
+            $mail->send(
+                -from    => $from,
+                -to      => $to,
+                -subject => $subject,
+                -body    => $body,
+            );
+        }
+        1;
+    };
+    print STDERR "CXGN::Contact: error sending email: $@\n" if !$ok;
 
     return;
 }

--- a/sgn.conf
+++ b/sgn.conf
@@ -94,10 +94,10 @@ user_registration_admin_confirmation 0      # when enabled, the new user confirm
 user_registration_admin_confirmation_email  # a comma-separated list of email addresses to send new user confirmation messages to, when the above is enabled
 disable_login 0
 default_login_janedoe 0
-require_login 1
+require_login 0
 
 #### QuickSearch is very resource intensive on the database
-enable_quick_search 0
+enable_quick_search 1
 
 #### Report parameters
 report_engine phenotype_properties_check

--- a/sgn.conf
+++ b/sgn.conf
@@ -91,10 +91,10 @@ user_registration_admin_confirmation 0      # when enabled, the new user confirm
 user_registration_admin_confirmation_email  # a comma-separated list of email addresses to send new user confirmation messages to, when the above is enabled
 disable_login 0
 default_login_janedoe 0
-require_login 0
+require_login 1
 
 #### QuickSearch is very resource intensive on the database
-enable_quick_search 1
+enable_quick_search 0
 
 #### Report parameters
 report_engine phenotype_properties_check


### PR DESCRIPTION
Fixes crash in email when form contains non UTF8 characters

fixes #6287 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [x] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
