### PR TITLE
Return undef when a tissue sample has no plate or trial

### DIFF
--- a/lib/CXGN/Stock/TissueSample.pm
+++ b/lib/CXGN/Stock/TissueSample.pm
@@ -339,7 +339,11 @@ sub _retrieve_trial {
     my $field_experiment_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->schema, 'field_layout', 'experiment_type')->cvterm_id();
     my $p_rs = $self->stock->search_related('nd_experiment_stocks')->search_related('nd_experiment', {'nd_experiment.type_id'=>[$field_experiment_cvterm_id, $genotyping_experiment_cvterm_id] })->search_related('nd_experiment_projects')->search_related('project');
     if ($p_rs->count != 1){
-        die "There is not one project linked to this stock!";
+        # A count other than one means no single trial can be named for this sample, so the
+        # attribute is left undefined. Raising an exception here caused every caller that read
+        # the accessor to fail. CXGN::BrAPI::v2::Samples tests `$s->get_trial` for truth before
+        # using it, so an undefined value is already handled.
+        return;
     }
     $self->get_trial([$p_rs->first->project_id, $p_rs->first->name]);
 }
@@ -349,7 +353,10 @@ sub _retrieve_plate {
     my $genotyping_experiment_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->schema, 'genotyping_layout', 'experiment_type')->cvterm_id();
     my $p_rs = $self->stock->search_related('nd_experiment_stocks')->search_related('nd_experiment', {'nd_experiment.type_id'=>$genotyping_experiment_cvterm_id})->search_related('nd_experiment_projects')->search_related('project');
     if ($p_rs->count != 1){
-        die "There is not one project linked to this stock!";
+        # A tissue sample that is not a well on a genotyping plate has no plate to name. Such
+        # samples are created by the field-trial tissue sample tool and by sampling trials, so
+        # the attribute is left undefined rather than raising an exception.
+        return;
     }
     $self->get_plate([$p_rs->first->project_id, $p_rs->first->name]);
 }


### PR DESCRIPTION
_retrieve_plate and _retrieve_trial raised an exception when the query
for the sample's genotyping or field project returned a count other than
one. Both are builders for Moose attributes declared with lazy => 1, so
each runs the first time get_plate or get_trial is read rather than when
the object is constructed. CXGN::Stock::TissueSample::Search reads both
accessors for every row it returns. A single sample without a plate
therefore caused GET /brapi/v2/samples to return HTTP 500 for the whole
request, including the genotyping plate samples in the same page.

Because the exception came from the accessor and not from the
constructor, wrapping the call to new in an eval did not prevent it.

Tissue samples without a genotyping project are created by two existing
tools: the field-trial tissue sample tool at
/breeders/trial/<id>/create_tissue_samples, and sampling trials. One
sample from either tool was sufficient to make the endpoint return HTTP
500 on every request.

Both subroutines now return without setting the attribute, which leaves
it undefined. CXGN::BrAPI::v2::Samples tests get_plate and get_trial for
truth before using them, in both detail and search, so the undefined
value is handled by the existing callers.

The behavior was observed on a local instance. On a trial with plots and
no tissue samples, GET /brapi/v2/samples returned 200. After
create_plant_entries and create_tissue_samples were posted for that
trial, the same request returned 500. With this change applied, the
request returned 200 and included the new samples, reporting a null
plate and the field trial as the study.
